### PR TITLE
feat: quiz type mode with answer matching and typo tolerance (#10)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import {
 import { createAppTheme } from './theme'
 import { useThemeMode } from './hooks/useThemeMode'
 import { LocalStorageService } from './services/storage'
-import { StorageContext } from './hooks/useStorage'
+import { StorageContext, useStorage } from './hooks/useStorage'
 import {
   useLanguagePairs,
   LanguagePairSelector,
@@ -23,6 +23,8 @@ import {
 } from './features/language-pairs'
 import type { CreatePairInput } from './features/language-pairs'
 import { WordListScreen } from './features/words'
+import { QuizScreen } from './features/quiz'
+import type { UserSettings } from './types'
 
 /**
  * A single shared storage instance for the application.
@@ -43,8 +45,22 @@ function AppContent() {
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   // Whether this is the first launch (no pairs yet, after loading completes).
   const [isFirstLaunch, setIsFirstLaunch] = useState(false)
-  // Active tab: 'pairs' = language pair management, 'words' = word list
-  const [activeTab, setActiveTab] = useState<'pairs' | 'words'>('words')
+  // Active tab
+  const [activeTab, setActiveTab] = useState<'quiz' | 'words' | 'pairs'>('quiz')
+
+  const storage = useStorage()
+  const [settings, setSettings] = useState<UserSettings>({
+    activePairId: null,
+    quizMode: 'type',
+    dailyGoal: 20,
+    theme: 'system',
+    typoTolerance: 1,
+  })
+
+  // Load settings on mount.
+  useEffect(() => {
+    void storage.getSettings().then((s) => setSettings(s))
+  }, [storage])
 
   useEffect(() => {
     if (!loading && pairs.length === 0) {
@@ -100,9 +116,10 @@ function AppContent() {
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <Tabs
             value={activeTab}
-            onChange={(_e, v: 'pairs' | 'words') => setActiveTab(v)}
+            onChange={(_e, v: 'quiz' | 'words' | 'pairs') => setActiveTab(v)}
             centered
           >
+            <Tab label="Quiz" value="quiz" />
             <Tab label="Words" value="words" />
             <Tab label="Language pairs" value="pairs" />
           </Tabs>
@@ -130,6 +147,10 @@ function AppContent() {
               </Box>
             ) : (
               <>
+                {activeTab === 'quiz' && (
+                  <QuizScreen pair={activePair} settings={settings} />
+                )}
+
                 {activeTab === 'words' && (
                   <WordListScreen activePair={activePair} />
                 )}

--- a/src/features/quiz/components/QuizFeedback.tsx
+++ b/src/features/quiz/components/QuizFeedback.tsx
@@ -1,0 +1,108 @@
+/**
+ * QuizFeedback - shows the result of a submitted answer.
+ *
+ * States:
+ *  - correct  → green, encouraging message
+ *  - almost   → amber, show exact spelling
+ *  - incorrect → red, show correct answer
+ */
+
+import { Box, Typography, Fade } from '@mui/material'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
+import type { MatchResult } from '@/utils/matching'
+
+interface QuizFeedbackProps {
+  readonly result: MatchResult
+  readonly correctAnswer: string
+  readonly userAnswer: string
+}
+
+export function QuizFeedback({ result, correctAnswer, userAnswer }: QuizFeedbackProps) {
+  if (result === 'correct') {
+    return (
+      <Fade in timeout={300}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 1,
+            py: 2,
+          }}
+          role="status"
+          aria-live="polite"
+        >
+          <CheckCircleOutlineIcon sx={{ fontSize: 48, color: 'success.main' }} />
+          <Typography variant="h6" color="success.main" fontWeight={700}>
+            Correct!
+          </Typography>
+        </Box>
+      </Fade>
+    )
+  }
+
+  if (result === 'almost') {
+    return (
+      <Fade in timeout={300}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 1,
+            py: 2,
+          }}
+          role="status"
+          aria-live="polite"
+        >
+          <ErrorOutlineIcon sx={{ fontSize: 48, color: 'warning.main' }} />
+          <Typography variant="h6" color="warning.main" fontWeight={700}>
+            Almost!
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            You typed: <strong>{userAnswer}</strong>
+          </Typography>
+          <Typography variant="body1" color="text.primary" sx={{ mt: 0.5 }}>
+            Exact spelling:{' '}
+            <Box component="span" sx={{ color: 'warning.main', fontWeight: 700 }}>
+              {correctAnswer}
+            </Box>
+          </Typography>
+        </Box>
+      </Fade>
+    )
+  }
+
+  // incorrect
+  return (
+    <Fade in timeout={300}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 1,
+          py: 2,
+        }}
+        role="status"
+        aria-live="polite"
+      >
+        <CancelOutlinedIcon sx={{ fontSize: 48, color: 'error.main' }} />
+        <Typography variant="h6" color="error.main" fontWeight={700}>
+          Incorrect
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          You typed: <strong>{userAnswer}</strong>
+        </Typography>
+        <Typography variant="body1" color="text.primary" sx={{ mt: 0.5 }}>
+          Correct answer:{' '}
+          <Box component="span" sx={{ color: 'success.main', fontWeight: 700 }}>
+            {correctAnswer}
+          </Box>
+        </Typography>
+      </Box>
+    </Fade>
+  )
+}

