### PR TITLE
feat: word management - CRUD, search, filter, list view (#6)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import {
   Typography,
   Container,
   Button,
+  Tab,
+  Tabs,
 } from '@mui/material'
 import { createAppTheme } from './theme'
 import { useThemeMode } from './hooks/useThemeMode'
@@ -20,6 +22,7 @@ import {
   LanguagePairList,
 } from './features/language-pairs'
 import type { CreatePairInput } from './features/language-pairs'
+import { WordListScreen } from './features/words'
 
 /**
  * A single shared storage instance for the application.
@@ -40,6 +43,8 @@ function AppContent() {
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   // Whether this is the first launch (no pairs yet, after loading completes).
   const [isFirstLaunch, setIsFirstLaunch] = useState(false)
+  // Active tab: 'pairs' = language pair management, 'words' = word list
+  const [activeTab, setActiveTab] = useState<'pairs' | 'words'>('words')
 
   useEffect(() => {
     if (!loading && pairs.length === 0) {
@@ -90,6 +95,20 @@ function AppContent() {
         </Toolbar>
       </AppBar>
 
+      {/* Navigation tabs — only show when there are pairs */}
+      {!loading && pairs.length > 0 && (
+        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+          <Tabs
+            value={activeTab}
+            onChange={(_e, v: 'pairs' | 'words') => setActiveTab(v)}
+            centered
+          >
+            <Tab label="Words" value="words" />
+            <Tab label="Language pairs" value="pairs" />
+          </Tabs>
+        </Box>
+      )}
+
       <Container maxWidth="sm" sx={{ py: 4 }}>
         {!loading && (
           <>
@@ -110,22 +129,30 @@ function AppContent() {
                 </Button>
               </Box>
             ) : (
-              <Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
-                  <Typography variant="h6" fontWeight={700}>
-                    Language pairs
-                  </Typography>
-                  <Button variant="outlined" size="small" onClick={handleOpenCreateDialog}>
-                    Add pair
-                  </Button>
-                </Box>
+              <>
+                {activeTab === 'words' && (
+                  <WordListScreen activePair={activePair} />
+                )}
 
-                <LanguagePairList
-                  pairs={pairs}
-                  activePairId={activePair?.id ?? null}
-                  onDelete={deletePair}
-                />
-              </Box>
+                {activeTab === 'pairs' && (
+                  <Box>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+                      <Typography variant="h6" fontWeight={700}>
+                        Language pairs
+                      </Typography>
+                      <Button variant="outlined" size="small" onClick={handleOpenCreateDialog}>
+                        Add pair
+                      </Button>
+                    </Box>
+
+                    <LanguagePairList
+                      pairs={pairs}
+                      activePairId={activePair?.id ?? null}
+                      onDelete={deletePair}
+                    />
+                  </Box>
+                )}
+              </>
             )}
           </>
         )}

