### PR TITLE
fix: use --legacy-peer-deps in CI to resolve yaml peer dep conflict (#26)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,10 +28,10 @@ jobs:
           cache: 'npm'
 
       - name: Verify lockfile integrity
-        run: npm ci --dry-run
+        run: npm ci --dry-run --legacy-peer-deps
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Type check
         run: npx tsc --noEmit


### PR DESCRIPTION
## Summary

- npm v10 (bundled with Node 20 on ubuntu-latest) enforces peer dependencies by default
- vite@6 declares \`yaml@^2.4.2\` as a peer dependency
- This caused \`npm ci\` in CI to fail: \"yaml@1.10.2 does not satisfy yaml@2.8.2\"
- The lockfile was generated with npm v11 locally where this peer dep conflict does not surface
- Fix: add \`--legacy-peer-deps\` to both the lockfile integrity check and the install step in the workflow

## Changes

- \`.github/workflows/deploy.yml\` - added \`--legacy-peer-deps\` to \`npm ci --dry-run\` and \`npm ci\` steps

## Testing

- 150/150 tests pass locally
- \`npm run build\` succeeds
- \`npm ci --dry-run --legacy-peer-deps\` passes locally
- \`npx tsc --noEmit\` clean

## Review

No code changes, only CI workflow update.

Closes #26