--- a/src/features/quiz/components/QuizScreen.test.tsx
+++ b/src/features/quiz/components/QuizScreen.test.tsx
@@ -1,0 +1,329 @@
+/**
+ * Tests for QuizScreen component.
+ *
+ * We mock useQuizSession to control session state without hitting storage.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from '@mui/material'
+import { createAppTheme } from '@/theme'
+import type { LanguagePair, UserSettings } from '@/types'
+import { QuizScreen } from './QuizScreen'
+import type { UseQuizSessionResult, QuizSessionState } from '../useQuizSession'
+
+// ─── Mock useQuizSession ───────────────────────────────────────────────────────
+
+vi.mock('../useQuizSession', () => ({
+  useQuizSession: vi.fn(),
+}))
+
+import { useQuizSession } from '../useQuizSession'
+const mockUseQuizSession = vi.mocked(useQuizSession)
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const mockPair: LanguagePair = {
+  id: 'pair-1',
+  sourceLang: 'Latvian',
+  targetLang: 'English',
+  sourceCode: 'lv',
+  targetCode: 'en',
+  createdAt: 1000,
+}
+
+const mockSettings: UserSettings = {
+  activePairId: 'pair-1',
+  quizMode: 'type',
+  dailyGoal: 20,
+  theme: 'dark',
+  typoTolerance: 1,
+}
+
+const mockWord = {
+  id: 'w1',
+  pairId: 'pair-1',
+  source: 'māja',
+  target: 'house',
+  notes: null,
+  tags: [],
+  createdAt: 1000,
+  isFromPack: false,
+}
+
+function makeQuestionState(): QuizSessionState {
+  return {
+    phase: 'question',
+    currentWord: mockWord,
+    direction: 'source-to-target',
+    pair: mockPair,
+    lastResult: null,
+    wordsCompleted: 2,
+    sessionGoal: 20,
+    correctCount: 1,
+    error: null,
+  }
+}
+
+function makeMockSession(state: QuizSessionState): UseQuizSessionResult {
+  return {
+    state,
+    submitAnswer: vi.fn().mockResolvedValue(undefined),
+    advance: vi.fn(),
+    endSession: vi.fn(),
+    restart: vi.fn(),
+  }
+}
+
+function renderQuiz(pair: LanguagePair | null = mockPair) {
+  const theme = createAppTheme('dark')
+  return render(
+    <ThemeProvider theme={theme}>
+      <QuizScreen pair={pair} settings={mockSettings} />
+    </ThemeProvider>,
+  )
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('QuizScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should show a message when no pair is selected', () => {
+    // useQuizSession still called even with null pair
+    mockUseQuizSession.mockReturnValue(makeMockSession({
+      phase: 'finished',
+      currentWord: null,
+      direction: null,
+      pair: null,
+      lastResult: null,
+      wordsCompleted: 0,
+      sessionGoal: 20,
+      correctCount: 0,
+      error: null,
+    }))
+
+    renderQuiz(null)
+    expect(screen.getByText(/select a language pair/i)).toBeInTheDocument()
+  })
+
+  it('should show loading message when phase is loading', () => {
+    mockUseQuizSession.mockReturnValue(makeMockSession({
+      ...makeQuestionState(),
+      phase: 'loading',
+      currentWord: null,
+      direction: null,
+    }))
+
+    renderQuiz()
+    expect(screen.getByText(/loading words/i)).toBeInTheDocument()
+  })
+
+  it('should render the word and direction indicator in question phase', () => {
+    mockUseQuizSession.mockReturnValue(makeMockSession(makeQuestionState()))
+
+    renderQuiz()
+
+    // Word displayed
+    expect(screen.getByText('māja')).toBeInTheDocument()
+
+    // Direction chip
+    expect(screen.getByText('Latvian → English')).toBeInTheDocument()
+  })
+
+  it('should render the text input and submit button in question phase', () => {
+    mockUseQuizSession.mockReturnValue(makeMockSession(makeQuestionState()))
+
+    renderQuiz()
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument()
+  })
+
+  it('should have correct input attributes for mobile keyboard handling', () => {
+    mockUseQuizSession.mockReturnValue(makeMockSession(makeQuestionState()))
+
+    renderQuiz()
+
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveAttribute('autocomplete', 'off')
+    expect(input).toHaveAttribute('autocorrect', 'off')
+    expect(input).toHaveAttribute('autocapitalize', 'none')
+    expect(input).toHaveAttribute('spellcheck', 'false')
+  })
+
+  it('should submit the answer when clicking the submit button', async () => {
+    const session = makeMockSession(makeQuestionState())
+    mockUseQuizSession.mockReturnValue(session)
+
+    renderQuiz()
+
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'house')
+
+    const submitBtn = screen.getByRole('button', { name: /submit/i })
+    await userEvent.click(submitBtn)
+
+    expect(session.submitAnswer).toHaveBeenCalledWith('house')
+  })
+
+  it('should submit on Enter key press', async () => {
+    const session = makeMockSession(makeQuestionState())
+    mockUseQuizSession.mockReturnValue(session)
+
+    renderQuiz()
+
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, 'house')
+    await userEvent.keyboard('{Enter}')
+
+    expect(session.submitAnswer).toHaveBeenCalledWith('house')
+  })
+
+  it('should not submit if input is empty', async () => {
+    const session = makeMockSession(makeQuestionState())
+    mockUseQuizSession.mockReturnValue(session)
+
+    renderQuiz()
+
+    const submitBtn = screen.getByRole('button', { name: /submit/i })
+    expect(submitBtn).toBeDisabled()
+  })
+
+  it('should show correct feedback when result is correct', () => {
+    mockUseQuizSession.mockReturnValue(makeMockSession({
+      ...makeQuestionState(),
+      phase: 'feedback',
+      lastResult: { result: 'correct', correctAnswer: 'house', distance: 0 },
+    }))
+
+    renderQuiz()
+    expect(screen.getByText(/correct!/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /next word/i })).toBeInTheDocument()
+  })
+
+  it('should show incorrect feedback with the correct answer', () => {
+    mockUseQuizSession.mockReturnValue(makeMockSession({
+      ...makeQuestionState(),
+      phase: 'feedback',
+      lastResult: { result: 'incorrect', correctAnswer: 'house', distance: 5 },
+    }))
+
+    renderQuiz()
+    expect(screen.getByText(/incorrect/i)).toBeInTheDocument()
+    expect(screen.getByText('house')).toBeInTheDocument()
+  })
+
+  it('should show almost feedback with exact spelling', () => {
+    mockUseQuizSession.mockReturnValue(makeMockSession({
+      ...makeQuestionState(),
+      phase: 'feedback',
+      lastResult: { result: 'almost', correctAnswer: 'house', distance: 1 },
+    }))
+
+    renderQuiz()
+    expect(screen.getByText(/almost!/i)).toBeInTheDocument()
+    expect(screen.getByText('house')).toBeInTheDocument()
+  })
+
+  it('should call advance when Next word button is clicked', async () => {
+    const session = makeMockSession({
+      ...makeQuestionState(),
+      phase: 'feedback',
+      lastResult: { result: 'correct', correctAnswer: 'house', distance: 0 },
+    })
+    mockUseQuizSession.mockReturnValue(session)
+
+    renderQuiz()
+
+    const nextBtn = screen.getByRole('button', { name: /next word/i })
+    await userEvent.click(nextBtn)
+
+    expect(session.advance).toHaveBeenCalled()
+  })
+
+  it('should show session progress bar', () => {
+    mockUseQuizSession.mockReturnValue(makeMockSession(makeQuestionState()))
+
+    renderQuiz()
+    // Progress shows "2 / 20"
+    expect(screen.getByText('2 / 20')).toBeInTheDocument()
+  })
+
+  it('should show session complete screen when finished', () => {
+    mockUseQuizSession.mockReturnValue(makeMockSession({
+      ...makeQuestionState(),
+      phase: 'finished',
+      currentWord: null,
+      direction: null,
+      wordsCompleted: 5,
+      correctCount: 4,
+    }))
+
+    renderQuiz()
+    expect(screen.getByText(/session complete/i)).toBeInTheDocument()
+    expect(screen.getByText(/you reviewed/i)).toBeInTheDocument()
+  })
+
+  it('should call endSession when end session button is clicked', async () => {
+    const session = makeMockSession(makeQuestionState())
+    mockUseQuizSession.mockReturnValue(session)
+
+    renderQuiz()
+
+    const endBtn = screen.getByRole('button', { name: /end session/i })
+    await userEvent.click(endBtn)
+
+    expect(session.endSession).toHaveBeenCalled()
+  })
+
+  it('should show the word from target when direction is target-to-source', () => {
+    mockUseQuizSession.mockReturnValue(makeMockSession({
+      ...makeQuestionState(),
+      direction: 'target-to-source',
+    }))
+
+    renderQuiz()
+
+    // In target-to-source, the question shows the target word ("house")
+    // and the direction is "English → Latvian"
+    expect(screen.getByText('house')).toBeInTheDocument()
+    expect(screen.getByText('English → Latvian')).toBeInTheDocument()
+  })
+
+  it('should show error state with a retry button', () => {
+    const session = makeMockSession({
+      ...makeQuestionState(),
+      phase: 'finished',
+      currentWord: null,
+      direction: null,
+      error: 'Failed to load words',
+    })
+    mockUseQuizSession.mockReturnValue(session)
+
+    renderQuiz()
+
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument()
+    expect(screen.getByText(/failed to load words/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument()
+  })
+
+  it('should call restart when try again button is clicked after error', async () => {
+    const session = makeMockSession({
+      ...makeQuestionState(),
+      phase: 'finished',
+      currentWord: null,
+      direction: null,
+      error: 'Failed to load words',
+    })
+    mockUseQuizSession.mockReturnValue(session)
+
+    renderQuiz()
+
+    await userEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(session.restart).toHaveBeenCalled()
+  })
+})

--- a/src/features/quiz/components/QuizScreen.tsx
+++ b/src/features/quiz/components/QuizScreen.tsx
@@ -1,0 +1,260 @@
+/**
+ * QuizScreen - the main quiz type-mode interface.
+ *
+ * Displays the word to translate, an input field, feedback, and session progress.
+ * Handles keyboard submission (Enter key), auto-focus, and mobile input settings.
+ */
+
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  KeyboardEvent,
+} from 'react'
+import {
+  Box,
+  Button,
+  Paper,
+  TextField,
+  Typography,
+  Chip,
+} from '@mui/material'
+import type { LanguagePair, UserSettings } from '@/types'
+import { useQuizSession } from '../useQuizSession'
+import { SessionProgress } from './SessionProgress'
+import { QuizFeedback } from './QuizFeedback'
+
+interface QuizScreenProps {
+  readonly pair: LanguagePair | null
+  readonly settings: UserSettings
+  /** Called when the user manually ends the session or session completes. */
+  readonly onSessionEnd?: () => void
+}
+
+export function QuizScreen({ pair, settings, onSessionEnd }: QuizScreenProps) {
+  const { state, submitAnswer, advance, endSession, restart } = useQuizSession(pair, settings)
+  const [inputValue, setInputValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const { phase, currentWord, direction, lastResult, wordsCompleted, sessionGoal, correctCount, error } = state
+
+  // Auto-focus the input whenever a new question is shown.
+  useEffect(() => {
+    if (phase === 'question' && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [phase, currentWord])
+
+  // Clear the input when a new question loads.
+  useEffect(() => {
+    if (phase === 'question') {
+      setInputValue('')
+    }
+  }, [phase, currentWord])
+
+  const handleSubmit = useCallback(async (): Promise<void> => {
+    if (inputValue.trim() === '') return
+    await submitAnswer(inputValue)
+  }, [inputValue, submitAnswer])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>): void => {
+      if (e.key === 'Enter') {
+        void handleSubmit()
+      }
+    },
+    [handleSubmit],
+  )
+
+  const handleAdvance = useCallback((): void => {
+    advance()
+  }, [advance])
+
+  const handleEndSession = useCallback((): void => {
+    endSession()
+    onSessionEnd?.()
+  }, [endSession, onSessionEnd])
+
+  // ─── No pair selected ──────────────────────────────────────────────────────
+
+  if (pair === null) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="h6" color="text.secondary">
+          Select a language pair to start quizzing.
+        </Typography>
+      </Box>
+    )
+  }
+
+  // ─── Loading ────────────────────────────────────────────────────────────────
+
+  if (phase === 'loading') {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="body1" color="text.secondary">
+          Loading words...
+        </Typography>
+      </Box>
+    )
+  }
+
+  // ─── Error ──────────────────────────────────────────────────────────────────
+
+  if (phase === 'finished' && error !== null) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="h6" color="error.main" gutterBottom>
+          Something went wrong
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          {error}
+        </Typography>
+        <Button variant="contained" onClick={restart}>
+          Try again
+        </Button>
+      </Box>
+    )
+  }
+
+  // ─── Session finished ──────────────────────────────────────────────────────
+
+  if (phase === 'finished') {
+    const accuracy = wordsCompleted > 0
+      ? Math.round((correctCount / wordsCompleted) * 100)
+      : 0
+
+    return (
+      <Box sx={{ textAlign: 'center', py: 6 }}>
+        <Typography variant="h5" fontWeight={700} gutterBottom>
+          Session complete!
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 1 }}>
+          You reviewed <strong>{wordsCompleted}</strong> word{wordsCompleted !== 1 ? 's' : ''}.
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+          Accuracy: <strong>{accuracy}%</strong> ({correctCount} / {wordsCompleted} correct)
+        </Typography>
+        <Button variant="contained" size="large" onClick={restart}>
+          Start new session
+        </Button>
+      </Box>
+    )
+  }
+
+  // ─── Direction indicator ────────────────────────────────────────────────────
+
+  const fromLang = direction === 'source-to-target' ? pair.sourceLang : pair.targetLang
+  const toLang = direction === 'source-to-target' ? pair.targetLang : pair.sourceLang
+  const questionText = direction === 'source-to-target'
+    ? currentWord?.source ?? ''
+    : currentWord?.target ?? ''
+
+  // ─── Quiz question / feedback ───────────────────────────────────────────────
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      {/* Progress bar */}
+      <SessionProgress
+        completed={wordsCompleted}
+        total={sessionGoal}
+        correct={correctCount}
+      />
+
+      {/* Direction chip */}
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Chip
+          label={`${fromLang} → ${toLang}`}
+          size="small"
+          variant="outlined"
+          sx={{ fontWeight: 600 }}
+          aria-label={`Translating from ${fromLang} to ${toLang}`}
+        />
+      </Box>
+
+      {/* Word card */}
+      <Paper
+        elevation={2}
+        sx={{
+          p: 4,
+          textAlign: 'center',
+          borderRadius: 3,
+        }}
+      >
+        <Typography
+          variant="h4"
+          component="p"
+          fontWeight={700}
+          sx={{ wordBreak: 'break-word' }}
+          aria-label={`Translate: ${questionText}`}
+        >
+          {questionText}
+        </Typography>
+      </Paper>
+
+      {/* Input / feedback area */}
+      {phase === 'question' && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            inputRef={inputRef}
+            fullWidth
+            label={`Type the ${toLang} translation`}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            autoComplete="off"
+            inputProps={{
+              'aria-label': `Type the ${toLang} translation`,
+              lang: direction === 'source-to-target' ? pair.targetCode : pair.sourceCode,
+              autoCorrect: 'off',
+              autoCapitalize: 'none',
+              spellCheck: false,
+            }}
+          />
+          <Button
+            variant="contained"
+            size="large"
+            fullWidth
+            onClick={() => void handleSubmit()}
+            disabled={inputValue.trim() === ''}
+          >
+            Submit
+          </Button>
+        </Box>
+      )}
+
+      {phase === 'feedback' && lastResult !== null && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <QuizFeedback
+            result={lastResult.result}
+            correctAnswer={lastResult.correctAnswer}
+            userAnswer={inputValue}
+          />
+          <Button
+            variant="contained"
+            size="large"
+            fullWidth
+            onClick={handleAdvance}
+            autoFocus
+          >
+            {wordsCompleted >= sessionGoal ? 'See results' : 'Next word'}
+          </Button>
+        </Box>
+      )}
+
+      {/* End session button - accessible but not prominent */}
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Button
+          variant="text"
+          size="small"
+          color="inherit"
+          onClick={handleEndSession}
+          sx={{ color: 'text.disabled', fontSize: '0.75rem' }}
+        >
+          End session
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/features/quiz/components/SessionProgress.tsx
+++ b/src/features/quiz/components/SessionProgress.tsx
@@ -1,0 +1,37 @@
+/**
+ * SessionProgress - displays a progress bar and score for the current quiz session.
+ */
+
+import { Box, LinearProgress, Typography } from '@mui/material'
+
+interface SessionProgressProps {
+  /** Number of words completed so far. */
+  readonly completed: number
+  /** Total words in the session (daily goal). */
+  readonly total: number
+  /** Number of correct answers. */
+  readonly correct: number
+}
+
+export function SessionProgress({ completed, total, correct }: SessionProgressProps) {
+  const progress = total > 0 ? Math.min(100, (completed / total) * 100) : 0
+
+  return (
+    <Box sx={{ width: '100%', mb: 2 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+        <Typography variant="caption" color="text.secondary">
+          {completed} / {total}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {correct} correct
+        </Typography>
+      </Box>
+      <LinearProgress
+        variant="determinate"
+        value={progress}
+        sx={{ height: 6, borderRadius: 3 }}
+        aria-label={`Session progress: ${completed} of ${total} words completed`}
+      />
+    </Box>
+  )
+}

--- a/src/features/quiz/index.ts
+++ b/src/features/quiz/index.ts
@@ -1,0 +1,3 @@
+export { QuizScreen } from './components/QuizScreen'
+export { useQuizSession } from './useQuizSession'
+export type { QuizSessionState, SessionPhase, UseQuizSessionResult } from './useQuizSession'

--- a/src/features/quiz/useQuizSession.test.ts
+++ b/src/features/quiz/useQuizSession.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for useQuizSession hook.
+ *
+ * We test the logic of the quiz session by mocking the storage service
+ * and the spaced repetition engine's getNextWords / recordAttempt functions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { createElement } from 'react'
+import { StorageContext } from '@/hooks/useStorage'
+import type { StorageService } from '@/services/storage/StorageService'
+import type { Word, LanguagePair, UserSettings, WordProgress } from '@/types'
+import { useQuizSession } from './useQuizSession'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@/services/spacedRepetition', () => ({
+  getNextWords: vi.fn(),
+  recordAttempt: vi.fn(),
+}))
+
+import { getNextWords, recordAttempt } from '@/services/spacedRepetition'
+const mockGetNextWords = vi.mocked(getNextWords)
+const mockRecordAttempt = vi.mocked(recordAttempt)
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const mockPair: LanguagePair = {
+  id: 'pair-1',
+  sourceLang: 'Latvian',
+  targetLang: 'English',
+  sourceCode: 'lv',
+  targetCode: 'en',
+  createdAt: 1000,
+}
+
+const makeWord = (id: string, source: string, target: string): Word => ({
+  id,
+  pairId: 'pair-1',
+  source,
+  target,
+  notes: null,
+  tags: [],
+  createdAt: 1000,
+  isFromPack: false,
+})
+
+const mockSettings: UserSettings = {
+  activePairId: 'pair-1',
+  quizMode: 'type',
+  dailyGoal: 3,
+  theme: 'dark',
+  typoTolerance: 1,
+}
+
+const mockProgress: WordProgress = {
+  wordId: 'w1',
+  correctCount: 0,
+  incorrectCount: 0,
+  streak: 0,
+  lastReviewed: null,
+  nextReview: 0,
+  confidence: 0,
+  history: [],
+}
+
+function makeMockStorage(): StorageService {
+  return {
+    getLanguagePairs: vi.fn(),
+    getLanguagePair: vi.fn(),
+    saveLanguagePair: vi.fn(),
+    deleteLanguagePair: vi.fn(),
+    getWords: vi.fn(),
+    getWord: vi.fn(),
+    saveWord: vi.fn(),
+    saveWords: vi.fn(),
+    deleteWord: vi.fn(),
+    getWordProgress: vi.fn(),
+    getAllProgress: vi.fn(),
+    saveWordProgress: vi.fn(),
+    getSettings: vi.fn().mockResolvedValue(mockSettings),
+    saveSettings: vi.fn(),
+    getDailyStats: vi.fn().mockResolvedValue(null),
+    getDailyStatsRange: vi.fn().mockResolvedValue([]),
+    saveDailyStats: vi.fn(),
+    getRecentDailyStats: vi.fn().mockResolvedValue([]),
+    exportAll: vi.fn(),
+    importAll: vi.fn(),
+    clearAll: vi.fn(),
+  }
+}
+
+function makeWrapper(storage: StorageService) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(StorageContext.Provider, { value: storage }, children)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useQuizSession', () => {
+  let mockStorage: StorageService
+
+  beforeEach(() => {
+    mockStorage = makeMockStorage()
+    vi.clearAllMocks()
+  })
+
+  it('should start in loading phase and transition to question phase when words are available', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    expect(result.current.state.phase).toBe('loading')
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('question')
+    })
+
+    expect(result.current.state.currentWord).toEqual(word)
+  })
+
+  it('should finish immediately if no words are available', async () => {
+    mockGetNextWords.mockResolvedValue([])
+
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('finished')
+    })
+  })
+
+  it('should show the word to translate based on direction', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('question')
+    })
+
+    expect(result.current.state.direction).toBe('source-to-target')
+    expect(result.current.state.currentWord?.source).toBe('māja')
+  })
+
+  it('should transition to feedback after submitting an answer', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    await act(async () => {
+      await result.current.submitAnswer('house')
+    })
+
+    expect(result.current.state.phase).toBe('feedback')
+  })
+
+  it('should record a correct result for exact match', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    await act(async () => {
+      await result.current.submitAnswer('house')
+    })
+
+    expect(result.current.state.lastResult?.result).toBe('correct')
+    expect(result.current.state.correctCount).toBe(1)
+    expect(result.current.state.wordsCompleted).toBe(1)
+
+    expect(mockRecordAttempt).toHaveBeenCalledWith(
+      mockStorage, 'w1', true, 'source-to-target', 'type',
+    )
+  })
+
+  it('should record an incorrect result for a wrong answer', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    await act(async () => {
+      await result.current.submitAnswer('wrong')
+    })
+
+    expect(result.current.state.lastResult?.result).toBe('incorrect')
+    expect(result.current.state.correctCount).toBe(0)
+
+    expect(mockRecordAttempt).toHaveBeenCalledWith(
+      mockStorage, 'w1', false, 'source-to-target', 'type',
+    )
+  })
+
+  it('should record an almost result as correct attempt', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, { ...mockSettings, typoTolerance: 1 }),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    // 'hous' is 1 char off from 'house' - within tolerance 1
+    await act(async () => {
+      await result.current.submitAnswer('hous')
+    })
+
+    expect(result.current.state.lastResult?.result).toBe('almost')
+    expect(result.current.state.correctCount).toBe(1)
+
+    // almost is treated as correct for recording purposes
+    expect(mockRecordAttempt).toHaveBeenCalledWith(
+      mockStorage, 'w1', true, 'source-to-target', 'type',
+    )
+  })
+
+  it('should advance to the next word after feedback', async () => {
+    const word1 = makeWord('w1', 'māja', 'house')
+    const word2 = makeWord('w2', 'kaķis', 'cat')
+    mockGetNextWords.mockResolvedValue([
+      { word: word1, direction: 'source-to-target', progress: null },
+      { word: word2, direction: 'source-to-target', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+    expect(result.current.state.currentWord?.id).toBe('w1')
+
+    await act(async () => {
+      await result.current.submitAnswer('house')
+    })
+
+    expect(result.current.state.phase).toBe('feedback')
+
+    act(() => {
+      result.current.advance()
+    })
+
+    expect(result.current.state.phase).toBe('question')
+    expect(result.current.state.currentWord?.id).toBe('w2')
+  })
+
+  it('should finish the session when daily goal is reached', async () => {
+    const words = [
+      { word: makeWord('w1', 'māja', 'house'), direction: 'source-to-target' as const, progress: null },
+      { word: makeWord('w2', 'kaķis', 'cat'), direction: 'source-to-target' as const, progress: null },
+      { word: makeWord('w3', 'suns', 'dog'), direction: 'source-to-target' as const, progress: null },
+    ]
+    mockGetNextWords.mockResolvedValue(words)
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    // dailyGoal = 3 in mockSettings
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    // Answer word 1
+    await act(async () => { await result.current.submitAnswer('house') })
+    act(() => { result.current.advance() })
+
+    // Answer word 2
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+    await act(async () => { await result.current.submitAnswer('cat') })
+    act(() => { result.current.advance() })
+
+    // Answer word 3 - this should trigger finish
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+    await act(async () => { await result.current.submitAnswer('dog') })
+    act(() => { result.current.advance() })
+
+    expect(result.current.state.phase).toBe('finished')
+    expect(result.current.state.wordsCompleted).toBe(3)
+  })
+
+  it('should finish when session is ended manually', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    act(() => {
+      result.current.endSession()
+    })
+
+    expect(result.current.state.phase).toBe('finished')
+  })
+
+  it('should quiz in target-to-source direction', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'target-to-source', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    expect(result.current.state.direction).toBe('target-to-source')
+    // The question should show the target word
+    expect(result.current.state.currentWord?.target).toBe('house')
+
+    // Answering with the source should be correct
+    await act(async () => {
+      await result.current.submitAnswer('māja')
+    })
+
+    expect(result.current.state.lastResult?.result).toBe('correct')
+    expect(mockRecordAttempt).toHaveBeenCalledWith(
+      mockStorage, 'w1', true, 'target-to-source', 'type',
+    )
+  })
+
+  it('should finish immediately if pair is null', async () => {
+    const { result } = renderHook(
+      () => useQuizSession(null, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('finished')
+    })
+  })
+
+  it('should provide session goal from settings dailyGoal', async () => {
+    mockGetNextWords.mockResolvedValue([])
+
+    const { result } = renderHook(
+      () => useQuizSession(mockPair, { ...mockSettings, dailyGoal: 15 }),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('finished'))
+
+    expect(result.current.state.sessionGoal).toBe(15)
+  })
+})