--- a/src/features/words/components/DeleteWordDialog.tsx
+++ b/src/features/words/components/DeleteWordDialog.tsx
@@ -1,0 +1,57 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+} from '@mui/material'
+
+export interface DeleteWordDialogProps {
+  readonly open: boolean
+  /** Number of words to delete. Used to customise dialog text. */
+  readonly count: number
+  /** Display label for the word (source word text) when deleting a single word. */
+  readonly wordLabel?: string
+  readonly onClose: () => void
+  readonly onConfirm: () => Promise<void>
+}
+
+/**
+ * Confirmation dialog for deleting one or more words.
+ */
+export function DeleteWordDialog({
+  open,
+  count,
+  wordLabel,
+  onClose,
+  onConfirm,
+}: DeleteWordDialogProps) {
+  const isBulk = count > 1
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Delete {isBulk ? `${count} words` : 'word'}?</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary">
+          {isBulk
+            ? `Are you sure you want to delete these ${count} words? This cannot be undone.`
+            : `Are you sure you want to delete "${wordLabel}"? This cannot be undone.`}
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={async () => {
+            await onConfirm()
+            onClose()
+          }}
+        >
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/features/words/components/WordFormDialog.test.tsx
+++ b/src/features/words/components/WordFormDialog.test.tsx
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { WordFormDialog } from './WordFormDialog'
+import type { Word } from '@/types'
+
+function makeWord(overrides: Partial<Word> = {}): Word {
+  return {
+    id: 'word-1',
+    pairId: 'pair-1',
+    source: 'house',
+    target: 'māja',
+    notes: 'a place to live',
+    tags: ['nouns', 'B1'],
+    createdAt: 1_000_000,
+    isFromPack: false,
+    ...overrides,
+  }
+}
+
+describe('WordFormDialog', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should not render when open is false', () => {
+    render(
+      <WordFormDialog
+        open={false}
+        word={null}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+    expect(screen.queryByText('Add word')).not.toBeInTheDocument()
+  })
+
+  it('should render add mode when open is true and word is null', () => {
+    render(
+      <WordFormDialog
+        open={true}
+        word={null}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('heading', { name: 'Add word' })).toBeInTheDocument()
+  })
+
+  it('should render edit mode when a word is provided', () => {
+    render(
+      <WordFormDialog
+        open={true}
+        word={makeWord()}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Edit word')).toBeInTheDocument()
+  })
+
+  it('should pre-fill form fields when editing an existing word', () => {
+    render(
+      <WordFormDialog
+        open={true}
+        word={makeWord()}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+    expect(screen.getByDisplayValue('house')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('māja')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('a place to live')).toBeInTheDocument()
+  })
+
+  it('should show existing tags in edit mode', () => {
+    render(
+      <WordFormDialog
+        open={true}
+        word={makeWord()}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('nouns')).toBeInTheDocument()
+    expect(screen.getByText('B1')).toBeInTheDocument()
+  })
+
+  it('should call onClose when Cancel is clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(
+      <WordFormDialog
+        open={true}
+        word={null}
+        onClose={onClose}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Cancel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('should disable submit button when fields are empty', () => {
+    render(
+      <WordFormDialog
+        open={true}
+        word={null}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /Add word/i })).toBeDisabled()
+  })
+
+  it('should enable submit button when source and target are filled', async () => {
+    const user = userEvent.setup()
+    render(
+      <WordFormDialog
+        open={true}
+        word={null}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    await user.type(screen.getByLabelText(/Source word/i), 'cat')
+    await user.type(screen.getByLabelText(/Target word/i), 'kaķis')
+    expect(screen.getByRole('button', { name: /Add word/i })).toBeEnabled()
+  })
+
+  it('should call onSubmit with correct data', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(true)
+
+    render(
+      <WordFormDialog
+        open={true}
+        word={null}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    await user.type(screen.getByLabelText(/Source word/i), 'cat')
+    await user.type(screen.getByLabelText(/Target word/i), 'kaķis')
+    await user.click(screen.getByRole('button', { name: /Add word/i }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        source: 'cat',
+        target: 'kaķis',
+        notes: null,
+        tags: [],
+      })
+    })
+  })
+
+  it('should show duplicate error when onSubmit returns false', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(false)
+
+    render(
+      <WordFormDialog
+        open={true}
+        word={null}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    await user.type(screen.getByLabelText(/Source word/i), 'cat')
+    await user.type(screen.getByLabelText(/Target word/i), 'kaķis')
+    await user.click(screen.getByRole('button', { name: /Add word/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('This word already exists in the list.'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('should add a tag when pressing Enter in the tag field', async () => {
+    const user = userEvent.setup()
+    render(
+      <WordFormDialog
+        open={true}
+        word={null}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    await user.type(screen.getByLabelText(/Tags/i), 'food')
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByText('food')).toBeInTheDocument()
+  })
+
+  it('should remove a tag when its delete button is clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <WordFormDialog
+        open={true}
+        word={makeWord()}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    // Word has 'nouns' and 'B1' tags.
+    // MUI Chip places aria-label on the chip root div (role="button") when onDelete is set.
+    // The actual delete SVG (CancelIcon) is inside. We need to click the CancelIcon directly.
+    const nounChip = screen.getByLabelText('Remove tag nouns')
+    // Find the CancelIcon SVG inside this chip
+    const cancelIcon = nounChip.querySelector('[data-testid="CancelIcon"]')
+    expect(cancelIcon).not.toBeNull()
+    await user.click(cancelIcon!)
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Remove tag nouns')).not.toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Remove tag B1')).toBeInTheDocument()
+  })
+
+  it('should close the dialog after successful submit in non-quick-add mode', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const onSubmit = vi.fn().mockResolvedValue(true)
+
+    render(
+      <WordFormDialog
+        open={true}
+        word={null}
+        quickAddMode={false}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    await user.type(screen.getByLabelText(/Source word/i), 'cat')
+    await user.type(screen.getByLabelText(/Target word/i), 'kaķis')
+    await user.click(screen.getByRole('button', { name: /Add word/i }))
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should reset the form in quick-add mode instead of closing', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const onSubmit = vi.fn().mockResolvedValue(true)
+
+    render(
+      <WordFormDialog
+        open={true}
+        word={null}
+        quickAddMode={true}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    await user.type(screen.getByLabelText(/Source word/i), 'cat')
+    await user.type(screen.getByLabelText(/Target word/i), 'kaķis')
+    await user.click(screen.getByRole('button', { name: /Add word/i }))
+
+    await waitFor(() => {
+      // Form should be reset, not closed
+      expect(onClose).not.toHaveBeenCalled()
+      expect(screen.getByLabelText(/Source word/i)).toHaveValue('')
+    })
+  })
+})

--- a/src/features/words/components/WordFormDialog.tsx
+++ b/src/features/words/components/WordFormDialog.tsx
@@ -1,0 +1,243 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Stack,
+  Chip,
+  Box,
+  Typography,
+  IconButton,
+  InputAdornment,
+} from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import type { Word } from '@/types'
+import type { CreateWordInput } from '../useWords'
+
+export interface WordFormDialogProps {
+  readonly open: boolean
+  /** If provided, the dialog is in edit mode. If null, add mode. */
+  readonly word: Word | null
+  /** If true, after saving the form resets for quick-add of another word. */
+  readonly quickAddMode?: boolean
+  readonly onClose: () => void
+  readonly onSubmit: (input: CreateWordInput) => Promise<boolean>
+}
+
+const EMPTY_FORM = {
+  source: '',
+  target: '',
+  notes: '',
+  tagInput: '',
+  tags: [] as string[],
+}
+
+/**
+ * Dialog for adding a new word or editing an existing one.
+ * Quick-add mode resets the form after each save to allow rapid entry.
+ */
+export function WordFormDialog({
+  open,
+  word,
+  quickAddMode = false,
+  onClose,
+  onSubmit,
+}: WordFormDialogProps) {
+  const isEdit = word !== null
+
+  const [source, setSource] = useState('')
+  const [target, setTarget] = useState('')
+  const [notes, setNotes] = useState('')
+  const [tagInput, setTagInput] = useState('')
+  const [tags, setTags] = useState<string[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [duplicateError, setDuplicateError] = useState(false)
+
+  // Populate form when editing an existing word or when dialog opens.
+  useEffect(() => {
+    if (open) {
+      if (word) {
+        setSource(word.source)
+        setTarget(word.target)
+        setNotes(word.notes ?? '')
+        setTags([...word.tags])
+      } else {
+        setSource(EMPTY_FORM.source)
+        setTarget(EMPTY_FORM.target)
+        setNotes(EMPTY_FORM.notes)
+        setTagInput(EMPTY_FORM.tagInput)
+        setTags(EMPTY_FORM.tags)
+      }
+      setDuplicateError(false)
+    }
+  }, [open, word])
+
+  const resetForm = useCallback(() => {
+    setSource('')
+    setTarget('')
+    setNotes('')
+    setTagInput('')
+    setTags([])
+    setDuplicateError(false)
+  }, [])
+
+  const addTag = useCallback(() => {
+    const trimmed = tagInput.trim()
+    if (trimmed && !tags.includes(trimmed)) {
+      setTags((prev) => [...prev, trimmed])
+    }
+    setTagInput('')
+  }, [tagInput, tags])
+
+  const removeTag = useCallback((tag: string) => {
+    setTags((prev) => prev.filter((t) => t !== tag))
+  }, [])
+
+  const handleTagKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ',') {
+        e.preventDefault()
+        addTag()
+      }
+    },
+    [addTag],
+  )
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!source.trim() || !target.trim()) return
+
+      setSubmitting(true)
+      setDuplicateError(false)
+
+      const success = await onSubmit({
+        source: source.trim(),
+        target: target.trim(),
+        notes: notes.trim() || null,
+        tags,
+      })
+
+      setSubmitting(false)
+
+      if (!success) {
+        setDuplicateError(true)
+        return
+      }
+
+      if (quickAddMode && !isEdit) {
+        resetForm()
+      } else {
+        onClose()
+      }
+    },
+    [source, target, notes, tags, onSubmit, quickAddMode, isEdit, onClose, resetForm],
+  )
+
+  const canSubmit = source.trim().length > 0 && target.trim().length > 0 && !submitting
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      PaperProps={{ component: 'form', onSubmit: handleSubmit }}
+    >
+      <DialogTitle>{isEdit ? 'Edit word' : 'Add word'}</DialogTitle>
+
+      <DialogContent>
+        <Stack spacing={2} sx={{ pt: 1 }}>
+          <TextField
+            label="Source word"
+            value={source}
+            onChange={(e) => setSource(e.target.value)}
+            autoFocus
+            required
+            fullWidth
+            inputProps={{ lang: 'mul' }}
+            error={duplicateError}
+          />
+
+          <TextField
+            label="Target word"
+            value={target}
+            onChange={(e) => setTarget(e.target.value)}
+            required
+            fullWidth
+            inputProps={{ lang: 'mul' }}
+            error={duplicateError}
+            helperText={duplicateError ? 'This word already exists in the list.' : undefined}
+          />
+
+          <TextField
+            label="Notes (optional)"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            multiline
+            rows={2}
+            fullWidth
+            placeholder="Example sentence, context, memory hint…"
+          />
+
+          <Box>
+            <TextField
+              label="Tags (optional)"
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              onKeyDown={handleTagKeyDown}
+              fullWidth
+              placeholder="Press Enter or comma to add a tag"
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      aria-label="Add tag"
+                      onClick={addTag}
+                      edge="end"
+                      size="small"
+                      disabled={!tagInput.trim()}
+                    >
+                      <AddIcon />
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+            {tags.length > 0 && (
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
+                {tags.map((tag) => (
+                  <Chip
+                    key={tag}
+                    label={tag}
+                    size="small"
+                    onDelete={() => removeTag(tag)}
+                    aria-label={`Remove tag ${tag}`}
+                  />
+                ))}
+              </Box>
+            )}
+          </Box>
+
+          {quickAddMode && !isEdit && (
+            <Typography variant="caption" color="text.secondary">
+              Quick-add mode: form resets after each save so you can add multiple words.
+            </Typography>
+          )}
+        </Stack>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button type="submit" variant="contained" disabled={!canSubmit}>
+          {isEdit ? 'Save' : 'Add word'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/features/words/components/WordList.test.tsx
+++ b/src/features/words/components/WordList.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { WordList } from './WordList'
+import type { Word, WordProgress } from '@/types'
+
+function makeWord(overrides: Partial<Word> = {}): Word {
+  return {
+    id: `word-${Math.random()}`,
+    pairId: 'pair-1',
+    source: 'house',
+    target: 'māja',
+    notes: null,
+    tags: [],
+    createdAt: Date.now(),
+    isFromPack: false,
+    ...overrides,
+  }
+}
+
+function makeProgress(wordId: string, confidence: number): WordProgress {
+  return {
+    wordId,
+    correctCount: 5,
+    incorrectCount: 1,
+    streak: 3,
+    lastReviewed: Date.now(),
+    nextReview: Date.now() + 86400000,
+    confidence,
+    history: [],
+  }
+}
+
+const defaultProps = {
+  words: [] as Word[],
+  progressMap: new Map<string, WordProgress>(),
+  onEdit: vi.fn() as (word: Word) => void,
+  onDelete: vi.fn().mockResolvedValue(undefined) as (wordId: string) => Promise<void>,
+  onBulkDelete: vi.fn().mockResolvedValue(undefined) as (wordIds: readonly string[]) => Promise<void>,
+}
+
+describe('WordList', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should show empty message when no words match filters', () => {
+    render(<WordList {...defaultProps} words={[]} />)
+    expect(screen.getByText(/No words match/i)).toBeInTheDocument()
+  })
+
+  it('should render word items', () => {
+    const words = [
+      makeWord({ id: 'w1', source: 'cat', target: 'kaķis' }),
+      makeWord({ id: 'w2', source: 'dog', target: 'suns' }),
+    ]
+    render(<WordList {...defaultProps} words={words} />)
+    expect(screen.getByText('cat')).toBeInTheDocument()
+    expect(screen.getByText('kaķis')).toBeInTheDocument()
+    expect(screen.getByText('dog')).toBeInTheDocument()
+    expect(screen.getByText('suns')).toBeInTheDocument()
+  })
+
+  it('should show word count', () => {
+    const words = [
+      makeWord({ id: 'w1' }),
+      makeWord({ id: 'w2' }),
+    ]
+    render(<WordList {...defaultProps} words={words} />)
+    expect(screen.getByText(/2 words/i)).toBeInTheDocument()
+  })
+
+  it('should filter words by search query', async () => {
+    const user = userEvent.setup()
+    const words = [
+      makeWord({ id: 'w1', source: 'cat', target: 'kaķis' }),
+      makeWord({ id: 'w2', source: 'dog', target: 'suns' }),
+    ]
+    render(<WordList {...defaultProps} words={words} />)
+
+    await user.type(screen.getByLabelText(/Search words/i), 'cat')
+
+    expect(screen.getByText('cat')).toBeInTheDocument()
+    expect(screen.queryByText('dog')).not.toBeInTheDocument()
+  })
+
+  it('should filter words by target word in search', async () => {
+    const user = userEvent.setup()
+    const words = [
+      makeWord({ id: 'w1', source: 'cat', target: 'kaķis' }),
+      makeWord({ id: 'w2', source: 'dog', target: 'suns' }),
+    ]
+    render(<WordList {...defaultProps} words={words} />)
+
+    await user.type(screen.getByLabelText(/Search words/i), 'kaķ')
+
+    expect(screen.getByText('cat')).toBeInTheDocument()
+    expect(screen.queryByText('dog')).not.toBeInTheDocument()
+  })
+
+  it('should show tag filter chips when words have tags', () => {
+    const words = [
+      makeWord({ id: 'w1', tags: ['food', 'B1'] }),
+    ]
+    render(<WordList {...defaultProps} words={words} />)
+    expect(screen.getByRole('button', { name: /food/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /B1/i })).toBeInTheDocument()
+  })
+
+  it('should filter by tag when a tag chip is clicked', async () => {
+    const user = userEvent.setup()
+    const words = [
+      makeWord({ id: 'w1', source: 'apple', target: 'ābols', tags: ['food'] }),
+      makeWord({ id: 'w2', source: 'run', target: 'skriet', tags: ['verbs'] }),
+    ]
+    render(<WordList {...defaultProps} words={words} />)
+
+    // Click the 'food' tag chip
+    const foodChip = screen.getByRole('button', { name: /food/i })
+    await user.click(foodChip)
+
+    expect(screen.getByText('apple')).toBeInTheDocument()
+    expect(screen.queryByText('run')).not.toBeInTheDocument()
+  })
+
+  it('should enter selection mode when Select button is clicked', async () => {
+    const user = userEvent.setup()
+    const words = [makeWord({ id: 'w1', source: 'cat', target: 'kaķis' })]
+    render(<WordList {...defaultProps} words={words} />)
+
+    await user.click(screen.getByRole('button', { name: /Select/i }))
+
+    expect(screen.getByLabelText(/Select cat/i)).toBeInTheDocument()
+  })
+
+  it('should exit selection mode when Cancel is clicked', async () => {
+    const user = userEvent.setup()
+    const words = [makeWord({ id: 'w1', source: 'cat', target: 'kaķis' })]
+    render(<WordList {...defaultProps} words={words} />)
+
+    await user.click(screen.getByRole('button', { name: /Select/i }))
+    await user.click(screen.getByRole('button', { name: /Cancel/i }))
+
+    expect(screen.queryByLabelText(/Select cat/i)).not.toBeInTheDocument()
+  })
+
+  it('should show Delete button when items are selected', async () => {
+    const user = userEvent.setup()
+    const words = [makeWord({ id: 'w1', source: 'cat', target: 'kaķis' })]
+    render(<WordList {...defaultProps} words={words} />)
+
+    await user.click(screen.getByRole('button', { name: /Select/i }))
+
+    // Click the checkbox input directly
+    const checkbox = screen.getByLabelText(/Select cat/i)
+    await user.click(checkbox)
+
+    // The Delete button text is "Delete (1)" - check by text content
+    const buttons = screen.getAllByRole('button')
+    const deleteBtn = buttons.find((b) => b.textContent?.includes('Delete') && b.textContent?.includes('1'))
+    expect(deleteBtn).toBeTruthy()
+  })
+
+  it('should open delete confirmation when single delete is triggered', async () => {
+    const user = userEvent.setup()
+    const words = [makeWord({ id: 'w1', source: 'cat', target: 'kaķis' })]
+    render(<WordList {...defaultProps} words={words} />)
+
+    await user.click(screen.getByLabelText(/Delete cat/i))
+
+    expect(screen.getByText(/Delete word\?/i)).toBeInTheDocument()
+  })
+
+  it('should call onDelete when delete is confirmed', async () => {
+    const user = userEvent.setup()
+    const onDelete = vi.fn().mockResolvedValue(undefined)
+    const words = [makeWord({ id: 'w1', source: 'cat', target: 'kaķis' })]
+    render(<WordList {...defaultProps} words={words} onDelete={onDelete} />)
+
+    await user.click(screen.getByLabelText(/Delete cat/i))
+    await user.click(screen.getByRole('button', { name: /^Delete$/i }))
+
+    expect(onDelete).toHaveBeenCalledWith('w1')
+  })
+
+  it('should call onEdit when edit button is clicked', async () => {
+    const user = userEvent.setup()
+    const onEdit = vi.fn()
+    const word = makeWord({ id: 'w1', source: 'cat', target: 'kaķis' })
+    render(<WordList {...defaultProps} words={[word]} onEdit={onEdit} />)
+
+    await user.click(screen.getByLabelText(/Edit cat/i))
+
+    expect(onEdit).toHaveBeenCalledWith(word)
+  })
+
+  it('should show confidence chip when progress exists', () => {
+    const word = makeWord({ id: 'w1', source: 'cat', target: 'kaķis' })
+    const progress = makeProgress('w1', 0.8)
+    const progressMap = new Map([['w1', progress]])
+
+    render(<WordList {...defaultProps} words={[word]} progressMap={progressMap} />)
+
+    expect(screen.getByLabelText(/Confidence: Mastered/i)).toBeInTheDocument()
+  })
+
+  it('should show select-all checkbox in selection mode', async () => {
+    const user = userEvent.setup()
+    const words = [
+      makeWord({ id: 'w1', source: 'cat' }),
+      makeWord({ id: 'w2', source: 'dog' }),
+    ]
+    render(<WordList {...defaultProps} words={words} />)
+
+    await user.click(screen.getByRole('button', { name: /Select/i }))
+
+    expect(screen.getByLabelText(/Select all visible words/i)).toBeInTheDocument()
+  })
+
+  it('should select all words when select-all is checked', async () => {
+    const user = userEvent.setup()
+    const words = [
+      makeWord({ id: 'w1', source: 'cat' }),
+      makeWord({ id: 'w2', source: 'dog' }),
+    ]
+    render(<WordList {...defaultProps} words={words} />)
+
+    await user.click(screen.getByRole('button', { name: /Select/i }))
+    await user.click(screen.getByLabelText(/Select all visible words/i))
+
+    // Delete button should show count of 2
+    const buttons = screen.getAllByRole('button')
+    const deleteBtn = buttons.find((b) => b.textContent?.includes('Delete') && b.textContent?.includes('2'))
+    expect(deleteBtn).toBeTruthy()
+  })
+
+  it('should show pack badge for starter pack words', () => {
+    const word = makeWord({ id: 'w1', source: 'cat', isFromPack: true })
+    render(<WordList {...defaultProps} words={[word]} />)
+    expect(screen.getByLabelText(/From starter pack/i)).toBeInTheDocument()
+  })
+
+  it('should filter by word source (user-added vs pack)', async () => {
+    const user = userEvent.setup()
+    const words = [
+      makeWord({ id: 'w1', source: 'cat', isFromPack: false }),
+      makeWord({ id: 'w2', source: 'dog', isFromPack: true }),
+    ]
+    render(<WordList {...defaultProps} words={words} />)
+
+    // Change word filter to 'user-added'
+    await user.click(screen.getByLabelText('Filter'))
+    await user.click(screen.getByText('My words'))
+
+    expect(screen.getByText('cat')).toBeInTheDocument()
+    expect(screen.queryByText('dog')).not.toBeInTheDocument()
+  })
+
+  it('should not show Select button when there are no words', () => {
+    render(<WordList {...defaultProps} words={[]} />)
+    expect(screen.queryByRole('button', { name: /Select/i })).not.toBeInTheDocument()
+  })
+
+  it('should show notes in word list item when notes exist', () => {
+    const word = makeWord({ id: 'w1', source: 'house', notes: 'a building to live in' })
+    render(<WordList {...defaultProps} words={[word]} />)
+    expect(screen.getByText('a building to live in')).toBeInTheDocument()
+  })
+})

