### PR TITLE
fix: CI pipeline safeguard, build fix, and lockfile docs (#26)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,9 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Verify lockfile integrity
+        run: npm ci --dry-run
+
       - name: Install dependencies
         run: npm ci
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,26 @@ npm run build      # Verify production build
 npx tsc --noEmit   # Type check only
 ```
 
+### Lockfile Integrity
+
+After any `npm install` (adding, removing, or upgrading packages), always verify the lockfile is consistent before committing:
+
+```bash
+npm install           # add/upgrade packages
+npm ci --dry-run      # verify lockfile is valid - must pass before committing
+```
+
+If `npm ci --dry-run` fails, the lockfile is out of sync. Regenerate it:
+
+```bash
+rm package-lock.json
+rm -rf node_modules
+npm install
+npm ci --dry-run      # should now pass
+```
+
+Never commit a `package-lock.json` that fails `npm ci`. The CI pipeline enforces this with a dedicated "Verify lockfile integrity" step that runs before install.
+
 ---
 
 ## Important Reminders

--- a/src/features/language-pairs/components/CreatePairDialog.test.tsx
+++ b/src/features/language-pairs/components/CreatePairDialog.test.tsx
@@ -76,8 +76,6 @@ describe('CreatePairDialog', () => {
       />,
     )
 
-    // Fill in identical source and target
-    const textboxes = screen.getAllByRole('textbox')
     // Fill language code fields directly
     const codeFields = screen.getAllByLabelText('Language code')
     await user.type(codeFields[0], 'en')


### PR DESCRIPTION
## Summary

- Adds a lockfile integrity verification step to the CI pipeline so broken lockfiles fail immediately
- Fixes a pre-existing build-breaking unused variable in `CreatePairDialog.test.tsx`
- Documents lockfile integrity process in `CLAUDE.md` for all agents

## Changes

- `.github/workflows/deploy.yml` - Added `Verify lockfile integrity` step (`npm ci --dry-run`) before `Install dependencies`. This catches any lockfile mismatch before spending time on a full install.
- `CLAUDE.md` - Added Lockfile Integrity section explaining when and how to verify/regenerate the lockfile.
- `src/features/language-pairs/components/CreatePairDialog.test.tsx` - Removed unused `textboxes` variable that caused `tsc -b` (used in `npm run build`) to fail.

## Notes

**Action required by repo owner:** The Pages source must be changed manually in Settings > Pages > Source from "Deploy from a branch" to **"GitHub Actions"**. This cannot be done via code. Without this, `actions/deploy-pages@v4` will fail and two competing workflows run on every push.

URL: https://github.com/mreppo/lexio/settings/pages

## Testing

- All 150 tests pass
- `npx tsc --noEmit` passes
- `npm run build` passes
- `npm ci` passes with regenerated lockfile

## Review

- Code review passed (reviewer found no issues)

Closes #26