--- a/src/features/quiz/useQuizSession.ts
+++ b/src/features/quiz/useQuizSession.ts
@@ -1,0 +1,231 @@
+/**
+ * useQuizSession - manages the state and logic for a single quiz session.
+ *
+ * Responsibilities:
+ * - Loads the next batch of words via the spaced repetition engine.
+ * - Tracks per-word attempt results within the session.
+ * - Records each attempt through the spaced repetition engine (which persists progress).
+ * - Tracks session progress against the daily goal.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import type { Word, LanguagePair, UserSettings } from '@/types'
+import type { QuizDirection } from '@/types'
+import { useStorage } from '@/hooks/useStorage'
+import { getNextWords, recordAttempt } from '@/services/spacedRepetition'
+import { matchAnswer } from '@/utils/matching'
+import type { AnswerMatchResult } from '@/utils/matching'
+import type { WordForQuiz } from '@/services/spacedRepetition'
+
+// ─── Session State ────────────────────────────────────────────────────────────
+
+export type SessionPhase =
+  | 'loading'      // fetching words
+  | 'question'     // showing a word, waiting for input
+  | 'feedback'     // showing result, about to advance
+  | 'finished'     // session complete
+
+export interface QuizSessionState {
+  readonly phase: SessionPhase
+  /** The current word being quizzed. */
+  readonly currentWord: Word | null
+  /** The direction for the current word. */
+  readonly direction: QuizDirection | null
+  /** The active language pair. */
+  readonly pair: LanguagePair | null
+  /** Result of the last submitted answer. */
+  readonly lastResult: AnswerMatchResult | null
+  /** Number of words completed in this session. */
+  readonly wordsCompleted: number
+  /** Total words in this session (= daily goal). */
+  readonly sessionGoal: number
+  /** Number of correct answers this session. */
+  readonly correctCount: number
+  /** Error message if something went wrong. */
+  readonly error: string | null
+}
+
+export interface UseQuizSessionResult {
+  readonly state: QuizSessionState
+  /** Submit the user's typed answer for the current word. */
+  readonly submitAnswer: (userAnswer: string) => Promise<void>
+  /** Advance past the feedback screen to the next word. */
+  readonly advance: () => void
+  /** Manually end the session early. */
+  readonly endSession: () => void
+  /** Start a new session (reset everything). */
+  readonly restart: () => void
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** How many words to pre-fetch per batch. */
+const BATCH_SIZE = 20
+
+/** Duration (ms) to show feedback before auto-advancing. */
+export const FEEDBACK_DELAY_MS = 1500
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+/**
+ * Manages a full quiz session for a given language pair.
+ *
+ * @param pair     - The active language pair, or null if none selected.
+ * @param settings - The current user settings (daily goal, typo tolerance).
+ */
+export function useQuizSession(
+  pair: LanguagePair | null,
+  settings: UserSettings,
+): UseQuizSessionResult {
+  const storage = useStorage()
+
+  const [phase, setPhase] = useState<SessionPhase>('loading')
+  const [queue, setQueue] = useState<WordForQuiz[]>([])
+  const [queueIndex, setQueueIndex] = useState(0)
+  const [lastResult, setLastResult] = useState<AnswerMatchResult | null>(null)
+  const [wordsCompleted, setWordsCompleted] = useState(0)
+  const [correctCount, setCorrectCount] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  // Track if the component is still mounted to avoid state updates after unmount.
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const sessionGoal = settings.dailyGoal
+
+  // ─── Load words ────────────────────────────────────────────────────────────
+
+  const loadWords = useCallback(async (): Promise<void> => {
+    if (pair === null) {
+      if (mountedRef.current) {
+        setPhase('finished')
+      }
+      return
+    }
+
+    if (mountedRef.current) {
+      setPhase('loading')
+      setError(null)
+    }
+
+    try {
+      const words = await getNextWords(storage, pair.id, BATCH_SIZE)
+
+      if (!mountedRef.current) return
+
+      if (words.length === 0) {
+        setPhase('finished')
+        return
+      }
+
+      setQueue(words)
+      setQueueIndex(0)
+      setPhase('question')
+    } catch (err) {
+      if (!mountedRef.current) return
+      const message = err instanceof Error ? err.message : 'Failed to load words'
+      setError(message)
+      setPhase('finished')
+    }
+  }, [storage, pair])
+
+  // Load words on mount and whenever the pair changes.
+  useEffect(() => {
+    void loadWords()
+  }, [loadWords])
+
+  // ─── Derived current word ──────────────────────────────────────────────────
+
+  const currentItem = queueIndex < queue.length ? queue[queueIndex] : null
+  const currentWord = currentItem?.word ?? null
+  const direction = currentItem?.direction ?? null
+
+  // ─── Submit answer ─────────────────────────────────────────────────────────
+
+  const submitAnswer = useCallback(
+    async (userAnswer: string): Promise<void> => {
+      if (phase !== 'question' || currentWord === null || direction === null) return
+
+      const correctText = direction === 'source-to-target'
+        ? currentWord.target
+        : currentWord.source
+
+      const matchResult = matchAnswer(userAnswer, correctText, settings.typoTolerance)
+      const isCorrect = matchResult.result === 'correct' || matchResult.result === 'almost'
+
+      // Record attempt via spaced repetition engine.
+      try {
+        await recordAttempt(storage, currentWord.id, isCorrect, direction, 'type')
+      } catch (err) {
+        // Non-fatal: log but don't interrupt the quiz.
+        console.error('Failed to record attempt:', err)
+      }
+
+      if (!mountedRef.current) return
+
+      setLastResult(matchResult)
+      setWordsCompleted((n) => n + 1)
+      if (isCorrect) {
+        setCorrectCount((n) => n + 1)
+      }
+      setPhase('feedback')
+    },
+    [phase, currentWord, direction, settings.typoTolerance, storage],
+  )
+
+  // ─── Advance ───────────────────────────────────────────────────────────────
+
+  const advance = useCallback((): void => {
+    if (phase !== 'feedback') return
+
+    const nextIndex = queueIndex + 1
+    const newWordsCompleted = wordsCompleted
+
+    // Session ends when the daily goal is reached or queue is exhausted.
+    if (newWordsCompleted >= sessionGoal || nextIndex >= queue.length) {
+      setPhase('finished')
+      return
+    }
+
+    setQueueIndex(nextIndex)
+    setLastResult(null)
+    setPhase('question')
+  }, [phase, queueIndex, wordsCompleted, sessionGoal, queue.length])
+
+  // ─── End session ───────────────────────────────────────────────────────────
+
+  const endSession = useCallback((): void => {
+    setPhase('finished')
+  }, [])
+
+  // ─── Restart ───────────────────────────────────────────────────────────────
+
+  const restart = useCallback((): void => {
+    setWordsCompleted(0)
+    setCorrectCount(0)
+    setLastResult(null)
+    setQueue([])
+    setQueueIndex(0)
+    void loadWords()
+  }, [loadWords])
+
+  // ─── Return ────────────────────────────────────────────────────────────────
+
+  const state: QuizSessionState = {
+    phase,
+    currentWord,
+    direction,
+    pair,
+    lastResult,
+    wordsCompleted,
+    sessionGoal,
+    correctCount,
+    error,
+  }
+
+  return { state, submitAnswer, advance, endSession, restart }
+}

--- a/src/utils/matching.test.ts
+++ b/src/utils/matching.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import { levenshtein, matchAnswer } from './matching'
+import type { MatchResult } from './matching'
+
+// ─── levenshtein ─────────────────────────────────────────────────────────────
+
+describe('levenshtein', () => {
+  it('should return 0 for identical strings', () => {
+    expect(levenshtein('cat', 'cat')).toBe(0)
+  })
+
+  it('should return 0 for two empty strings', () => {
+    expect(levenshtein('', '')).toBe(0)
+  })
+
+  it('should return the length of the non-empty string when the other is empty', () => {
+    expect(levenshtein('hello', '')).toBe(5)
+    expect(levenshtein('', 'hello')).toBe(5)
+  })
+
+  it('should calculate distance for a single substitution', () => {
+    expect(levenshtein('cat', 'bat')).toBe(1)
+  })
+
+  it('should calculate distance for a single insertion', () => {
+    expect(levenshtein('cat', 'cats')).toBe(1)
+    expect(levenshtein('cats', 'cat')).toBe(1)
+  })
+
+  it('should calculate distance for a single deletion', () => {
+    expect(levenshtein('cats', 'cat')).toBe(1)
+  })
+
+  it('should calculate distance for multiple edits', () => {
+    expect(levenshtein('kitten', 'sitting')).toBe(3)
+    expect(levenshtein('saturday', 'sunday')).toBe(3)
+  })
+
+  it('should be symmetric', () => {
+    expect(levenshtein('abc', 'xyz')).toBe(levenshtein('xyz', 'abc'))
+    expect(levenshtein('kitten', 'sitting')).toBe(levenshtein('sitting', 'kitten'))
+  })
+
+  it('should handle Latvian diacritics', () => {
+    // ā vs a is one substitution
+    expect(levenshtein('māja', 'maja')).toBe(1)
+    // galds vs galdi is one substitution
+    expect(levenshtein('galds', 'galdi')).toBe(1)
+  })
+})
+
+// ─── matchAnswer ──────────────────────────────────────────────────────────────
+
+describe('matchAnswer', () => {
+  // ── Exact match ────────────────────────────────────────────────────────────
+
+  it('should return correct for an exact match', () => {
+    const result = matchAnswer('house', 'house', 0)
+    expect(result.result).toBe<MatchResult>('correct')
+    expect(result.distance).toBe(0)
+  })
+
+  it('should return correct for a case-insensitive match', () => {
+    const result = matchAnswer('House', 'house', 0)
+    expect(result.result).toBe<MatchResult>('correct')
+  })
+
+  it('should return correct when the answer has leading/trailing whitespace', () => {
+    const result = matchAnswer('  house  ', 'house', 0)
+    expect(result.result).toBe<MatchResult>('correct')
+  })
+
+  it('should preserve the original (trimmed) correctAnswer in the result', () => {
+    const result = matchAnswer('house', '  house  ', 0)
+    expect(result.correctAnswer).toBe('house')
+  })
+
+  // ── Typo tolerance = 0 (exact only) ────────────────────────────────────────
+
+  it('should return incorrect when distance is 1 and tolerance is 0', () => {
+    const result = matchAnswer('hous', 'house', 0)
+    expect(result.result).toBe<MatchResult>('incorrect')
+  })
+
+  it('should return incorrect when distance is 2 and tolerance is 0', () => {
+    const result = matchAnswer('hos', 'house', 0)
+    expect(result.result).toBe<MatchResult>('incorrect')
+  })
+
+  // ── Typo tolerance = 1 ─────────────────────────────────────────────────────
+
+  it('should return almost when distance is 1 and tolerance is 1', () => {
+    const result = matchAnswer('hous', 'house', 1)
+    expect(result.result).toBe<MatchResult>('almost')
+  })
+
+  it('should return incorrect when distance is 2 and tolerance is 1', () => {
+    const result = matchAnswer('hos', 'house', 1)
+    expect(result.result).toBe<MatchResult>('incorrect')
+  })
+
+  // ── Typo tolerance = 2 ─────────────────────────────────────────────────────
+
+  it('should return almost when distance is 1 and tolerance is 2', () => {
+    const result = matchAnswer('hous', 'house', 2)
+    expect(result.result).toBe<MatchResult>('almost')
+  })
+
+  it('should return almost when distance is 2 and tolerance is 2', () => {
+    const result = matchAnswer('hos', 'house', 2)
+    expect(result.result).toBe<MatchResult>('almost')
+  })
+
+  it('should return incorrect when distance is 3 and tolerance is 2', () => {
+    const result = matchAnswer('ho', 'house', 2)
+    expect(result.result).toBe<MatchResult>('incorrect')
+  })
+
+  // ── Latvian diacritics ─────────────────────────────────────────────────────
+
+  it('should handle Latvian diacritics as distinct characters (distance 1)', () => {
+    // māja typed as maja: 1 char difference
+    const result1 = matchAnswer('maja', 'māja', 0)
+    expect(result1.result).toBe<MatchResult>('incorrect')
+    expect(result1.distance).toBe(1)
+
+    const result2 = matchAnswer('maja', 'māja', 1)
+    expect(result2.result).toBe<MatchResult>('almost')
+  })
+
+  it('should return correct for exact Latvian diacritic match', () => {
+    const result = matchAnswer('māja', 'māja', 0)
+    expect(result.result).toBe<MatchResult>('correct')
+  })
+
+  // ── Edge cases ─────────────────────────────────────────────────────────────
+
+  it('should return incorrect for an empty answer against a non-empty correct answer', () => {
+    const result = matchAnswer('', 'house', 0)
+    expect(result.result).toBe<MatchResult>('incorrect')
+    expect(result.distance).toBe(5)
+  })
+
+  it('should include the distance in the result', () => {
+    const result = matchAnswer('hous', 'house', 1)
+    expect(result.distance).toBe(1)
+  })
+})

--- a/src/utils/matching.ts
+++ b/src/utils/matching.ts
@@ -1,0 +1,104 @@
+/**
+ * Answer matching utilities for the quiz type mode.
+ *
+ * Provides Levenshtein distance calculation and answer comparison
+ * with configurable typo tolerance levels.
+ */
+
+// ─── Levenshtein Distance ─────────────────────────────────────────────────────
+
+/**
+ * Calculates the Levenshtein edit distance between two strings.
+ * Uses dynamic programming (Wagner-Fischer algorithm) with O(m*n) time
+ * and O(min(m,n)) space optimisation.
+ */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0
+  if (a.length === 0) return b.length
+  if (b.length === 0) return a.length
+
+  // Ensure 'a' is the shorter string for space optimisation
+  if (a.length > b.length) return levenshtein(b, a)
+
+  let prev = Array.from({ length: a.length + 1 }, (_, i) => i)
+  let curr = new Array<number>(a.length + 1)
+
+  for (let j = 1; j <= b.length; j++) {
+    curr[0] = j
+    for (let i = 1; i <= a.length; i++) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1
+      curr[i] = Math.min(
+        curr[i - 1] + 1,          // insertion
+        prev[i] + 1,               // deletion
+        prev[i - 1] + substitutionCost, // substitution
+      )
+    }
+    ;[prev, curr] = [curr, prev]
+  }
+
+  return prev[a.length]
+}
+
+// ─── Match Result ─────────────────────────────────────────────────────────────
+
+/** The result of comparing a user's answer against the correct answer. */
+export type MatchResult = 'correct' | 'almost' | 'incorrect'
+
+export interface AnswerMatchResult {
+  readonly result: MatchResult
+  /**
+   * The normalised correct answer (trimmed, original casing).
+   * Useful for displaying "The correct answer is: …" on incorrect/almost.
+   */
+  readonly correctAnswer: string
+  /** The edit distance between the normalised inputs. */
+  readonly distance: number
+}
+
+// ─── Answer Matching ──────────────────────────────────────────────────────────
+
+/**
+ * Normalises a string for comparison: trims whitespace and lowercases.
+ */
+function normalise(s: string): string {
+  return s.trim().toLowerCase()
+}
+
+/**
+ * Compares a user's typed answer against the correct answer.
+ *
+ * Matching rules:
+ * - Comparison is case-insensitive and whitespace-trimmed.
+ * - If the edit distance is 0 → 'correct'.
+ * - If the edit distance is within the tolerance level → 'almost'.
+ * - Otherwise → 'incorrect'.
+ *
+ * @param userAnswer  - The raw string the user typed.
+ * @param correctAnswer - The expected correct translation.
+ * @param typoTolerance - Maximum edit distance to accept as 'almost' (from UserSettings).
+ *                        0 = exact match only, 1 = one char off, 2 = two chars off.
+ */
+export function matchAnswer(
+  userAnswer: string,
+  correctAnswer: string,
+  typoTolerance: number,
+): AnswerMatchResult {
+  const normUser = normalise(userAnswer)
+  const normCorrect = normalise(correctAnswer)
+  const distance = levenshtein(normUser, normCorrect)
+
+  let result: MatchResult
+  if (distance === 0) {
+    result = 'correct'
+  } else if (typoTolerance > 0 && distance <= typoTolerance) {
+    result = 'almost'
+  } else {
+    result = 'incorrect'
+  }
+
+  return {
+    result,
+    correctAnswer: correctAnswer.trim(),
+    distance,
+  }
+}