--- a/src/features/words/components/WordList.tsx
+++ b/src/features/words/components/WordList.tsx
@@ -1,0 +1,371 @@
+import { useState, useMemo, useCallback } from 'react'
+import {
+  Box,
+  TextField,
+  InputAdornment,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  List,
+  Paper,
+  Typography,
+  Button,
+  Chip,
+  Stack,
+  Divider,
+  Toolbar,
+  Checkbox,
+} from '@mui/material'
+import SearchIcon from '@mui/icons-material/Search'
+import SortIcon from '@mui/icons-material/Sort'
+import DeleteIcon from '@mui/icons-material/Delete'
+import type { Word, WordProgress } from '@/types'
+import {
+  SORT_OPTIONS,
+  WORD_FILTERS,
+  CONFIDENCE_FILTERS,
+  getConfidenceBucket,
+} from '../constants'
+import type { SortOption, WordFilter, ConfidenceFilter } from '../constants'
+import { WordListItem } from './WordListItem'
+import { DeleteWordDialog } from './DeleteWordDialog'
+
+export interface WordListProps {
+  readonly words: readonly Word[]
+  readonly progressMap: ReadonlyMap<string, WordProgress>
+  readonly onEdit: (word: Word) => void
+  readonly onDelete: (wordId: string) => Promise<void>
+  readonly onBulkDelete: (wordIds: readonly string[]) => Promise<void>
+}
+
+/**
+ * Full word list with search, filter, sort and bulk-selection controls.
+ */
+export function WordList({
+  words,
+  progressMap,
+  onEdit,
+  onDelete,
+  onBulkDelete,
+}: WordListProps) {
+  const [search, setSearch] = useState('')
+  const [sortOption, setSortOption] = useState<SortOption>('date-desc')
+  const [wordFilter, setWordFilter] = useState<WordFilter>('all')
+  const [confidenceFilter, setConfidenceFilter] = useState<ConfidenceFilter>('all')
+  const [activeTags, setActiveTags] = useState<string[]>([])
+
+  // Selection state for bulk delete.
+  const [selectionMode, setSelectionMode] = useState(false)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+
+  // Delete confirmation state.
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [wordToDelete, setWordToDelete] = useState<Word | null>(null)
+
+  // Collect all unique tags from the word list.
+  const allTags = useMemo(() => {
+    const tagSet = new Set<string>()
+    for (const word of words) {
+      for (const tag of word.tags) tagSet.add(tag)
+    }
+    return Array.from(tagSet).sort()
+  }, [words])
+
+  const filteredAndSorted = useMemo(() => {
+    const q = search.toLowerCase()
+
+    return [...words]
+      .filter((w) => {
+        // Text search
+        if (q && !w.source.toLowerCase().includes(q) && !w.target.toLowerCase().includes(q)) {
+          return false
+        }
+        // Word filter
+        if (wordFilter === 'user-added' && w.isFromPack) return false
+        if (wordFilter === 'from-pack' && !w.isFromPack) return false
+        // Tag filter
+        if (activeTags.length > 0 && !activeTags.every((t) => w.tags.includes(t))) return false
+        // Confidence filter
+        if (confidenceFilter !== 'all') {
+          const progress = progressMap.get(w.id) ?? null
+          const bucket = getConfidenceBucket(progress?.confidence ?? null)
+          if (bucket !== confidenceFilter) return false
+        }
+        return true
+      })
+      .sort((a, b) => {
+        const progA = progressMap.get(a.id)
+        const progB = progressMap.get(b.id)
+        switch (sortOption) {
+          case 'source-asc': return a.source.localeCompare(b.source)
+          case 'source-desc': return b.source.localeCompare(a.source)
+          case 'target-asc': return a.target.localeCompare(b.target)
+          case 'target-desc': return b.target.localeCompare(a.target)
+          case 'date-asc': return a.createdAt - b.createdAt
+          case 'date-desc': return b.createdAt - a.createdAt
+          case 'confidence-asc': return (progA?.confidence ?? 0) - (progB?.confidence ?? 0)
+          case 'confidence-desc': return (progB?.confidence ?? 0) - (progA?.confidence ?? 0)
+          default: return 0
+        }
+      })
+  }, [words, search, sortOption, wordFilter, confidenceFilter, activeTags, progressMap])
+
+  const handleToggleTag = useCallback((tag: string) => {
+    setActiveTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    )
+  }, [])
+
+  const handleToggleSelect = useCallback((wordId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(wordId)) next.delete(wordId)
+      else next.add(wordId)
+      return next
+    })
+  }, [])
+
+  const handleSelectAll = useCallback(() => {
+    if (selectedIds.size === filteredAndSorted.length) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(filteredAndSorted.map((w) => w.id)))
+    }
+  }, [selectedIds.size, filteredAndSorted])
+
+  const handleEnterSelectionMode = useCallback(() => {
+    setSelectionMode(true)
+    setSelectedIds(new Set())
+  }, [])
+
+  const handleExitSelectionMode = useCallback(() => {
+    setSelectionMode(false)
+    setSelectedIds(new Set())
+  }, [])
+
+  const handleDeleteSingle = useCallback((word: Word) => {
+    setWordToDelete(word)
+    setDeleteDialogOpen(true)
+  }, [])
+
+  const handleConfirmDeleteSingle = useCallback(async () => {
+    if (wordToDelete) {
+      await onDelete(wordToDelete.id)
+      setWordToDelete(null)
+    }
+  }, [wordToDelete, onDelete])
+
+  const handleBulkDeleteRequest = useCallback(() => {
+    if (selectedIds.size > 0) {
+      setDeleteDialogOpen(true)
+    }
+  }, [selectedIds.size])
+
+  const handleConfirmBulkDelete = useCallback(async () => {
+    await onBulkDelete(Array.from(selectedIds))
+    setSelectedIds(new Set())
+    setSelectionMode(false)
+  }, [onBulkDelete, selectedIds])
+
+  const handleDeleteDialogClose = useCallback(() => {
+    setDeleteDialogOpen(false)
+    setWordToDelete(null)
+  }, [])
+
+  const isBulkDelete = wordToDelete === null
+  const allVisibleSelected =
+    filteredAndSorted.length > 0 && selectedIds.size === filteredAndSorted.length
+
+  return (
+    <Box>
+      {/* Search and controls bar */}
+      <Stack spacing={1.5} sx={{ mb: 2 }}>
+        <TextField
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search words…"
+          size="small"
+          fullWidth
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+          }}
+          inputProps={{ 'aria-label': 'Search words' }}
+        />
+
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          <FormControl size="small" sx={{ minWidth: 130 }}>
+            <InputLabel id="sort-label">
+              <SortIcon fontSize="small" sx={{ mr: 0.5, verticalAlign: 'middle' }} />
+              Sort
+            </InputLabel>
+            <Select
+              labelId="sort-label"
+              value={sortOption}
+              label="Sort"
+              onChange={(e) => setSortOption(e.target.value as SortOption)}
+            >
+              {SORT_OPTIONS.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ minWidth: 120 }}>
+            <InputLabel id="filter-label">Filter</InputLabel>
+            <Select
+              labelId="filter-label"
+              value={wordFilter}
+              label="Filter"
+              onChange={(e) => setWordFilter(e.target.value as WordFilter)}
+            >
+              {WORD_FILTERS.map((f) => (
+                <MenuItem key={f.value} value={f.value}>
+                  {f.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ minWidth: 130 }}>
+            <InputLabel id="confidence-label">Confidence</InputLabel>
+            <Select
+              labelId="confidence-label"
+              value={confidenceFilter}
+              label="Confidence"
+              onChange={(e) => setConfidenceFilter(e.target.value as ConfidenceFilter)}
+            >
+              {CONFIDENCE_FILTERS.map((f) => (
+                <MenuItem key={f.value} value={f.value}>
+                  {f.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+
+        {/* Tag filter chips */}
+        {allTags.length > 0 && (
+          <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+            {allTags.map((tag) => (
+              <Chip
+                key={tag}
+                label={tag}
+                size="small"
+                onClick={() => handleToggleTag(tag)}
+                color={activeTags.includes(tag) ? 'primary' : 'default'}
+                variant={activeTags.includes(tag) ? 'filled' : 'outlined'}
+                aria-pressed={activeTags.includes(tag)}
+              />
+            ))}
+          </Box>
+        )}
+      </Stack>
+
+      {/* Result count + bulk controls */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: 1,
+          minHeight: 32,
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          {filteredAndSorted.length} word{filteredAndSorted.length !== 1 ? 's' : ''}
+          {words.length !== filteredAndSorted.length && ` (of ${words.length})`}
+        </Typography>
+
+        {!selectionMode && filteredAndSorted.length > 0 && (
+          <Button size="small" variant="text" onClick={handleEnterSelectionMode}>
+            Select
+          </Button>
+        )}
+
+        {selectionMode && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {selectedIds.size > 0 && (
+              <Button
+                size="small"
+                variant="contained"
+                color="error"
+                startIcon={<DeleteIcon />}
+                onClick={handleBulkDeleteRequest}
+              >
+                Delete ({selectedIds.size})
+              </Button>
+            )}
+            <Button size="small" variant="text" onClick={handleExitSelectionMode}>
+              Cancel
+            </Button>
+          </Box>
+        )}
+      </Box>
+
+      {/* Word list */}
+      {filteredAndSorted.length === 0 ? (
+        <Box sx={{ py: 4, textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            No words match your search or filters.
+          </Typography>
+        </Box>
+      ) : (
+        <Paper variant="outlined" sx={{ borderRadius: 2 }}>
+          {selectionMode && (
+            <>
+              <Toolbar
+                variant="dense"
+                sx={{ pl: 1, minHeight: 40 }}
+              >
+                <Checkbox
+                  checked={allVisibleSelected}
+                  indeterminate={selectedIds.size > 0 && !allVisibleSelected}
+                  onChange={handleSelectAll}
+                  inputProps={{ 'aria-label': 'Select all visible words' }}
+                  size="small"
+                />
+                <Typography variant="body2" color="text.secondary" sx={{ ml: 1 }}>
+                  {selectedIds.size > 0
+                    ? `${selectedIds.size} selected`
+                    : 'Select all'}
+                </Typography>
+              </Toolbar>
+              <Divider />
+            </>
+          )}
+          <List disablePadding>
+            {filteredAndSorted.map((word, index) => (
+              <Box key={word.id}>
+                {index > 0 && <Divider component="li" />}
+                <WordListItem
+                  word={word}
+                  progress={progressMap.get(word.id) ?? null}
+                  selected={selectedIds.has(word.id)}
+                  selectionMode={selectionMode}
+                  onToggleSelect={handleToggleSelect}
+                  onEdit={onEdit}
+                  onDelete={handleDeleteSingle}
+                />
+              </Box>
+            ))}
+          </List>
+        </Paper>
+      )}
+
+      <DeleteWordDialog
+        open={deleteDialogOpen}
+        count={isBulkDelete ? selectedIds.size : 1}
+        wordLabel={wordToDelete?.source}
+        onClose={handleDeleteDialogClose}
+        onConfirm={isBulkDelete ? handleConfirmBulkDelete : handleConfirmDeleteSingle}
+      />
+    </Box>
+  )
+}

--- a/src/features/words/components/WordListItem.tsx
+++ b/src/features/words/components/WordListItem.tsx
@@ -1,0 +1,162 @@
+import { useCallback } from 'react'
+import {
+  ListItem,
+  ListItemText,
+  ListItemSecondaryAction,
+  Checkbox,
+  IconButton,
+  Box,
+  Typography,
+  Chip,
+  Tooltip,
+} from '@mui/material'
+import EditIcon from '@mui/icons-material/Edit'
+import DeleteIcon from '@mui/icons-material/Delete'
+import InventoryIcon from '@mui/icons-material/Inventory'
+import type { Word, WordProgress } from '@/types'
+import { getConfidenceBucket, CONFIDENCE_LABELS, CONFIDENCE_COLORS } from '../constants'
+
+export interface WordListItemProps {
+  readonly word: Word
+  readonly progress: WordProgress | null
+  readonly selected: boolean
+  readonly selectionMode: boolean
+  readonly onToggleSelect: (wordId: string) => void
+  readonly onEdit: (word: Word) => void
+  readonly onDelete: (word: Word) => void
+}
+
+/**
+ * Single row in the word list.
+ * Shows source/target, optional confidence chip, starter-pack badge, edit/delete actions.
+ */
+export function WordListItem({
+  word,
+  progress,
+  selected,
+  selectionMode,
+  onToggleSelect,
+  onEdit,
+  onDelete,
+}: WordListItemProps) {
+  const confidenceBucket = getConfidenceBucket(progress?.confidence ?? null)
+
+  const handleToggleSelect = useCallback(() => {
+    onToggleSelect(word.id)
+  }, [onToggleSelect, word.id])
+
+  const handleEdit = useCallback(() => {
+    onEdit(word)
+  }, [onEdit, word])
+
+  const handleDelete = useCallback(() => {
+    onDelete(word)
+  }, [onDelete, word])
+
+  return (
+    <ListItem
+      disablePadding
+      sx={{ py: 0.5, pr: selectionMode ? 1 : 10 }}
+      onClick={selectionMode ? handleToggleSelect : undefined}
+      role={selectionMode ? 'checkbox' : undefined}
+      aria-checked={selectionMode ? selected : undefined}
+    >
+      {selectionMode && (
+        <Checkbox
+          edge="start"
+          checked={selected}
+          onChange={handleToggleSelect}
+          onClick={(e) => e.stopPropagation()}
+          tabIndex={-1}
+          disableRipple
+          inputProps={{ 'aria-label': `Select ${word.source}` }}
+          sx={{ ml: 0.5, mr: 0 }}
+        />
+      )}
+
+      <ListItemText
+        sx={{ my: 0.5, ml: selectionMode ? 0 : 2 }}
+        primary={
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+            <Typography variant="body1" component="span" fontWeight={500}>
+              {word.source}
+            </Typography>
+            <Typography variant="body2" component="span" color="text.secondary">
+              →
+            </Typography>
+            <Typography variant="body1" component="span">
+              {word.target}
+            </Typography>
+
+            {word.isFromPack && (
+              <Tooltip title="From starter pack">
+                <Chip
+                  icon={<InventoryIcon sx={{ fontSize: 12 }} />}
+                  label="Pack"
+                  size="small"
+                  variant="outlined"
+                  sx={{ height: 18, fontSize: '0.65rem', borderRadius: 1 }}
+                  aria-label="From starter pack"
+                />
+              </Tooltip>
+            )}
+
+            {progress !== null && (
+              <Chip
+                label={CONFIDENCE_LABELS[confidenceBucket]}
+                size="small"
+                color={CONFIDENCE_COLORS[confidenceBucket]}
+                sx={{ height: 18, fontSize: '0.65rem' }}
+                aria-label={`Confidence: ${CONFIDENCE_LABELS[confidenceBucket]}`}
+              />
+            )}
+          </Box>
+        }
+        secondary={
+          word.notes || word.tags.length > 0 ? (
+            <Box sx={{ mt: 0.25 }}>
+              {word.notes && (
+                <Typography variant="caption" color="text.secondary" display="block">
+                  {word.notes}
+                </Typography>
+              )}
+              {word.tags.length > 0 && (
+                <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.25 }}>
+                  {word.tags.map((tag) => (
+                    <Chip
+                      key={tag}
+                      label={tag}
+                      size="small"
+                      variant="outlined"
+                      sx={{ height: 16, fontSize: '0.6rem', borderRadius: 1 }}
+                    />
+                  ))}
+                </Box>
+              )}
+            </Box>
+          ) : null
+        }
+      />
+
+      {!selectionMode && (
+        <ListItemSecondaryAction>
+          <IconButton
+            size="small"
+            aria-label={`Edit ${word.source}`}
+            onClick={handleEdit}
+          >
+            <EditIcon fontSize="small" />
+          </IconButton>
+          <IconButton
+            size="small"
+            aria-label={`Delete ${word.source}`}
+            onClick={handleDelete}
+            color="error"
+          >
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+        </ListItemSecondaryAction>
+      )}
+    </ListItem>
+  )
+}

--- a/src/features/words/components/WordListScreen.test.tsx
+++ b/src/features/words/components/WordListScreen.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createElement } from 'react'
+import type { ReactNode } from 'react'
+import { WordListScreen } from './WordListScreen'
+import { StorageContext } from '@/hooks/useStorage'
+import type { StorageService } from '@/services/storage'
+import type { LanguagePair, Word, UserSettings } from '@/types'
+
+const DEFAULT_SETTINGS: UserSettings = {
+  activePairId: 'pair-1',
+  quizMode: 'mixed',
+  dailyGoal: 20,
+  theme: 'dark',
+  typoTolerance: 1,
+}
+
+const DEFAULT_PAIR: LanguagePair = {
+  id: 'pair-1',
+  sourceLang: 'English',
+  sourceCode: 'en',
+  targetLang: 'Latvian',
+  targetCode: 'lv',
+  createdAt: 1_000_000,
+}
+
+function makeWord(overrides: Partial<Word> = {}): Word {
+  return {
+    id: 'word-1',
+    pairId: 'pair-1',
+    source: 'house',
+    target: 'māja',
+    notes: null,
+    tags: [],
+    createdAt: 1_000_000,
+    isFromPack: false,
+    ...overrides,
+  }
+}
+
+function makeStorage(words: Word[] = []): StorageService {
+  const storedWords = [...words]
+  return {
+    getLanguagePairs: vi.fn().mockResolvedValue([DEFAULT_PAIR]),
+    getLanguagePair: vi.fn().mockResolvedValue(DEFAULT_PAIR),
+    saveLanguagePair: vi.fn().mockResolvedValue(undefined),
+    deleteLanguagePair: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue(DEFAULT_SETTINGS),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+
+    getWords: vi.fn().mockImplementation(async () => [...storedWords]),
+    getWord: vi.fn().mockResolvedValue(null),
+    saveWord: vi.fn().mockImplementation(async (word: Word) => {
+      storedWords.push(word)
+    }),
+    saveWords: vi.fn().mockResolvedValue(undefined),
+    deleteWord: vi.fn().mockImplementation(async (id: string) => {
+      const idx = storedWords.findIndex((w) => w.id === id)
+      if (idx >= 0) storedWords.splice(idx, 1)
+    }),
+
+    getWordProgress: vi.fn().mockResolvedValue(null),
+    getAllProgress: vi.fn().mockResolvedValue([]),
+    saveWordProgress: vi.fn().mockResolvedValue(undefined),
+
+    getDailyStats: vi.fn().mockResolvedValue(null),
+    getDailyStatsRange: vi.fn().mockResolvedValue([]),
+    saveDailyStats: vi.fn().mockResolvedValue(undefined),
+    getRecentDailyStats: vi.fn().mockResolvedValue([]),
+    exportAll: vi.fn().mockResolvedValue('{}'),
+    importAll: vi.fn().mockResolvedValue(undefined),
+    clearAll: vi.fn().mockResolvedValue(undefined),
+  } as StorageService
+}
+
+function makeWrapper(storage: StorageService) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(StorageContext.Provider, { value: storage }, children)
+}
+
+describe('WordListScreen', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should show "no pair" message when activePair is null', () => {
+    render(
+      <WordListScreen activePair={null} />,
+      { wrapper: makeWrapper(makeStorage()) },
+    )
+    expect(screen.getByText(/No language pair selected/i)).toBeInTheDocument()
+  })
+
+  it('should show empty state when no words exist', async () => {
+    render(
+      <WordListScreen activePair={DEFAULT_PAIR} />,
+      { wrapper: makeWrapper(makeStorage([])) },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/No words yet/i)).toBeInTheDocument()
+    })
+  })
+
+  it('should show "Add your first word" button in empty state', async () => {
+    render(
+      <WordListScreen activePair={DEFAULT_PAIR} />,
+      { wrapper: makeWrapper(makeStorage([])) },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Add your first word/i })).toBeInTheDocument()
+    })
+  })
+
+  it('should show word list when words exist', async () => {
+    const word = makeWord({ source: 'house', target: 'māja' })
+    render(
+      <WordListScreen activePair={DEFAULT_PAIR} />,
+      { wrapper: makeWrapper(makeStorage([word])) },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('house')).toBeInTheDocument()
+      expect(screen.getByText('māja')).toBeInTheDocument()
+    })
+  })
+
+  it('should show pair name as heading when words exist', async () => {
+    const word = makeWord()
+    render(
+      <WordListScreen activePair={DEFAULT_PAIR} />,
+      { wrapper: makeWrapper(makeStorage([word])) },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('English → Latvian')).toBeInTheDocument()
+    })
+  })
+
+  it('should open add word dialog when "Add word" is clicked', async () => {
+    const user = userEvent.setup()
+    const word = makeWord()
+    render(
+      <WordListScreen activePair={DEFAULT_PAIR} />,
+      { wrapper: makeWrapper(makeStorage([word])) },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Add word/i })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /^Add word$/i }))
+
+    expect(screen.getByRole('heading', { name: /Add word/i })).toBeInTheDocument()
+  })
+
+  it('should add a word and show it in the list', async () => {
+    const user = userEvent.setup()
+    render(
+      <WordListScreen activePair={DEFAULT_PAIR} />,
+      { wrapper: makeWrapper(makeStorage([])) },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Add your first word/i })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /Add your first word/i }))
+
+    await user.type(screen.getByLabelText(/Source word/i), 'cat')
+    await user.type(screen.getByLabelText(/Target word/i), 'kaķis')
+    await user.click(screen.getByRole('button', { name: /Add word/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('cat')).toBeInTheDocument()
+      expect(screen.getByText('kaķis')).toBeInTheDocument()
+    })
+  })
+
+  it('should open edit dialog when edit button is clicked', async () => {
+    const user = userEvent.setup()
+    const word = makeWord({ source: 'house', target: 'māja' })
+    render(
+      <WordListScreen activePair={DEFAULT_PAIR} />,
+      { wrapper: makeWrapper(makeStorage([word])) },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('house')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByLabelText(/Edit house/i))
+
+    expect(screen.getByText('Edit word')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('house')).toBeInTheDocument()
+  })
+
+  it('should delete a word when confirmed', async () => {
+    const user = userEvent.setup()
+    const word = makeWord({ source: 'house', target: 'māja' })
+    render(
+      <WordListScreen activePair={DEFAULT_PAIR} />,
+      { wrapper: makeWrapper(makeStorage([word])) },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('house')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByLabelText(/Delete house/i))
+    await user.click(screen.getByRole('button', { name: /^Delete$/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('house')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/features/words/components/WordListScreen.tsx
+++ b/src/features/words/components/WordListScreen.tsx
@@ -1,0 +1,161 @@
+import { useState, useCallback } from 'react'
+import {
+  Box,
+  Typography,
+  Button,
+  CircularProgress,
+  Stack,
+} from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import type { Word, LanguagePair } from '@/types'
+import { useWords } from '../useWords'
+import type { CreateWordInput } from '../useWords'
+import { WordList } from './WordList'
+import { WordFormDialog } from './WordFormDialog'
+
+export interface WordListScreenProps {
+  readonly activePair: LanguagePair | null
+}
+
+/**
+ * Top-level screen for browsing and managing vocabulary for the active language pair.
+ * Handles empty states, loading, and delegates list + form to sub-components.
+ */
+export function WordListScreen({ activePair }: WordListScreenProps) {
+  const { words, progressMap, loading, addWord, updateWord, deleteWord, deleteWords } =
+    useWords(activePair?.id ?? null)
+
+  const [formOpen, setFormOpen] = useState(false)
+  const [wordToEdit, setWordToEdit] = useState<Word | null>(null)
+  const [quickAddMode, setQuickAddMode] = useState(false)
+
+  const handleOpenAdd = useCallback((quick = false) => {
+    setWordToEdit(null)
+    setQuickAddMode(quick)
+    setFormOpen(true)
+  }, [])
+
+  const handleOpenEdit = useCallback((word: Word) => {
+    setWordToEdit(word)
+    setQuickAddMode(false)
+    setFormOpen(true)
+  }, [])
+
+  const handleCloseForm = useCallback(() => {
+    setFormOpen(false)
+    setWordToEdit(null)
+  }, [])
+
+  const handleSubmit = useCallback(
+    async (input: CreateWordInput): Promise<boolean> => {
+      if (!activePair) return false
+
+      if (wordToEdit) {
+        await updateWord(wordToEdit.id, input)
+        return true
+      }
+
+      const result = await addWord(activePair.id, input)
+      return result !== null
+    },
+    [activePair, wordToEdit, addWord, updateWord],
+  )
+
+  // No active pair selected
+  if (!activePair) {
+    return (
+      <Box sx={{ py: 8, textAlign: 'center' }}>
+        <Typography variant="h6" gutterBottom>
+          No language pair selected
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Select a language pair from the toolbar to manage words.
+        </Typography>
+      </Box>
+    )
+  }
+
+  // Loading state
+  if (loading) {
+    return (
+      <Box sx={{ py: 8, display: 'flex', justifyContent: 'center' }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  // Empty state
+  if (words.length === 0) {
+    return (
+      <>
+        <Box sx={{ py: 8, textAlign: 'center' }}>
+          <Typography variant="h6" gutterBottom fontWeight={700}>
+            No words yet
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3, maxWidth: 340, mx: 'auto' }}>
+            Add your first word to start building your vocabulary for{' '}
+            <strong>
+              {activePair.sourceLang} → {activePair.targetLang}
+            </strong>
+            . You can also import a starter pack from the settings.
+          </Typography>
+          <Stack direction="row" spacing={1} justifyContent="center">
+            <Button variant="contained" startIcon={<AddIcon />} onClick={() => handleOpenAdd(false)}>
+              Add your first word
+            </Button>
+            <Button variant="outlined" onClick={() => handleOpenAdd(true)}>
+              Quick add
+            </Button>
+          </Stack>
+        </Box>
+
+        <WordFormDialog
+          open={formOpen}
+          word={wordToEdit}
+          quickAddMode={quickAddMode}
+          onClose={handleCloseForm}
+          onSubmit={handleSubmit}
+        />
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+        <Typography variant="h6" fontWeight={700}>
+          {activePair.sourceLang} → {activePair.targetLang}
+        </Typography>
+        <Stack direction="row" spacing={1}>
+          <Button variant="outlined" size="small" onClick={() => handleOpenAdd(true)}>
+            Quick add
+          </Button>
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<AddIcon />}
+            onClick={() => handleOpenAdd(false)}
+          >
+            Add word
+          </Button>
+        </Stack>
+      </Box>
+
+      <WordList
+        words={words}
+        progressMap={progressMap}
+        onEdit={handleOpenEdit}
+        onDelete={deleteWord}
+        onBulkDelete={deleteWords}
+      />
+
+      <WordFormDialog
+        open={formOpen}
+        word={wordToEdit}
+        quickAddMode={quickAddMode}
+        onClose={handleCloseForm}
+        onSubmit={handleSubmit}
+      />
+    </>
+  )
+}

--- a/src/features/words/components/index.ts
+++ b/src/features/words/components/index.ts
@@ -1,0 +1,14 @@
+export { WordFormDialog } from './WordFormDialog'
+export type { WordFormDialogProps } from './WordFormDialog'
+
+export { DeleteWordDialog } from './DeleteWordDialog'
+export type { DeleteWordDialogProps } from './DeleteWordDialog'
+
+export { WordListItem } from './WordListItem'
+export type { WordListItemProps } from './WordListItem'
+
+export { WordList } from './WordList'
+export type { WordListProps } from './WordList'
+
+export { WordListScreen } from './WordListScreen'
+export type { WordListScreenProps } from './WordListScreen'

--- a/src/features/words/constants.test.ts
+++ b/src/features/words/constants.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getConfidenceBucket,
+  CONFIDENCE_THRESHOLDS,
+  SORT_OPTIONS,
+  WORD_FILTERS,
+  CONFIDENCE_FILTERS,
+} from './constants'
+
+describe('getConfidenceBucket', () => {
+  it('should return "learning" when confidence is null', () => {
+    expect(getConfidenceBucket(null)).toBe('learning')
+  })
+
+  it('should return "learning" when confidence is below familiar threshold', () => {
+    expect(getConfidenceBucket(0)).toBe('learning')
+    expect(getConfidenceBucket(CONFIDENCE_THRESHOLDS.FAMILIAR - 0.01)).toBe('learning')
+  })
+
+  it('should return "familiar" when confidence is at or above familiar threshold', () => {
+    expect(getConfidenceBucket(CONFIDENCE_THRESHOLDS.FAMILIAR)).toBe('familiar')
+    expect(getConfidenceBucket(CONFIDENCE_THRESHOLDS.MASTERED - 0.01)).toBe('familiar')
+  })
+
+  it('should return "mastered" when confidence is at or above mastered threshold', () => {
+    expect(getConfidenceBucket(CONFIDENCE_THRESHOLDS.MASTERED)).toBe('mastered')
+    expect(getConfidenceBucket(1)).toBe('mastered')
+  })
+})
+
+describe('SORT_OPTIONS', () => {
+  it('should include all expected sort values', () => {
+    const values = SORT_OPTIONS.map((o) => o.value)
+    expect(values).toContain('source-asc')
+    expect(values).toContain('source-desc')
+    expect(values).toContain('target-asc')
+    expect(values).toContain('target-desc')
+    expect(values).toContain('date-asc')
+    expect(values).toContain('date-desc')
+    expect(values).toContain('confidence-asc')
+    expect(values).toContain('confidence-desc')
+  })
+})
+
+describe('WORD_FILTERS', () => {
+  it('should include all, user-added, and from-pack', () => {
+    const values = WORD_FILTERS.map((f) => f.value)
+    expect(values).toContain('all')
+    expect(values).toContain('user-added')
+    expect(values).toContain('from-pack')
+  })
+})
+
+describe('CONFIDENCE_FILTERS', () => {
+  it('should include all confidence levels', () => {
+    const values = CONFIDENCE_FILTERS.map((f) => f.value)
+    expect(values).toContain('all')
+    expect(values).toContain('learning')
+    expect(values).toContain('familiar')
+    expect(values).toContain('mastered')
+  })
+})

--- a/src/features/words/constants.ts
+++ b/src/features/words/constants.ts
@@ -1,0 +1,61 @@
+export type SortOption = 'source-asc' | 'source-desc' | 'target-asc' | 'target-desc' | 'date-asc' | 'date-desc' | 'confidence-asc' | 'confidence-desc'
+
+export type WordFilter = 'all' | 'user-added' | 'from-pack'
+
+export type ConfidenceFilter = 'all' | 'learning' | 'familiar' | 'mastered'
+
+export interface SortOptionConfig {
+  readonly value: SortOption
+  readonly label: string
+}
+
+export const SORT_OPTIONS: readonly SortOptionConfig[] = [
+  { value: 'source-asc', label: 'Source (A–Z)' },
+  { value: 'source-desc', label: 'Source (Z–A)' },
+  { value: 'target-asc', label: 'Target (A–Z)' },
+  { value: 'target-desc', label: 'Target (Z–A)' },
+  { value: 'date-desc', label: 'Newest first' },
+  { value: 'date-asc', label: 'Oldest first' },
+  { value: 'confidence-asc', label: 'Confidence (low–high)' },
+  { value: 'confidence-desc', label: 'Confidence (high–low)' },
+] as const
+
+export const WORD_FILTERS: readonly { value: WordFilter; label: string }[] = [
+  { value: 'all', label: 'All words' },
+  { value: 'user-added', label: 'My words' },
+  { value: 'from-pack', label: 'Starter pack' },
+] as const
+
+export const CONFIDENCE_FILTERS: readonly { value: ConfidenceFilter; label: string }[] = [
+  { value: 'all', label: 'All levels' },
+  { value: 'learning', label: 'Learning' },
+  { value: 'familiar', label: 'Familiar' },
+  { value: 'mastered', label: 'Mastered' },
+] as const
+
+/** Confidence thresholds for bucketing words. */
+export const CONFIDENCE_THRESHOLDS = {
+  FAMILIAR: 0.4,
+  MASTERED: 0.75,
+} as const
+
+export function getConfidenceBucket(confidence: number | null): ConfidenceFilter {
+  if (confidence === null) return 'learning'
+  if (confidence >= CONFIDENCE_THRESHOLDS.MASTERED) return 'mastered'
+  if (confidence >= CONFIDENCE_THRESHOLDS.FAMILIAR) return 'familiar'
+  return 'learning'
+}
+
+export const CONFIDENCE_LABELS: Record<ConfidenceFilter, string> = {
+  all: 'All',
+  learning: 'Learning',
+  familiar: 'Familiar',
+  mastered: 'Mastered',
+}
+
+export const CONFIDENCE_COLORS: Record<ConfidenceFilter, 'default' | 'warning' | 'info' | 'success'> = {
+  all: 'default',
+  learning: 'warning',
+  familiar: 'info',
+  mastered: 'success',
+}

--- a/src/features/words/index.ts
+++ b/src/features/words/index.ts
@@ -1,0 +1,28 @@
+export { useWords } from './useWords'
+export type { UseWordsResult, CreateWordInput } from './useWords'
+
+export {
+  SORT_OPTIONS,
+  WORD_FILTERS,
+  CONFIDENCE_FILTERS,
+  CONFIDENCE_THRESHOLDS,
+  CONFIDENCE_LABELS,
+  CONFIDENCE_COLORS,
+  getConfidenceBucket,
+} from './constants'
+export type { SortOption, WordFilter, ConfidenceFilter, SortOptionConfig } from './constants'
+
+export {
+  WordFormDialog,
+  DeleteWordDialog,
+  WordListItem,
+  WordList,
+  WordListScreen,
+} from './components'
+export type {
+  WordFormDialogProps,
+  DeleteWordDialogProps,
+  WordListItemProps,
+  WordListProps,
+  WordListScreenProps,
+} from './components'

--- a/src/features/words/useWords.test.ts
+++ b/src/features/words/useWords.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useWords } from './useWords'
+import type { StorageService } from '@/services/storage'
+import type { Word, WordProgress, UserSettings } from '@/types'
+import { StorageContext } from '@/hooks/useStorage'
+import { createElement } from 'react'
+import type { ReactNode } from 'react'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SETTINGS: UserSettings = {
+  activePairId: 'pair-1',
+  quizMode: 'mixed',
+  dailyGoal: 20,
+  theme: 'dark',
+  typoTolerance: 1,
+}
+
+function makeWord(overrides: Partial<Word> = {}): Word {
+  return {
+    id: 'word-1',
+    pairId: 'pair-1',
+    source: 'house',
+    target: 'māja',
+    notes: null,
+    tags: [],
+    createdAt: 1_000_000,
+    isFromPack: false,
+    ...overrides,
+  }
+}
+
+function makeProgress(overrides: Partial<WordProgress> = {}): WordProgress {
+  return {
+    wordId: 'word-1',
+    correctCount: 3,
+    incorrectCount: 1,
+    streak: 2,
+    lastReviewed: 1_000_000,
+    nextReview: 2_000_000,
+    confidence: 0.6,
+    history: [],
+    ...overrides,
+  }
+}
+
+function makeStorage(
+  words: Word[] = [],
+  progress: WordProgress[] = [],
+): StorageService {
+  const storedWords = [...words]
+  const storedProgress = [...progress]
+
+  return {
+    getLanguagePairs: vi.fn().mockResolvedValue([]),
+    getLanguagePair: vi.fn().mockResolvedValue(null),
+    saveLanguagePair: vi.fn().mockResolvedValue(undefined),
+    deleteLanguagePair: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue(DEFAULT_SETTINGS),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+
+    getWords: vi.fn().mockImplementation(async () => [...storedWords]),
+    getWord: vi.fn().mockImplementation(async (id: string) =>
+      storedWords.find((w) => w.id === id) ?? null,
+    ),
+    saveWord: vi.fn().mockImplementation(async (word: Word) => {
+      const idx = storedWords.findIndex((w) => w.id === word.id)
+      if (idx >= 0) storedWords[idx] = word
+      else storedWords.push(word)
+    }),
+    saveWords: vi.fn().mockResolvedValue(undefined),
+    deleteWord: vi.fn().mockImplementation(async (id: string) => {
+      const idx = storedWords.findIndex((w) => w.id === id)
+      if (idx >= 0) storedWords.splice(idx, 1)
+    }),
+
+    getWordProgress: vi.fn().mockResolvedValue(null),
+    getAllProgress: vi.fn().mockImplementation(async () => [...storedProgress]),
+    saveWordProgress: vi.fn().mockResolvedValue(undefined),
+
+    getDailyStats: vi.fn().mockResolvedValue(null),
+    getDailyStatsRange: vi.fn().mockResolvedValue([]),
+    saveDailyStats: vi.fn().mockResolvedValue(undefined),
+    getRecentDailyStats: vi.fn().mockResolvedValue([]),
+    exportAll: vi.fn().mockResolvedValue('{}'),
+    importAll: vi.fn().mockResolvedValue(undefined),
+    clearAll: vi.fn().mockResolvedValue(undefined),
+  } as StorageService
+}
+
+function makeWrapper(storage: StorageService) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(StorageContext.Provider, { value: storage }, children)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useWords', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('initial load', () => {
+    it('should start in loading state when pairId is provided', () => {
+      const storage = makeStorage()
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+      expect(result.current.loading).toBe(true)
+    })
+
+    it('should immediately be not loading when pairId is null', async () => {
+      const storage = makeStorage()
+      const { result } = renderHook(() => useWords(null), {
+        wrapper: makeWrapper(storage),
+      })
+      await act(async () => {})
+      expect(result.current.loading).toBe(false)
+      expect(result.current.words).toHaveLength(0)
+    })
+
+    it('should load words for the given pairId', async () => {
+      const word = makeWord()
+      const storage = makeStorage([word])
+
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      expect(result.current.loading).toBe(false)
+      expect(result.current.words).toHaveLength(1)
+      expect(result.current.words[0].id).toBe('word-1')
+    })
+
+    it('should load progress into progressMap', async () => {
+      const word = makeWord()
+      const progress = makeProgress()
+      const storage = makeStorage([word], [progress])
+
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      expect(result.current.progressMap.get('word-1')).toEqual(progress)
+    })
+
+    it('should clear words when pairId becomes null', async () => {
+      const word = makeWord()
+      const storage = makeStorage([word])
+
+      const { result, rerender } = renderHook(
+        ({ pairId }: { pairId: string | null }) => useWords(pairId),
+        {
+          wrapper: makeWrapper(storage),
+          initialProps: { pairId: 'pair-1' as string | null },
+        },
+      )
+
+      await act(async () => {})
+      expect(result.current.words).toHaveLength(1)
+
+      rerender({ pairId: null })
+      await act(async () => {})
+      expect(result.current.words).toHaveLength(0)
+    })
+  })
+
+  describe('addWord', () => {
+    it('should add a new word and return it', async () => {
+      const storage = makeStorage()
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      let added: Word | null = null
+      await act(async () => {
+        added = await result.current.addWord('pair-1', {
+          source: 'cat',
+          target: 'kaķis',
+          notes: null,
+          tags: [],
+        })
+      })
+
+      expect(added).not.toBeNull()
+      expect(added!.source).toBe('cat')
+      expect(added!.target).toBe('kaķis')
+      expect(result.current.words).toHaveLength(1)
+    })
+
+    it('should save the word to storage', async () => {
+      const storage = makeStorage()
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      await act(async () => {
+        await result.current.addWord('pair-1', {
+          source: 'dog',
+          target: 'suns',
+          notes: null,
+          tags: [],
+        })
+      })
+
+      expect(storage.saveWord).toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'dog', target: 'suns' }),
+      )
+    })
+
+    it('should prevent exact duplicates (case-insensitive) and return null', async () => {
+      const word = makeWord({ source: 'Cat', target: 'Kaķis' })
+      const storage = makeStorage([word])
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      let added: Word | null = null
+      await act(async () => {
+        added = await result.current.addWord('pair-1', {
+          source: 'cat',
+          target: 'kaķis',
+          notes: null,
+          tags: [],
+        })
+      })
+
+      expect(added).toBeNull()
+      expect(result.current.words).toHaveLength(1)
+    })
+
+    it('should allow words with same source but different target', async () => {
+      const word = makeWord({ source: 'cat', target: 'kaķis' })
+      const storage = makeStorage([word])
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      let added: Word | null = null
+      await act(async () => {
+        added = await result.current.addWord('pair-1', {
+          source: 'cat',
+          target: 'kaķēns',
+          notes: null,
+          tags: [],
+        })
+      })
+
+      expect(added).not.toBeNull()
+      expect(result.current.words).toHaveLength(2)
+    })
+
+    it('should trim whitespace from source and target', async () => {
+      const storage = makeStorage()
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      await act(async () => {
+        await result.current.addWord('pair-1', {
+          source: '  cat  ',
+          target: '  kaķis  ',
+          notes: null,
+          tags: [],
+        })
+      })
+
+      expect(result.current.words[0].source).toBe('cat')
+      expect(result.current.words[0].target).toBe('kaķis')
+    })
+
+    it('should set isFromPack to false for user-added words', async () => {
+      const storage = makeStorage()
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      await act(async () => {
+        await result.current.addWord('pair-1', {
+          source: 'cat',
+          target: 'kaķis',
+          notes: null,
+          tags: [],
+        })
+      })
+
+      expect(result.current.words[0].isFromPack).toBe(false)
+    })
+  })
+
+  describe('updateWord', () => {
+    it('should update an existing word in state', async () => {
+      const word = makeWord({ source: 'house', target: 'māja' })
+      const storage = makeStorage([word])
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      await act(async () => {
+        await result.current.updateWord('word-1', {
+          source: 'home',
+          target: 'mājvieta',
+          notes: 'updated',
+          tags: ['B1'],
+        })
+      })
+
+      const updated = result.current.words.find((w) => w.id === 'word-1')
+      expect(updated?.source).toBe('home')
+      expect(updated?.target).toBe('mājvieta')
+      expect(updated?.notes).toBe('updated')
+      expect(updated?.tags).toEqual(['B1'])
+    })
+
+    it('should persist the updated word to storage', async () => {
+      const word = makeWord()
+      const storage = makeStorage([word])
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      await act(async () => {
+        await result.current.updateWord('word-1', {
+          source: 'home',
+          target: 'mājvieta',
+          notes: null,
+          tags: [],
+        })
+      })
+
+      expect(storage.saveWord).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'word-1', source: 'home' }),
+      )
+    })
+
+    it('should do nothing when wordId does not exist', async () => {
+      const storage = makeStorage()
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      await act(async () => {
+        await result.current.updateWord('non-existent', {
+          source: 'foo',
+          target: 'bar',
+          notes: null,
+          tags: [],
+        })
+      })
+
+      expect(storage.saveWord).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deleteWord', () => {
+    it('should remove the word from state', async () => {
+      const word = makeWord()
+      const storage = makeStorage([word])
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+      expect(result.current.words).toHaveLength(1)
+
+      await act(async () => {
+        await result.current.deleteWord('word-1')
+      })
+
+      expect(result.current.words).toHaveLength(0)
+    })
+
+    it('should call storage.deleteWord', async () => {
+      const word = makeWord()
+      const storage = makeStorage([word])
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      await act(async () => {
+        await result.current.deleteWord('word-1')
+      })
+
+      expect(storage.deleteWord).toHaveBeenCalledWith('word-1')
+    })
+
+    it('should remove progress entry from progressMap', async () => {
+      const word = makeWord()
+      const progress = makeProgress()
+      const storage = makeStorage([word], [progress])
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+      expect(result.current.progressMap.has('word-1')).toBe(true)
+
+      await act(async () => {
+        await result.current.deleteWord('word-1')
+      })
+
+      expect(result.current.progressMap.has('word-1')).toBe(false)
+    })
+  })
+
+  describe('deleteWords', () => {
+    it('should remove multiple words from state', async () => {
+      const words = [
+        makeWord({ id: 'w1', source: 'cat' }),
+        makeWord({ id: 'w2', source: 'dog' }),
+        makeWord({ id: 'w3', source: 'bird' }),
+      ]
+      const storage = makeStorage(words)
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+      expect(result.current.words).toHaveLength(3)
+
+      await act(async () => {
+        await result.current.deleteWords(['w1', 'w2'])
+      })
+
+      expect(result.current.words).toHaveLength(1)
+      expect(result.current.words[0].id).toBe('w3')
+    })
+
+    it('should call storage.deleteWord for each id', async () => {
+      const words = [
+        makeWord({ id: 'w1' }),
+        makeWord({ id: 'w2' }),
+      ]
+      const storage = makeStorage(words)
+      const { result } = renderHook(() => useWords('pair-1'), {
+        wrapper: makeWrapper(storage),
+      })
+
+      await act(async () => {})
+
+      await act(async () => {
+        await result.current.deleteWords(['w1', 'w2'])
+      })
+
+      expect(storage.deleteWord).toHaveBeenCalledWith('w1')
+      expect(storage.deleteWord).toHaveBeenCalledWith('w2')
+    })
+  })
+})

