### PR TITLE
feat: complete storage service - missing methods, useStorage hook, full tests (#3)

### DIFF
--- a/src/hooks/useStorage.ts
+++ b/src/hooks/useStorage.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from 'react'
+import { getStorageService } from '@/services/storage'
+import type { StorageService } from '@/services/storage'
+
+/**
+ * React Context for dependency-injecting the StorageService.
+ * Defaults to the singleton from getStorageService() so wrapping in a provider
+ * is optional - only needed for testing or swapping implementations.
+ */
+export const StorageContext = createContext<StorageService>(getStorageService())
+
+/**
+ * Hook to access the StorageService instance from React components.
+ *
+ * Usage:
+ *   const storage = useStorage()
+ *   const pairs = await storage.getLanguagePairs()
+ */
+export function useStorage(): StorageService {
+  return useContext(StorageContext)
+}

--- a/src/services/storage/LocalStorageService.test.ts
+++ b/src/services/storage/LocalStorageService.test.ts
@@ -1,14 +1,36 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { LocalStorageService } from './LocalStorageService'
-import type { LanguagePair, Word, WordProgress, UserSettings } from '@/types'
+import type { LanguagePair, Word, WordProgress, UserSettings, DailyStats } from '@/types'
 
 describe('LocalStorageService', () => {
   let service: LocalStorageService
+
+  const makePair = (id = 'pair-1'): LanguagePair => ({
+    id,
+    sourceLang: 'Latvian',
+    targetLang: 'English',
+    sourceCode: 'lv',
+    targetCode: 'en',
+    createdAt: 1000000,
+  })
+
+  const makeWord = (id = 'word-1', pairId = 'pair-1'): Word => ({
+    id,
+    pairId,
+    source: 'māja',
+    target: 'house',
+    notes: null,
+    tags: [],
+    createdAt: 1000000,
+    isFromPack: false,
+  })
 
   beforeEach(() => {
     localStorage.clear()
     service = new LocalStorageService()
   })
+
+  // --- Language pairs ---
 
   describe('getLanguagePairs', () => {
     it('should return an empty array when no pairs are stored', async () => {
@@ -17,39 +39,35 @@ describe('LocalStorageService', () => {
     })
   })
 
+  describe('getLanguagePair', () => {
+    it('should return a pair by id', async () => {
+      const pair = makePair()
+      await service.saveLanguagePair(pair)
+      const found = await service.getLanguagePair('pair-1')
+      expect(found).toEqual(pair)
+    })
+
+    it('should return null for a non-existent id', async () => {
+      const found = await service.getLanguagePair('no-such-id')
+      expect(found).toBeNull()
+    })
+  })
+
   describe('saveLanguagePair', () => {
     it('should persist a new language pair', async () => {
-      const pair: LanguagePair = {
-        id: 'pair-1',
-        sourceLang: 'Latvian',
-        targetLang: 'English',
-        sourceCode: 'lv',
-        targetCode: 'en',
-        createdAt: 1000000,
-      }
-
+      const pair = makePair()
       await service.saveLanguagePair(pair)
       const pairs = await service.getLanguagePairs()
-
       expect(pairs).toHaveLength(1)
       expect(pairs[0]).toEqual(pair)
     })
 
     it('should update an existing pair on re-save', async () => {
-      const pair: LanguagePair = {
-        id: 'pair-1',
-        sourceLang: 'Latvian',
-        targetLang: 'English',
-        sourceCode: 'lv',
-        targetCode: 'en',
-        createdAt: 1000000,
-      }
+      const pair = makePair()
       const updated: LanguagePair = { ...pair, targetLang: 'German' }
-
       await service.saveLanguagePair(pair)
       await service.saveLanguagePair(updated)
       const pairs = await service.getLanguagePairs()
-
       expect(pairs).toHaveLength(1)
       expect(pairs[0]?.targetLang).toBe('German')
     })
@@ -57,22 +75,14 @@ describe('LocalStorageService', () => {
 
   describe('deleteLanguagePair', () => {
     it('should remove the specified pair', async () => {
-      const pair: LanguagePair = {
-        id: 'pair-1',
-        sourceLang: 'Latvian',
-        targetLang: 'English',
-        sourceCode: 'lv',
-        targetCode: 'en',
-        createdAt: 1000000,
-      }
-
-      await service.saveLanguagePair(pair)
+      await service.saveLanguagePair(makePair())
       await service.deleteLanguagePair('pair-1')
       const pairs = await service.getLanguagePairs()
-
       expect(pairs).toHaveLength(0)
     })
   })
+
+  // --- Words ---
 
   describe('getWords / saveWord', () => {
     it('should return an empty array when no words exist for a pair', async () => {
@@ -81,74 +91,49 @@ describe('LocalStorageService', () => {
     })
 
     it('should persist and retrieve a word', async () => {
-      const word: Word = {
-        id: 'word-1',
-        pairId: 'pair-1',
-        source: 'māja',
-        target: 'house',
-        notes: null,
-        tags: [],
-        createdAt: 1000000,
-        isFromPack: false,
-      }
-
+      const word = makeWord()
       await service.saveWord(word)
       const words = await service.getWords('pair-1')
-
       expect(words).toHaveLength(1)
       expect(words[0]).toEqual(word)
     })
 
     it('should update a word on re-save', async () => {
-      const word: Word = {
-        id: 'word-1',
-        pairId: 'pair-1',
-        source: 'māja',
-        target: 'house',
-        notes: null,
-        tags: [],
-        createdAt: 1000000,
-        isFromPack: false,
-      }
+      const word = makeWord()
       const updated: Word = { ...word, notes: 'a building' }
-
       await service.saveWord(word)
       await service.saveWord(updated)
       const words = await service.getWords('pair-1')
-
       expect(words).toHaveLength(1)
       expect(words[0]?.notes).toBe('a building')
+    })
+  })
+
+  describe('getWord', () => {
+    it('should find a word by id across pairs', async () => {
+      await service.saveLanguagePair(makePair('pair-1'))
+      await service.saveLanguagePair(makePair('pair-2'))
+      const word = makeWord('word-x', 'pair-2')
+      await service.saveWord(word)
+      const found = await service.getWord('word-x')
+      expect(found).toEqual(word)
+    })
+
+    it('should return null for a non-existent word', async () => {
+      await service.saveLanguagePair(makePair())
+      const found = await service.getWord('no-such-word')
+      expect(found).toBeNull()
     })
   })
 
   describe('saveWords', () => {
     it('should bulk-save multiple words', async () => {
       const words: Word[] = [
-        {
-          id: 'word-1',
-          pairId: 'pair-1',
-          source: 'māja',
-          target: 'house',
-          notes: null,
-          tags: [],
-          createdAt: 1000000,
-          isFromPack: false,
-        },
-        {
-          id: 'word-2',
-          pairId: 'pair-1',
-          source: 'suns',
-          target: 'dog',
-          notes: null,
-          tags: [],
-          createdAt: 1000001,
-          isFromPack: false,
-        },
+        makeWord('word-1'),
+        { ...makeWord('word-2'), source: 'suns', target: 'dog' },
       ]
-
       await service.saveWords(words)
       const retrieved = await service.getWords('pair-1')
-
       expect(retrieved).toHaveLength(2)
     })
 
@@ -159,33 +144,15 @@ describe('LocalStorageService', () => {
 
   describe('deleteWord', () => {
     it('should remove a word by id', async () => {
-      const pair: LanguagePair = {
-        id: 'pair-1',
-        sourceLang: 'Latvian',
-        targetLang: 'English',
-        sourceCode: 'lv',
-        targetCode: 'en',
-        createdAt: 1000000,
-      }
-      const word: Word = {
-        id: 'word-1',
-        pairId: 'pair-1',
-        source: 'māja',
-        target: 'house',
-        notes: null,
-        tags: [],
-        createdAt: 1000000,
-        isFromPack: false,
-      }
-
-      await service.saveLanguagePair(pair)
-      await service.saveWord(word)
+      await service.saveLanguagePair(makePair())
+      await service.saveWord(makeWord())
       await service.deleteWord('word-1')
       const words = await service.getWords('pair-1')
-
       expect(words).toHaveLength(0)
     })
   })
+
+  // --- Progress ---
 
   describe('getWordProgress / saveWordProgress', () => {
     it('should return null for a word with no progress', async () => {
@@ -204,13 +171,13 @@ describe('LocalStorageService', () => {
         confidence: 0.7,
         history: [],
       }
-
       await service.saveWordProgress(progress)
       const retrieved = await service.getWordProgress('word-1')
-
       expect(retrieved).toEqual(progress)
     })
   })
+
+  // --- Settings ---
 
   describe('getSettings / saveSettings', () => {
     it('should return default settings when none are stored', async () => {
@@ -230,13 +197,13 @@ describe('LocalStorageService', () => {
         theme: 'light',
         typoTolerance: 2,
       }
-
       await service.saveSettings(settings)
       const retrieved = await service.getSettings()
-
       expect(retrieved).toEqual(settings)
     })
   })
+
+  // --- Daily stats ---
 
   describe('getDailyStats / saveDailyStats', () => {
     it('should return null for a date with no stats', async () => {
@@ -245,18 +212,34 @@ describe('LocalStorageService', () => {
     })
 
     it('should persist and retrieve daily stats', async () => {
-      const stats = {
+      const stats: DailyStats = {
         date: '2026-01-01',
         wordsReviewed: 15,
         correctCount: 12,
         incorrectCount: 3,
         streakDays: 5,
       }
-
       await service.saveDailyStats(stats)
       const retrieved = await service.getDailyStats('2026-01-01')
-
       expect(retrieved).toEqual(stats)
+    })
+  })
+
+  describe('getDailyStatsRange', () => {
+    it('should return stats within the given date range', async () => {
+      await service.saveDailyStats({ date: '2026-01-01', wordsReviewed: 10, correctCount: 8, incorrectCount: 2, streakDays: 1 })
+      await service.saveDailyStats({ date: '2026-01-02', wordsReviewed: 15, correctCount: 12, incorrectCount: 3, streakDays: 2 })
+      await service.saveDailyStats({ date: '2026-01-04', wordsReviewed: 5, correctCount: 5, incorrectCount: 0, streakDays: 1 })
+
+      const stats = await service.getDailyStatsRange('2026-01-01', '2026-01-03')
+      expect(stats).toHaveLength(2)
+      expect(stats[0]?.date).toBe('2026-01-01')
+      expect(stats[1]?.date).toBe('2026-01-02')
+    })
+
+    it('should return an empty array when no stats exist in range', async () => {
+      const stats = await service.getDailyStatsRange('2026-06-01', '2026-06-07')
+      expect(stats).toEqual([])
     })
   })
 
@@ -270,7 +253,6 @@ describe('LocalStorageService', () => {
         incorrectCount: 2,
         streakDays: 1,
       })
-
       const stats = await service.getRecentDailyStats(7)
       expect(stats).toHaveLength(1)
       expect(stats[0]?.date).toBe(today)
@@ -279,6 +261,127 @@ describe('LocalStorageService', () => {
     it('should return an empty array when no stats exist', async () => {
       const stats = await service.getRecentDailyStats(7)
       expect(stats).toEqual([])
+    })
+  })
+
+  // --- Data management ---
+
+  describe('exportAll / importAll', () => {
+    it('should roundtrip all data through export and import', async () => {
+      const pair = makePair()
+      const word = makeWord()
+      const progress: WordProgress = {
+        wordId: 'word-1',
+        correctCount: 3,
+        incorrectCount: 1,
+        streak: 2,
+        lastReviewed: 1000000,
+        nextReview: 2000000,
+        confidence: 0.6,
+        history: [],
+      }
+      const settings: UserSettings = {
+        activePairId: 'pair-1',
+        quizMode: 'choice',
+        dailyGoal: 30,
+        theme: 'light',
+        typoTolerance: 0,
+      }
+      const dailyStats: DailyStats = {
+        date: '2026-03-01',
+        wordsReviewed: 20,
+        correctCount: 18,
+        incorrectCount: 2,
+        streakDays: 7,
+      }
+
+      await service.saveLanguagePair(pair)
+      await service.saveWord(word)
+      await service.saveWordProgress(progress)
+      await service.saveSettings(settings)
+      await service.saveDailyStats(dailyStats)
+
+      const exported = await service.exportAll()
+
+      // Clear and re-import
+      await service.clearAll()
+      expect(await service.getLanguagePairs()).toEqual([])
+
+      await service.importAll(exported)
+
+      expect(await service.getLanguagePairs()).toEqual([pair])
+      expect(await service.getWords('pair-1')).toEqual([word])
+      expect(await service.getWordProgress('word-1')).toEqual(progress)
+      expect(await service.getSettings()).toEqual(settings)
+      expect(await service.getDailyStats('2026-03-01')).toEqual(dailyStats)
+    })
+
+    it('should produce valid JSON from exportAll', async () => {
+      await service.saveLanguagePair(makePair())
+      const exported = await service.exportAll()
+      const parsed = JSON.parse(exported)
+      expect(parsed.version).toBe(1)
+      expect(parsed.exportedAt).toBeDefined()
+      expect(parsed.languagePairs).toHaveLength(1)
+    })
+  })
+
+  describe('importAll - error handling', () => {
+    it('should throw on invalid JSON', async () => {
+      await expect(service.importAll('not valid json')).rejects.toThrow()
+    })
+
+    it('should handle partial data gracefully', async () => {
+      await service.importAll(JSON.stringify({ languagePairs: [makePair()] }))
+      const pairs = await service.getLanguagePairs()
+      expect(pairs).toHaveLength(1)
+      // Settings should fall back to defaults since they were cleared
+      const settings = await service.getSettings()
+      expect(settings.dailyGoal).toBe(20)
+    })
+  })
+
+  describe('clearAll', () => {
+    it('should remove all lexio: keys from localStorage', async () => {
+      await service.saveLanguagePair(makePair())
+      await service.saveWord(makeWord())
+      await service.saveSettings({ activePairId: 'pair-1', quizMode: 'type', dailyGoal: 10, theme: 'light', typoTolerance: 1 })
+      // Add a non-lexio key to ensure it survives
+      localStorage.setItem('other-app:key', 'should-survive')
+
+      await service.clearAll()
+
+      expect(await service.getLanguagePairs()).toEqual([])
+      expect(await service.getWords('pair-1')).toEqual([])
+      expect(localStorage.getItem('other-app:key')).toBe('should-survive')
+    })
+  })
+
+  // --- Error handling ---
+
+  describe('corrupted data handling', () => {
+    it('should return defaults when stored JSON is corrupted', async () => {
+      localStorage.setItem('lexio:settings', '{invalid json')
+      const settings = await service.getSettings()
+      expect(settings).toEqual({
+        activePairId: null,
+        quizMode: 'mixed',
+        dailyGoal: 20,
+        theme: 'dark',
+        typoTolerance: 1,
+      })
+    })
+
+    it('should return empty array when language pairs JSON is corrupted', async () => {
+      localStorage.setItem('lexio:language-pairs', 'broken')
+      const pairs = await service.getLanguagePairs()
+      expect(pairs).toEqual([])
+    })
+
+    it('should return null when word progress JSON is corrupted', async () => {
+      localStorage.setItem('lexio:progress:word-1', 'not-json')
+      const progress = await service.getWordProgress('word-1')
+      expect(progress).toBeNull()
     })
   })
 })

--- a/src/services/storage/LocalStorageService.ts
+++ b/src/services/storage/LocalStorageService.ts
@@ -11,7 +11,6 @@ const KEYS = {
   LANGUAGE_PAIRS: 'lexio:language-pairs',
   WORDS_PREFIX: 'lexio:words:',
   PROGRESS_PREFIX: 'lexio:progress:',
-  ALL_PROGRESS_PREFIX: 'lexio:all-progress:',
   SETTINGS: 'lexio:settings',
   DAILY_STATS_PREFIX: 'lexio:daily-stats:',
 } as const
@@ -43,8 +42,15 @@ function writeJson<T>(key: string, value: T): void {
  * This is the only place in the codebase that calls localStorage directly.
  */
 export class LocalStorageService implements StorageService {
+  // --- Language pairs ---
+
   async getLanguagePairs(): Promise<LanguagePair[]> {
     return readJson<LanguagePair[]>(KEYS.LANGUAGE_PAIRS) ?? []
+  }
+
+  async getLanguagePair(id: string): Promise<LanguagePair | null> {
+    const pairs = await this.getLanguagePairs()
+    return pairs.find((p) => p.id === id) ?? null
   }
 
   async saveLanguagePair(pair: LanguagePair): Promise<void> {
@@ -61,8 +67,20 @@ export class LocalStorageService implements StorageService {
     writeJson(KEYS.LANGUAGE_PAIRS, pairs.filter((p) => p.id !== id))
   }
 
+  // --- Words ---
+
   async getWords(pairId: string): Promise<Word[]> {
     return readJson<Word[]>(`${KEYS.WORDS_PREFIX}${pairId}`) ?? []
+  }
+
+  async getWord(id: string): Promise<Word | null> {
+    const pairs = await this.getLanguagePairs()
+    for (const pair of pairs) {
+      const words = await this.getWords(pair.id)
+      const found = words.find((w) => w.id === id)
+      if (found) return found
+    }
+    return null
   }
 
   async saveWord(word: Word): Promise<void> {
@@ -76,7 +94,6 @@ export class LocalStorageService implements StorageService {
 
   async saveWords(words: Word[]): Promise<void> {
     if (words.length === 0) return
-    // Group by pairId for efficiency
     const byPair = new Map<string, Word[]>()
     for (const word of words) {
       const existing = byPair.get(word.pairId) ?? []
@@ -94,7 +111,6 @@ export class LocalStorageService implements StorageService {
   }
 
   async deleteWord(id: string): Promise<void> {
-    // We need to search across all pairs - find by scanning keys
     const pairs = await this.getLanguagePairs()
     for (const pair of pairs) {
       const words = await this.getWords(pair.id)
@@ -105,6 +121,8 @@ export class LocalStorageService implements StorageService {
       }
     }
   }
+
+  // --- Progress ---
 
   async getWordProgress(wordId: string): Promise<WordProgress | null> {
     return readJson<WordProgress>(`${KEYS.PROGRESS_PREFIX}${wordId}`)
@@ -124,6 +142,8 @@ export class LocalStorageService implements StorageService {
     writeJson(`${KEYS.PROGRESS_PREFIX}${progress.wordId}`, progress)
   }
 
+  // --- Settings ---
+
   async getSettings(): Promise<UserSettings> {
     return readJson<UserSettings>(KEYS.SETTINGS) ?? DEFAULT_SETTINGS
   }
@@ -132,8 +152,23 @@ export class LocalStorageService implements StorageService {
     writeJson(KEYS.SETTINGS, settings)
   }
 
+  // --- Daily stats ---
+
   async getDailyStats(date: string): Promise<DailyStats | null> {
     return readJson<DailyStats>(`${KEYS.DAILY_STATS_PREFIX}${date}`)
+  }
+
+  async getDailyStatsRange(from: string, to: string): Promise<DailyStats[]> {
+    const result: DailyStats[] = []
+    const current = new Date(from)
+    const end = new Date(to)
+    while (current <= end) {
+      const dateStr = current.toISOString().slice(0, 10)
+      const stats = await this.getDailyStats(dateStr)
+      if (stats !== null) result.push(stats)
+      current.setDate(current.getDate() + 1)
+    }
+    return result
   }
 
   async saveDailyStats(stats: DailyStats): Promise<void> {
@@ -151,5 +186,95 @@ export class LocalStorageService implements StorageService {
       if (stats !== null) result.push(stats)
     }
     return result
+  }
+
+  // --- Data management ---
+
+  async exportAll(): Promise<string> {
+    const pairs = await this.getLanguagePairs()
+    const words: Record<string, Word[]> = {}
+    const progress: Record<string, WordProgress> = {}
+
+    for (const pair of pairs) {
+      const pairWords = await this.getWords(pair.id)
+      words[pair.id] = pairWords
+      for (const word of pairWords) {
+        const p = await this.getWordProgress(word.id)
+        if (p !== null) progress[word.id] = p
+      }
+    }
+
+    const settings = await this.getSettings()
+
+    // Collect all daily stats from localStorage keys
+    const dailyStats: DailyStats[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (key?.startsWith(KEYS.DAILY_STATS_PREFIX)) {
+        const stats = readJson<DailyStats>(key)
+        if (stats !== null) dailyStats.push(stats)
+      }
+    }
+
+    return JSON.stringify({
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      languagePairs: pairs,
+      words,
+      progress,
+      settings,
+      dailyStats,
+    })
+  }
+
+  async importAll(data: string): Promise<void> {
+    const parsed = JSON.parse(data) as {
+      languagePairs?: LanguagePair[]
+      words?: Record<string, Word[]>
+      progress?: Record<string, WordProgress>
+      settings?: UserSettings
+      dailyStats?: DailyStats[]
+    }
+
+    await this.clearAll()
+
+    if (parsed.languagePairs) {
+      writeJson(KEYS.LANGUAGE_PAIRS, parsed.languagePairs)
+    }
+
+    if (parsed.words) {
+      for (const [pairId, pairWords] of Object.entries(parsed.words)) {
+        writeJson(`${KEYS.WORDS_PREFIX}${pairId}`, pairWords)
+      }
+    }
+
+    if (parsed.progress) {
+      for (const [wordId, wordProgress] of Object.entries(parsed.progress)) {
+        writeJson(`${KEYS.PROGRESS_PREFIX}${wordId}`, wordProgress)
+      }
+    }
+
+    if (parsed.settings) {
+      writeJson(KEYS.SETTINGS, parsed.settings)
+    }
+
+    if (parsed.dailyStats) {
+      for (const stats of parsed.dailyStats) {
+        writeJson(`${KEYS.DAILY_STATS_PREFIX}${stats.date}`, stats)
+      }
+    }
+  }
+
+  async clearAll(): Promise<void> {
+    const keysToRemove: string[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (key?.startsWith('lexio:')) {
+        keysToRemove.push(key)
+      }
+    }
+    for (const key of keysToRemove) {
+      localStorage.removeItem(key)
+    }
   }
 }

--- a/src/services/storage/StorageService.ts
+++ b/src/services/storage/StorageService.ts
@@ -15,11 +15,13 @@ import type {
 export interface StorageService {
   // Language pairs
   getLanguagePairs(): Promise<LanguagePair[]>
+  getLanguagePair(id: string): Promise<LanguagePair | null>
   saveLanguagePair(pair: LanguagePair): Promise<void>
   deleteLanguagePair(id: string): Promise<void>
 
   // Words
   getWords(pairId: string): Promise<Word[]>
+  getWord(id: string): Promise<Word | null>
   saveWord(word: Word): Promise<void>
   saveWords(words: Word[]): Promise<void>
   deleteWord(id: string): Promise<void>
@@ -35,6 +37,12 @@ export interface StorageService {
 
   // Stats
   getDailyStats(date: string): Promise<DailyStats | null>
+  getDailyStatsRange(from: string, to: string): Promise<DailyStats[]>
   saveDailyStats(stats: DailyStats): Promise<void>
   getRecentDailyStats(days: number): Promise<DailyStats[]>
+
+  // Data management
+  exportAll(): Promise<string>
+  importAll(data: string): Promise<void>
+  clearAll(): Promise<void>
 }

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -1,2 +1,18 @@
+import { LocalStorageService } from './LocalStorageService'
+import type { StorageService } from './StorageService'
+
 export type { StorageService } from './StorageService'
 export { LocalStorageService } from './LocalStorageService'
+
+let instance: StorageService | null = null
+
+/**
+ * Returns a singleton StorageService instance.
+ * For MVP this is always LocalStorageService; can be swapped later based on config/env.
+ */
+export function getStorageService(): StorageService {
+  if (instance === null) {
+    instance = new LocalStorageService()
+  }
+  return instance
+}


### PR DESCRIPTION
## Summary

Complete the remaining gaps from issue #3 that were not covered by the initial scaffolding PR.

### StorageService interface additions
- `getLanguagePair(id)` - fetch a single pair by ID
- `getWord(id)` - fetch a single word by ID (scans across pairs)
- `getDailyStatsRange(from, to)` - fetch stats within a date range
- `exportAll()` - serialise all data to a versioned JSON string
- `importAll(data)` - restore from JSON backup (clears existing data first)
- `clearAll()` - remove all `lexio:` prefixed keys (preserves other apps' data)

### Storage provider
- Updated `src/services/storage/index.ts` with `getStorageService()` singleton factory
- Re-exports `StorageService` type and `LocalStorageService` class

### React integration
- `src/hooks/useStorage.ts` - hook with `StorageContext` for dependency injection
- Default context uses `getStorageService()`, so wrapping in a provider is optional

### New tests
- `getLanguagePair(id)` and `getWord(id)` lookup tests
- `getDailyStatsRange` with populated and empty ranges
- Export/import roundtrip (all entity types survive the cycle)
- `exportAll` produces valid JSON with version field
- `importAll` error handling: invalid JSON throws, partial data imports gracefully
- `clearAll` only removes `lexio:` keys
- Corrupted JSON handling: settings, language pairs, and progress all degrade gracefully

Closes #3

## Test plan

- [x] All new methods have unit tests
- [x] Export/import roundtrip preserves all data
- [x] Corrupted localStorage handled gracefully
- [x] `clearAll` does not affect non-lexio keys
- [x] All existing tests still pass