### PR DESCRIPTION
## Summary

- Implements the core quiz learning interaction: show a word, user types the translation
- Adds Levenshtein-based answer matching with configurable typo tolerance (exact / 1-char / 2-chars)
- Correct, almost-correct (amber), and incorrect (red) visual feedback states
- Session progress bar tracking words completed vs daily goal
- All attempts recorded via the spaced repetition engine

## Changes

- `src/utils/matching.ts` - Levenshtein distance (Wagner-Fischer, O(min(m,n)) space) and `matchAnswer` utility
- `src/utils/matching.test.ts` - 24 tests
- `src/features/quiz/useQuizSession.ts` - session state hook (loading, question, feedback, finished phases)
- `src/features/quiz/useQuizSession.test.ts` - 13 tests covering session flow, directions, goal tracking
- `src/features/quiz/components/QuizScreen.tsx` - main quiz UI
- `src/features/quiz/components/QuizFeedback.tsx` - correct/almost/incorrect feedback component
- `src/features/quiz/components/SessionProgress.tsx` - progress bar
- `src/features/quiz/components/QuizScreen.test.tsx` - 18 component tests
- `src/features/quiz/index.ts` - public exports
- `src/App.tsx` - added Quiz tab to navigation

## Testing

- 274 tests pass (55 new)
- `npx tsc --noEmit` clean
- `npm run build` succeeds

## Review

- Code review passed: no `any`, no direct localStorage, all colours via MUI theme tokens, Latvian diacritics handled, mobile keyboard attributes set

Closes #10