--- a/src/features/words/useWords.ts
+++ b/src/features/words/useWords.ts
@@ -1,0 +1,157 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { Word, WordProgress } from '@/types'
+import { useStorage } from '@/hooks/useStorage'
+import { generateId } from '@/utils/id'
+
+export interface CreateWordInput {
+  readonly source: string
+  readonly target: string
+  readonly notes: string | null
+  readonly tags: readonly string[]
+}
+
+export interface UseWordsResult {
+  /** All words for the active pair. */
+  readonly words: readonly Word[]
+  /** Progress keyed by word id. */
+  readonly progressMap: ReadonlyMap<string, WordProgress>
+  /** True while the initial load is in progress. */
+  readonly loading: boolean
+  /** Create a new word for the given pair. Returns null if duplicate. */
+  readonly addWord: (pairId: string, input: CreateWordInput) => Promise<Word | null>
+  /** Update an existing word. */
+  readonly updateWord: (wordId: string, input: CreateWordInput) => Promise<void>
+  /** Delete a single word by id. */
+  readonly deleteWord: (wordId: string) => Promise<void>
+  /** Delete multiple words by id. */
+  readonly deleteWords: (wordIds: readonly string[]) => Promise<void>
+}
+
+/**
+ * Custom hook that manages words for the active language pair.
+ * All mutations go through StorageService - no direct localStorage access.
+ */
+export function useWords(activePairId: string | null): UseWordsResult {
+  const storage = useStorage()
+  const [words, setWords] = useState<Word[]>([])
+  const [progressMap, setProgressMap] = useState<Map<string, WordProgress>>(new Map())
+  const [loading, setLoading] = useState(true)
+
+  // Reload whenever the active pair changes.
+  useEffect(() => {
+    if (activePairId === null) {
+      setWords([])
+      setProgressMap(new Map())
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+
+    const load = async () => {
+      const [loadedWords, allProgress] = await Promise.all([
+        storage.getWords(activePairId),
+        storage.getAllProgress(activePairId),
+      ])
+
+      if (!cancelled) {
+        setWords(loadedWords)
+        const map = new Map<string, WordProgress>()
+        for (const p of allProgress) {
+          map.set(p.wordId, p)
+        }
+        setProgressMap(map)
+        setLoading(false)
+      }
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [storage, activePairId])
+
+  const addWord = useCallback(
+    async (pairId: string, input: CreateWordInput): Promise<Word | null> => {
+      // Prevent exact duplicates (case-insensitive source + target match).
+      const normSource = input.source.trim().toLowerCase()
+      const normTarget = input.target.trim().toLowerCase()
+      const duplicate = words.find(
+        (w) =>
+          w.source.toLowerCase() === normSource &&
+          w.target.toLowerCase() === normTarget,
+      )
+      if (duplicate) return null
+
+      const newWord: Word = {
+        id: generateId(),
+        pairId,
+        source: input.source.trim(),
+        target: input.target.trim(),
+        notes: input.notes?.trim() || null,
+        tags: input.tags.map((t) => t.trim()).filter(Boolean),
+        createdAt: Date.now(),
+        isFromPack: false,
+      }
+
+      await storage.saveWord(newWord)
+      setWords((prev) => [...prev, newWord])
+      return newWord
+    },
+    [storage, words],
+  )
+
+  const updateWord = useCallback(
+    async (wordId: string, input: CreateWordInput): Promise<void> => {
+      const existing = words.find((w) => w.id === wordId)
+      if (!existing) return
+
+      const updated: Word = {
+        ...existing,
+        source: input.source.trim(),
+        target: input.target.trim(),
+        notes: input.notes?.trim() || null,
+        tags: input.tags.map((t) => t.trim()).filter(Boolean),
+      }
+
+      await storage.saveWord(updated)
+      setWords((prev) => prev.map((w) => (w.id === wordId ? updated : w)))
+    },
+    [storage, words],
+  )
+
+  const deleteWord = useCallback(
+    async (wordId: string): Promise<void> => {
+      await storage.deleteWord(wordId)
+      setWords((prev) => prev.filter((w) => w.id !== wordId))
+      setProgressMap((prev) => {
+        const next = new Map(prev)
+        next.delete(wordId)
+        return next
+      })
+    },
+    [storage],
+  )
+
+  const deleteWords = useCallback(
+    async (wordIds: readonly string[]): Promise<void> => {
+      for (const id of wordIds) {
+        await storage.deleteWord(id)
+      }
+      const idSet = new Set(wordIds)
+      setWords((prev) => prev.filter((w) => !idSet.has(w.id)))
+      setProgressMap((prev) => {
+        const next = new Map(prev)
+        for (const id of wordIds) {
+          next.delete(id)
+        }
+        return next
+      })
+    },
+    [storage],
+  )
+
+  return { words, progressMap, loading, addWord, updateWord, deleteWord, deleteWords }
+}


### PR DESCRIPTION
## Summary

- Implements `src/features/words/` module with full vocabulary CRUD
- `useWords` hook handles add/edit/delete/bulk-delete via StorageService with duplicate prevention
- `WordListScreen` is the top-level screen with empty state, loading, and no-pair-selected states
- `WordList` provides live search, 8 sort options, word filter (all/user-added/pack), confidence filter (all/learning/familiar/mastered), tag filter chips, and bulk selection mode
- `WordListItem` shows source → target, confidence chip (only when progress exists), starter-pack badge, edit/delete actions
- `WordFormDialog` supports add and edit modes, quick-add mode (form resets after save), tag management
- `DeleteWordDialog` for single and bulk delete confirmation
- `App.tsx` updated with tab navigation (Words / Language pairs)

## Changes

- `src/features/words/constants.ts` - sort/filter options, confidence thresholds and bucket helpers
- `src/features/words/useWords.ts` - custom hook, all storage through StorageService
- `src/features/words/components/WordFormDialog.tsx` - add/edit dialog
- `src/features/words/components/DeleteWordDialog.tsx` - delete confirmation
- `src/features/words/components/WordListItem.tsx` - single word row
- `src/features/words/components/WordList.tsx` - full list with controls
- `src/features/words/components/WordListScreen.tsx` - top-level feature screen
- `src/features/words/components/index.ts` + `src/features/words/index.ts` - barrel exports
- `src/App.tsx` - tab navigation integrating WordListScreen

## Testing

- 63 new tests across 5 new test files
- All 219 tests pass (`npm test -- --run`)
- No TypeScript errors (`npx tsc --noEmit`)
- Production build succeeds (`npm run build`)

## Review

- Code review passed (see issue comments)
- TypeScript strict compliance verified
- No direct localStorage calls — all through StorageService
- MUI theme used throughout, no hardcoded colours/spacing

Closes #6