### PR TITLE
feat: mixed quiz mode, mode selector, and session summary (#12)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import {
 } from './features/language-pairs'
 import type { CreatePairInput } from './features/language-pairs'
 import { WordListScreen } from './features/words'
-import { QuizScreen } from './features/quiz'
+import { QuizHub } from './features/quiz'
 import type { UserSettings } from './types'
 
 /**
@@ -148,7 +148,11 @@ function AppContent() {
             ) : (
               <>
                 {activeTab === 'quiz' && (
-                  <QuizScreen pair={activePair} settings={settings} />
+                  <QuizHub
+                    pair={activePair}
+                    settings={settings}
+                    onSettingsChange={setSettings}
+                  />
                 )}
 
                 {activeTab === 'words' && (

--- a/src/features/quiz/components/ActiveQuizView.tsx
+++ b/src/features/quiz/components/ActiveQuizView.tsx
@@ -1,0 +1,139 @@
+/**
+ * ActiveQuizView - renders the correct quiz screen for the given mode
+ * and surfaces the session result (stats) to the parent when the session ends.
+ *
+ * Each quiz variant has its own hook that manages its state independently.
+ * This component mounts the appropriate hook-driven view and captures the
+ * final wordsCompleted / correctCount before handing them up to QuizHub.
+ */
+
+import { useEffect, useRef } from 'react'
+import type { LanguagePair, UserSettings, QuizMode } from '@/types'
+import { useQuizSession } from '../useQuizSession'
+import { useChoiceQuizSession } from '../useChoiceQuizSession'
+import { useMixedQuizSession } from '../useMixedQuizSession'
+import { TypeQuizContent } from './TypeQuizContent'
+import { ChoiceQuizContent } from './ChoiceQuizContent'
+import { MixedQuizContent } from './MixedQuizContent'
+
+interface ActiveQuizViewProps {
+  readonly mode: QuizMode
+  readonly pair: LanguagePair | null
+  readonly settings: UserSettings
+  /**
+   * Called once when the session transitions to 'finished'.
+   * Receives the final wordsReviewed and correctCount.
+   */
+  readonly onSessionFinished: (wordsReviewed: number, correctCount: number) => void
+}
+
+// ─── Per-mode containers ──────────────────────────────────────────────────────
+// Each container runs the appropriate session hook and calls onSessionFinished
+// exactly once when phase becomes 'finished'.
+// We store onSessionFinished in a ref so the effect dep array only contains
+// the stable `phase` value — the callback itself is always current.
+
+interface TypeContainerProps {
+  readonly pair: LanguagePair | null
+  readonly settings: UserSettings
+  readonly onSessionFinished: (wordsReviewed: number, correctCount: number) => void
+}
+
+function TypeContainer({ pair, settings, onSessionFinished }: TypeContainerProps) {
+  const session = useQuizSession(pair, settings)
+  const { phase, wordsCompleted, correctCount } = session.state
+
+  const onFinishedRef = useRef(onSessionFinished)
+  onFinishedRef.current = onSessionFinished
+
+  useEffect(() => {
+    if (phase === 'finished') {
+      onFinishedRef.current(wordsCompleted, correctCount)
+    }
+  // wordsCompleted and correctCount are stable at the moment phase becomes
+  // 'finished', so including them is correct and avoids stale reads.
+  }, [phase, wordsCompleted, correctCount])
+
+  return <TypeQuizContent session={session} pair={pair} settings={settings} />
+}
+
+interface ChoiceContainerProps {
+  readonly pair: LanguagePair | null
+  readonly settings: UserSettings
+  readonly onSessionFinished: (wordsReviewed: number, correctCount: number) => void
+}
+
+function ChoiceContainer({ pair, settings, onSessionFinished }: ChoiceContainerProps) {
+  const session = useChoiceQuizSession(pair, settings)
+  const { phase, wordsCompleted, correctCount } = session.state
+
+  const onFinishedRef = useRef(onSessionFinished)
+  onFinishedRef.current = onSessionFinished
+
+  useEffect(() => {
+    if (phase === 'finished') {
+      onFinishedRef.current(wordsCompleted, correctCount)
+    }
+  }, [phase, wordsCompleted, correctCount])
+
+  return <ChoiceQuizContent session={session} pair={pair} />
+}
+
+interface MixedContainerProps {
+  readonly pair: LanguagePair | null
+  readonly settings: UserSettings
+  readonly onSessionFinished: (wordsReviewed: number, correctCount: number) => void
+}
+
+function MixedContainer({ pair, settings, onSessionFinished }: MixedContainerProps) {
+  const session = useMixedQuizSession(pair, settings)
+  const { phase, wordsCompleted, correctCount } = session.state
+
+  const onFinishedRef = useRef(onSessionFinished)
+  onFinishedRef.current = onSessionFinished
+
+  useEffect(() => {
+    if (phase === 'finished') {
+      onFinishedRef.current(wordsCompleted, correctCount)
+    }
+  }, [phase, wordsCompleted, correctCount])
+
+  return <MixedQuizContent session={session} pair={pair} settings={settings} />
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function ActiveQuizView({
+  mode,
+  pair,
+  settings,
+  onSessionFinished,
+}: ActiveQuizViewProps) {
+  if (mode === 'type') {
+    return (
+      <TypeContainer
+        pair={pair}
+        settings={settings}
+        onSessionFinished={onSessionFinished}
+      />
+    )
+  }
+
+  if (mode === 'choice') {
+    return (
+      <ChoiceContainer
+        pair={pair}
+        settings={settings}
+        onSessionFinished={onSessionFinished}
+      />
+    )
+  }
+
+  return (
+    <MixedContainer
+      pair={pair}
+      settings={settings}
+      onSessionFinished={onSessionFinished}
+    />
+  )
+}

--- a/src/features/quiz/components/ChoiceQuizContent.tsx
+++ b/src/features/quiz/components/ChoiceQuizContent.tsx
@@ -1,0 +1,245 @@
+/**
+ * ChoiceQuizContent - renders the choice-mode quiz UI.
+ *
+ * Accepts an already-running session and does not render its own finished state.
+ */
+
+import { useCallback } from 'react'
+import {
+  Box,
+  Button,
+  Paper,
+  Typography,
+  Chip,
+  Alert,
+} from '@mui/material'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined'
+import type { LanguagePair } from '@/types'
+import type { UseChoiceQuizSessionResult } from '../useChoiceQuizSession'
+import { SessionProgress } from './SessionProgress'
+import { MIN_WORDS_FOR_CHOICE } from '@/utils/distractorGenerator'
+
+type OptionState = 'default' | 'correct' | 'incorrect' | 'reveal'
+
+function getOptionState(index: number, correctIndex: number, selectedIndex: number): OptionState {
+  if (selectedIndex === -1) return 'default'
+  if (index === selectedIndex && index === correctIndex) return 'correct'
+  if (index === selectedIndex && index !== correctIndex) return 'incorrect'
+  if (index === correctIndex && selectedIndex !== correctIndex) return 'reveal'
+  return 'default'
+}
+
+function getOptionSx(state: OptionState) {
+  const base = {
+    justifyContent: 'flex-start',
+    textAlign: 'left' as const,
+    minHeight: 56,
+    px: 2,
+    py: 1.5,
+    fontWeight: 600,
+    fontSize: '1rem',
+    borderRadius: 2,
+    transition: 'background-color 0.2s, border-color 0.2s',
+    wordBreak: 'break-word' as const,
+  }
+  switch (state) {
+    case 'correct':
+      return {
+        ...base,
+        borderColor: 'success.main',
+        '&.Mui-disabled': {
+          color: 'success.contrastText',
+          backgroundColor: 'success.main',
+          borderColor: 'success.main',
+          opacity: 1,
+        },
+      }
+    case 'incorrect':
+      return {
+        ...base,
+        borderColor: 'error.main',
+        '&.Mui-disabled': { color: 'error.main', borderColor: 'error.main', opacity: 1 },
+      }
+    case 'reveal':
+      return {
+        ...base,
+        borderColor: 'success.main',
+        '&.Mui-disabled': { color: 'success.main', borderColor: 'success.main', opacity: 1 },
+      }
+    default:
+      return base
+  }
+}
+
+interface ChoiceQuizContentProps {
+  readonly session: UseChoiceQuizSessionResult
+  readonly pair: LanguagePair | null
+}
+
+export function ChoiceQuizContent({ session, pair }: ChoiceQuizContentProps) {
+  const { state, selectOption, advance, endSession } = session
+  const {
+    phase,
+    currentWord,
+    direction,
+    options,
+    correctIndex,
+    selectedIndex,
+    lastCorrect,
+    wordsCompleted,
+    sessionGoal,
+    correctCount,
+    error,
+  } = state
+
+  const handleSelect = useCallback(
+    (index: number): void => { void selectOption(index) },
+    [selectOption],
+  )
+
+  if (pair === null) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="h6" color="text.secondary">
+          Select a language pair to start quizzing.
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (phase === 'loading') {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="body1" color="text.secondary">Loading words...</Typography>
+      </Box>
+    )
+  }
+
+  if (phase === 'not-enough-words') {
+    return (
+      <Box sx={{ py: 4 }}>
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Multiple choice mode requires at least {MIN_WORDS_FOR_CHOICE} words in
+          this language pair.
+        </Alert>
+        <Typography variant="body2" color="text.secondary">
+          Add more words to your word list to use multiple choice mode.
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (phase === 'finished' && error !== null) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="h6" color="error.main" gutterBottom>Something went wrong</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>{error}</Typography>
+      </Box>
+    )
+  }
+
+  // Finished without error: parent handles transition.
+  if (phase === 'finished') return null
+
+  const fromLang = direction === 'source-to-target' ? pair.sourceLang : pair.targetLang
+  const toLang = direction === 'source-to-target' ? pair.targetLang : pair.sourceLang
+  const questionText =
+    direction === 'source-to-target' ? currentWord?.source ?? '' : currentWord?.target ?? ''
+  const isAnswered = selectedIndex !== -1
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <SessionProgress completed={wordsCompleted} total={sessionGoal} correct={correctCount} />
+
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Chip
+          label={`${fromLang} → ${toLang}`}
+          size="small"
+          variant="outlined"
+          sx={{ fontWeight: 600 }}
+          aria-label={`Translating from ${fromLang} to ${toLang}`}
+        />
+      </Box>
+
+      <Paper elevation={2} sx={{ p: 4, textAlign: 'center', borderRadius: 3 }}>
+        <Typography
+          variant="h4"
+          component="p"
+          fontWeight={700}
+          sx={{ wordBreak: 'break-word' }}
+          aria-label={`Translate: ${questionText}`}
+        >
+          {questionText}
+        </Typography>
+        {currentWord?.notes != null && currentWord.notes !== '' && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1, fontStyle: 'italic' }}>
+            {currentWord.notes}
+          </Typography>
+        )}
+      </Paper>
+
+      <Box
+        sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}
+        role="group"
+        aria-label={`Choose the ${toLang} translation`}
+      >
+        {options.map((option, index) => {
+          const optionState = getOptionState(index, correctIndex, selectedIndex)
+          const isSelected = index === selectedIndex
+          const isCorrectOption = index === correctIndex
+
+          return (
+            <Button
+              key={`${option}-${index}`}
+              variant="outlined"
+              fullWidth
+              disabled={isAnswered}
+              onClick={() => handleSelect(index)}
+              sx={getOptionSx(optionState)}
+              aria-label={`Option ${index + 1}: ${option}`}
+              aria-pressed={isSelected}
+              aria-describedby={isAnswered && isCorrectOption ? 'correct-answer-label' : undefined}
+              startIcon={
+                isAnswered && optionState === 'correct' ? <CheckCircleOutlineIcon /> :
+                isAnswered && optionState === 'incorrect' ? <CancelOutlinedIcon /> :
+                isAnswered && optionState === 'reveal' ? <CheckCircleOutlineIcon /> :
+                null
+              }
+            >
+              {option}
+            </Button>
+          )
+        })}
+      </Box>
+
+      {isAnswered && (
+        <Box role="status" aria-live="polite" sx={{ textAlign: 'center' }}>
+          {lastCorrect === true ? (
+            <Typography variant="h6" color="success.main" fontWeight={700}>Correct!</Typography>
+          ) : (
+            <Typography variant="h6" color="error.main" fontWeight={700}>Incorrect</Typography>
+          )}
+        </Box>
+      )}
+
+      {isAnswered && (
+        <Button variant="contained" size="large" fullWidth onClick={advance} autoFocus>
+          {wordsCompleted >= sessionGoal ? 'See results' : 'Next word'}
+        </Button>
+      )}
+
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Button
+          variant="text"
+          size="small"
+          color="inherit"
+          onClick={endSession}
+          sx={{ color: 'text.disabled', fontSize: '0.75rem' }}
+        >
+          End session
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/features/quiz/components/MixedQuizContent.tsx
+++ b/src/features/quiz/components/MixedQuizContent.tsx
@@ -1,0 +1,336 @@
+/**
+ * MixedQuizContent - renders the mixed-mode quiz UI.
+ *
+ * Accepts an already-running mixed session and does not render its own finished state.
+ * Uses shared structural elements (SessionProgress, word card) for both type and
+ * choice sub-modes so there is no jarring layout shift when the mode alternates.
+ */
+
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  KeyboardEvent,
+} from 'react'
+import {
+  Box,
+  Button,
+  Paper,
+  TextField,
+  Typography,
+  Chip,
+} from '@mui/material'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined'
+import type { LanguagePair, UserSettings } from '@/types'
+import type { UseMixedQuizSessionResult } from '../useMixedQuizSession'
+import { SessionProgress } from './SessionProgress'
+import { QuizFeedback } from './QuizFeedback'
+
+type OptionState = 'default' | 'correct' | 'incorrect' | 'reveal'
+
+function getOptionState(index: number, correctIndex: number, selectedIndex: number): OptionState {
+  if (selectedIndex === -1) return 'default'
+  if (index === selectedIndex && index === correctIndex) return 'correct'
+  if (index === selectedIndex && index !== correctIndex) return 'incorrect'
+  if (index === correctIndex && selectedIndex !== correctIndex) return 'reveal'
+  return 'default'
+}
+
+function getOptionSx(state: OptionState) {
+  const base = {
+    justifyContent: 'flex-start',
+    textAlign: 'left' as const,
+    minHeight: 56,
+    px: 2,
+    py: 1.5,
+    fontWeight: 600,
+    fontSize: '1rem',
+    borderRadius: 2,
+    transition: 'background-color 0.2s, border-color 0.2s',
+    wordBreak: 'break-word' as const,
+  }
+  switch (state) {
+    case 'correct':
+      return {
+        ...base,
+        borderColor: 'success.main',
+        '&.Mui-disabled': {
+          color: 'success.contrastText',
+          backgroundColor: 'success.main',
+          borderColor: 'success.main',
+          opacity: 1,
+        },
+      }
+    case 'incorrect':
+      return {
+        ...base,
+        borderColor: 'error.main',
+        '&.Mui-disabled': { color: 'error.main', borderColor: 'error.main', opacity: 1 },
+      }
+    case 'reveal':
+      return {
+        ...base,
+        borderColor: 'success.main',
+        '&.Mui-disabled': { color: 'success.main', borderColor: 'success.main', opacity: 1 },
+      }
+    default:
+      return base
+  }
+}
+
+interface MixedQuizContentProps {
+  readonly session: UseMixedQuizSessionResult
+  readonly pair: LanguagePair | null
+  readonly settings: UserSettings
+}
+
+export function MixedQuizContent({ session, pair, settings }: MixedQuizContentProps) {
+  // settings is available for future use (typo tolerance hint display, etc.)
+  void settings
+
+  const { state, submitAnswer, selectOption, advance, endSession } = session
+  const {
+    phase,
+    currentWord,
+    direction,
+    currentMode,
+    options,
+    correctIndex,
+    selectedIndex,
+    lastResult,
+    lastChoiceCorrect,
+    wordsCompleted,
+    sessionGoal,
+    correctCount,
+    error,
+  } = state
+
+  const [inputValue, setInputValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (phase === 'question' && currentMode === 'type' && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [phase, currentWord, currentMode])
+
+  useEffect(() => {
+    if (phase === 'question') {
+      setInputValue('')
+    }
+  }, [phase, currentWord])
+
+  const handleSubmit = useCallback(async (): Promise<void> => {
+    if (inputValue.trim() === '') return
+    await submitAnswer(inputValue)
+  }, [inputValue, submitAnswer])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>): void => {
+      if (e.key === 'Enter') void handleSubmit()
+    },
+    [handleSubmit],
+  )
+
+  const handleSelect = useCallback(
+    (index: number): void => { void selectOption(index) },
+    [selectOption],
+  )
+
+  if (pair === null) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="h6" color="text.secondary">
+          Select a language pair to start quizzing.
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (phase === 'loading') {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="body1" color="text.secondary">Loading words...</Typography>
+      </Box>
+    )
+  }
+
+  if (phase === 'finished' && error !== null) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="h6" color="error.main" gutterBottom>Something went wrong</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>{error}</Typography>
+      </Box>
+    )
+  }
+
+  // Finished without error: parent handles transition.
+  if (phase === 'finished') return null
+
+  const fromLang = direction === 'source-to-target' ? pair.sourceLang : pair.targetLang
+  const toLang = direction === 'source-to-target' ? pair.targetLang : pair.sourceLang
+  const questionText =
+    direction === 'source-to-target' ? currentWord?.source ?? '' : currentWord?.target ?? ''
+
+  const isChoiceAnswered = currentMode === 'choice' && selectedIndex !== -1
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <SessionProgress completed={wordsCompleted} total={sessionGoal} correct={correctCount} />
+
+      {/* Direction chip + mode badge */}
+      <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1 }}>
+        <Chip
+          label={`${fromLang} → ${toLang}`}
+          size="small"
+          variant="outlined"
+          sx={{ fontWeight: 600 }}
+          aria-label={`Translating from ${fromLang} to ${toLang}`}
+        />
+        <Chip
+          label={currentMode === 'type' ? 'Type' : 'Choice'}
+          size="small"
+          color="primary"
+          variant="outlined"
+          sx={{ fontWeight: 600 }}
+          aria-label={`Quiz mode: ${currentMode}`}
+        />
+      </Box>
+
+      {/* Word card */}
+      <Paper elevation={2} sx={{ p: 4, textAlign: 'center', borderRadius: 3 }}>
+        <Typography
+          variant="h4"
+          component="p"
+          fontWeight={700}
+          sx={{ wordBreak: 'break-word' }}
+          aria-label={`Translate: ${questionText}`}
+        >
+          {questionText}
+        </Typography>
+        {currentWord?.notes != null && currentWord.notes !== '' && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1, fontStyle: 'italic' }}>
+            {currentWord.notes}
+          </Typography>
+        )}
+      </Paper>
+
+      {/* ── Type mode ──────────────────────────────────────────────────────── */}
+
+      {currentMode === 'type' && phase === 'question' && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            inputRef={inputRef}
+            fullWidth
+            label={`Type the ${toLang} translation`}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            autoComplete="off"
+            inputProps={{
+              'aria-label': `Type the ${toLang} translation`,
+              lang: direction === 'source-to-target' ? pair.targetCode : pair.sourceCode,
+              autoCorrect: 'off',
+              autoCapitalize: 'none',
+              spellCheck: false,
+            }}
+          />
+          <Button
+            variant="contained"
+            size="large"
+            fullWidth
+            onClick={() => void handleSubmit()}
+            disabled={inputValue.trim() === ''}
+          >
+            Submit
+          </Button>
+        </Box>
+      )}
+
+      {currentMode === 'type' && phase === 'feedback' && lastResult !== null && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <QuizFeedback
+            result={lastResult.result}
+            correctAnswer={lastResult.correctAnswer}
+            userAnswer={inputValue}
+          />
+          <Button variant="contained" size="large" fullWidth onClick={advance} autoFocus>
+            {wordsCompleted >= sessionGoal ? 'See results' : 'Next word'}
+          </Button>
+        </Box>
+      )}
+
+      {/* ── Choice mode ────────────────────────────────────────────────────── */}
+
+      {currentMode === 'choice' && (
+        <>
+          <Box
+            sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}
+            role="group"
+            aria-label={`Choose the ${toLang} translation`}
+          >
+            {options.map((option, index) => {
+              const optionState = getOptionState(index, correctIndex, selectedIndex)
+              const isSelected = index === selectedIndex
+              const isCorrectOption = index === correctIndex
+
+              return (
+                <Button
+                  key={`${option}-${index}`}
+                  variant="outlined"
+                  fullWidth
+                  disabled={isChoiceAnswered}
+                  onClick={() => handleSelect(index)}
+                  sx={getOptionSx(optionState)}
+                  aria-label={`Option ${index + 1}: ${option}`}
+                  aria-pressed={isSelected}
+                  aria-describedby={
+                    isChoiceAnswered && isCorrectOption ? 'correct-answer-label' : undefined
+                  }
+                  startIcon={
+                    isChoiceAnswered && optionState === 'correct' ? <CheckCircleOutlineIcon /> :
+                    isChoiceAnswered && optionState === 'incorrect' ? <CancelOutlinedIcon /> :
+                    isChoiceAnswered && optionState === 'reveal' ? <CheckCircleOutlineIcon /> :
+                    null
+                  }
+                >
+                  {option}
+                </Button>
+              )
+            })}
+          </Box>
+
+          {isChoiceAnswered && (
+            <>
+              <Box role="status" aria-live="polite" sx={{ textAlign: 'center' }}>
+                {lastChoiceCorrect === true ? (
+                  <Typography variant="h6" color="success.main" fontWeight={700}>Correct!</Typography>
+                ) : (
+                  <Typography variant="h6" color="error.main" fontWeight={700}>Incorrect</Typography>
+                )}
+              </Box>
+              <Button variant="contained" size="large" fullWidth onClick={advance} autoFocus>
+                {wordsCompleted >= sessionGoal ? 'See results' : 'Next word'}
+              </Button>
+            </>
+          )}
+        </>
+      )}
+
+      {/* End session */}
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Button
+          variant="text"
+          size="small"
+          color="inherit"
+          onClick={endSession}
+          sx={{ color: 'text.disabled', fontSize: '0.75rem' }}
+        >
+          End session
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/features/quiz/components/MixedQuizScreen.tsx
+++ b/src/features/quiz/components/MixedQuizScreen.tsx
@@ -1,0 +1,473 @@
+/**
+ * MixedQuizScreen - renders the appropriate quiz UI for each question in a mixed session.
+ *
+ * For each word, the session hook determines whether to use type or choice mode.
+ * This component renders inline type-input or choice-buttons accordingly, using the
+ * same shared structural elements (SessionProgress, word card) so there is no
+ * jarring layout shift when the mode changes between questions.
+ */
+
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  KeyboardEvent,
+} from 'react'
+import {
+  Box,
+  Button,
+  Paper,
+  TextField,
+  Typography,
+  Chip,
+} from '@mui/material'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined'
+import type { LanguagePair, UserSettings } from '@/types'
+import { useMixedQuizSession } from '../useMixedQuizSession'
+import { SessionProgress } from './SessionProgress'
+import { QuizFeedback } from './QuizFeedback'
+
+interface MixedQuizScreenProps {
+  readonly pair: LanguagePair | null
+  readonly settings: UserSettings
+  /**
+   * Fraction of questions that should be type mode (0–1). Default 0.5.
+   * Derived from settings but passed separately so callers can override.
+   */
+  readonly typeRatio?: number
+  /** Called when the session ends (goal reached or manual end). */
+  readonly onSessionEnd?: () => void
+}
+
+// ─── Option button styling (mirrors ChoiceQuizScreen) ─────────────────────────
+
+type OptionState = 'default' | 'correct' | 'incorrect' | 'reveal'
+
+function getOptionState(
+  index: number,
+  correctIndex: number,
+  selectedIndex: number,
+): OptionState {
+  if (selectedIndex === -1) return 'default'
+  if (index === selectedIndex && index === correctIndex) return 'correct'
+  if (index === selectedIndex && index !== correctIndex) return 'incorrect'
+  if (index === correctIndex && selectedIndex !== correctIndex) return 'reveal'
+  return 'default'
+}
+
+function getOptionSx(state: OptionState) {
+  const base = {
+    justifyContent: 'flex-start',
+    textAlign: 'left' as const,
+    minHeight: 56,
+    px: 2,
+    py: 1.5,
+    fontWeight: 600,
+    fontSize: '1rem',
+    borderRadius: 2,
+    transition: 'background-color 0.2s, border-color 0.2s',
+    wordBreak: 'break-word' as const,
+  }
+
+  switch (state) {
+    case 'correct':
+      return {
+        ...base,
+        borderColor: 'success.main',
+        '&.Mui-disabled': {
+          color: 'success.contrastText',
+          backgroundColor: 'success.main',
+          borderColor: 'success.main',
+          opacity: 1,
+        },
+      }
+    case 'incorrect':
+      return {
+        ...base,
+        borderColor: 'error.main',
+        '&.Mui-disabled': {
+          color: 'error.main',
+          borderColor: 'error.main',
+          opacity: 1,
+        },
+      }
+    case 'reveal':
+      return {
+        ...base,
+        borderColor: 'success.main',
+        '&.Mui-disabled': {
+          color: 'success.main',
+          borderColor: 'success.main',
+          opacity: 1,
+        },
+      }
+    default:
+      return base
+  }
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function MixedQuizScreen({
+  pair,
+  settings,
+  typeRatio = 0.5,
+  onSessionEnd,
+}: MixedQuizScreenProps) {
+  const {
+    state,
+    submitAnswer,
+    selectOption,
+    advance,
+    endSession,
+    restart,
+  } = useMixedQuizSession(pair, settings, typeRatio)
+
+  const [inputValue, setInputValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const {
+    phase,
+    currentWord,
+    direction,
+    currentMode,
+    options,
+    correctIndex,
+    selectedIndex,
+    lastResult,
+    lastChoiceCorrect,
+    wordsCompleted,
+    sessionGoal,
+    correctCount,
+    error,
+  } = state
+
+  // Auto-focus input when a type-mode question is shown.
+  useEffect(() => {
+    if (phase === 'question' && currentMode === 'type' && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [phase, currentWord, currentMode])
+
+  // Clear input when a new question loads.
+  useEffect(() => {
+    if (phase === 'question') {
+      setInputValue('')
+    }
+  }, [phase, currentWord])
+
+  const handleSubmit = useCallback(async (): Promise<void> => {
+    if (inputValue.trim() === '') return
+    await submitAnswer(inputValue)
+  }, [inputValue, submitAnswer])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>): void => {
+      if (e.key === 'Enter') {
+        void handleSubmit()
+      }
+    },
+    [handleSubmit],
+  )
+
+  const handleSelect = useCallback(
+    (index: number): void => {
+      void selectOption(index)
+    },
+    [selectOption],
+  )
+
+  const handleAdvance = useCallback((): void => {
+    advance()
+  }, [advance])
+
+  const handleEndSession = useCallback((): void => {
+    endSession()
+    onSessionEnd?.()
+  }, [endSession, onSessionEnd])
+
+  // ─── No pair selected ──────────────────────────────────────────────────────
+
+  if (pair === null) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="h6" color="text.secondary">
+          Select a language pair to start quizzing.
+        </Typography>
+      </Box>
+    )
+  }
+
+  // ─── Loading ────────────────────────────────────────────────────────────────
+
+  if (phase === 'loading') {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="body1" color="text.secondary">
+          Loading words...
+        </Typography>
+      </Box>
+    )
+  }
+
+  // ─── Error ──────────────────────────────────────────────────────────────────
+
+  if (phase === 'finished' && error !== null) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="h6" color="error.main" gutterBottom>
+          Something went wrong
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          {error}
+        </Typography>
+        <Button variant="contained" onClick={restart}>
+          Try again
+        </Button>
+      </Box>
+    )
+  }
+
+  // ─── Session finished — handled by parent (QuizHub) ───────────────────────
+  // When phase is 'finished', parent should swap to SessionSummary.
+  // But as a fallback render a simple completion view.
+
+  if (phase === 'finished') {
+    const accuracy =
+      wordsCompleted > 0 ? Math.round((correctCount / wordsCompleted) * 100) : 0
+
+    return (
+      <Box sx={{ textAlign: 'center', py: 6 }}>
+        <Typography variant="h5" fontWeight={700} gutterBottom>
+          Session complete!
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 1 }}>
+          You reviewed <strong>{wordsCompleted}</strong>{' '}
+          word{wordsCompleted !== 1 ? 's' : ''}.
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+          Accuracy: <strong>{accuracy}%</strong> ({correctCount} / {wordsCompleted} correct)
+        </Typography>
+        <Button variant="contained" size="large" onClick={restart}>
+          Start new session
+        </Button>
+      </Box>
+    )
+  }
+
+  // ─── Direction indicator ─────────────────────────────────────────────────
+
+  const fromLang =
+    direction === 'source-to-target' ? pair.sourceLang : pair.targetLang
+  const toLang =
+    direction === 'source-to-target' ? pair.targetLang : pair.sourceLang
+  const questionText =
+    direction === 'source-to-target'
+      ? currentWord?.source ?? ''
+      : currentWord?.target ?? ''
+
+  const isChoiceAnswered = currentMode === 'choice' && selectedIndex !== -1
+
+  // ─── Quiz UI ──────────────────────────────────────────────────────────────
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      {/* Progress bar */}
+      <SessionProgress
+        completed={wordsCompleted}
+        total={sessionGoal}
+        correct={correctCount}
+      />
+
+      {/* Direction chip + mode indicator */}
+      <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1 }}>
+        <Chip
+          label={`${fromLang} → ${toLang}`}
+          size="small"
+          variant="outlined"
+          sx={{ fontWeight: 600 }}
+          aria-label={`Translating from ${fromLang} to ${toLang}`}
+        />
+        <Chip
+          label={currentMode === 'type' ? 'Type' : 'Choice'}
+          size="small"
+          color="primary"
+          variant="outlined"
+          sx={{ fontWeight: 600 }}
+          aria-label={`Quiz mode: ${currentMode}`}
+        />
+      </Box>
+
+      {/* Word card */}
+      <Paper
+        elevation={2}
+        sx={{ p: 4, textAlign: 'center', borderRadius: 3 }}
+      >
+        <Typography
+          variant="h4"
+          component="p"
+          fontWeight={700}
+          sx={{ wordBreak: 'break-word' }}
+          aria-label={`Translate: ${questionText}`}
+        >
+          {questionText}
+        </Typography>
+        {currentWord?.notes != null && currentWord.notes !== '' && (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ mt: 1, fontStyle: 'italic' }}
+          >
+            {currentWord.notes}
+          </Typography>
+        )}
+      </Paper>
+
+      {/* ── Type mode ────────────────────────────────────────────────────── */}
+
+      {currentMode === 'type' && phase === 'question' && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            inputRef={inputRef}
+            fullWidth
+            label={`Type the ${toLang} translation`}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            autoComplete="off"
+            inputProps={{
+              'aria-label': `Type the ${toLang} translation`,
+              lang:
+                direction === 'source-to-target'
+                  ? pair.targetCode
+                  : pair.sourceCode,
+              autoCorrect: 'off',
+              autoCapitalize: 'none',
+              spellCheck: false,
+            }}
+          />
+          <Button
+            variant="contained"
+            size="large"
+            fullWidth
+            onClick={() => void handleSubmit()}
+            disabled={inputValue.trim() === ''}
+          >
+            Submit
+          </Button>
+        </Box>
+      )}
+
+      {currentMode === 'type' && phase === 'feedback' && lastResult !== null && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <QuizFeedback
+            result={lastResult.result}
+            correctAnswer={lastResult.correctAnswer}
+            userAnswer={inputValue}
+          />
+          <Button
+            variant="contained"
+            size="large"
+            fullWidth
+            onClick={handleAdvance}
+            autoFocus
+          >
+            {wordsCompleted >= sessionGoal ? 'See results' : 'Next word'}
+          </Button>
+        </Box>
+      )}
+
+      {/* ── Choice mode ───────────────────────────────────────────────────── */}
+
+      {currentMode === 'choice' && (
+        <>
+          <Box
+            sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}
+            role="group"
+            aria-label={`Choose the ${toLang} translation`}
+          >
+            {options.map((option, index) => {
+              const optionState = getOptionState(index, correctIndex, selectedIndex)
+              const isSelected = index === selectedIndex
+              const isCorrectOption = index === correctIndex
+
+              return (
+                <Button
+                  key={`${option}-${index}`}
+                  variant="outlined"
+                  fullWidth
+                  disabled={isChoiceAnswered}
+                  onClick={() => handleSelect(index)}
+                  sx={getOptionSx(optionState)}
+                  aria-label={`Option ${index + 1}: ${option}`}
+                  aria-pressed={isSelected}
+                  aria-describedby={
+                    isChoiceAnswered && isCorrectOption
+                      ? 'correct-answer-label'
+                      : undefined
+                  }
+                  startIcon={
+                    isChoiceAnswered && optionState === 'correct' ? (
+                      <CheckCircleOutlineIcon />
+                    ) : isChoiceAnswered && optionState === 'incorrect' ? (
+                      <CancelOutlinedIcon />
+                    ) : isChoiceAnswered && optionState === 'reveal' ? (
+                      <CheckCircleOutlineIcon />
+                    ) : null
+                  }
+                >
+                  {option}
+                </Button>
+              )
+            })}
+          </Box>
+
+          {isChoiceAnswered && (
+            <>
+              <Box
+                role="status"
+                aria-live="polite"
+                sx={{ textAlign: 'center' }}
+              >
+                {lastChoiceCorrect === true ? (
+                  <Typography variant="h6" color="success.main" fontWeight={700}>
+                    Correct!
+                  </Typography>
+                ) : (
+                  <Typography variant="h6" color="error.main" fontWeight={700}>
+                    Incorrect
+                  </Typography>
+                )}
+              </Box>
+
+              <Button
+                variant="contained"
+                size="large"
+                fullWidth
+                onClick={handleAdvance}
+                autoFocus
+              >
+                {wordsCompleted >= sessionGoal ? 'See results' : 'Next word'}
+              </Button>
+            </>
+          )}
+        </>
+      )}
+
+      {/* End session button */}
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Button
+          variant="text"
+          size="small"
+          color="inherit"
+          onClick={handleEndSession}
+          sx={{ color: 'text.disabled', fontSize: '0.75rem' }}
+        >
+          End session
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/features/quiz/components/QuizHub.tsx
+++ b/src/features/quiz/components/QuizHub.tsx
@@ -1,0 +1,124 @@
+/**
+ * QuizHub - the entry point for the quiz feature.
+ *
+ * Manages the pre-quiz mode selection screen, active quiz routing, and
+ * the post-session summary. It persists the user's mode preference and
+ * pulls the current streak from daily stats for the summary screen.
+ *
+ * Hub state machine:
+ *   'select'  → user picks Type / Choice / Mixed
+ *   'active'  → quiz is running
+ *   'summary' → session ended, showing SessionSummary
+ */
+
+import { useState, useCallback, useEffect } from 'react'
+import { Box } from '@mui/material'
+import type { LanguagePair, UserSettings, QuizMode } from '@/types'
+import { useStorage } from '@/hooks/useStorage'
+import { QuizModeSelector } from './QuizModeSelector'
+import { SessionSummary } from './SessionSummary'
+import { ActiveQuizView } from './ActiveQuizView'
+
+interface QuizHubProps {
+  readonly pair: LanguagePair | null
+  readonly settings: UserSettings
+  /** Called when the user changes the quiz mode preference so it can be persisted. */
+  readonly onSettingsChange: (updated: UserSettings) => void
+}
+
+type HubPhase = 'select' | 'active' | 'summary'
+
+interface SessionResult {
+  readonly wordsReviewed: number
+  readonly correctCount: number
+}
+
+export function QuizHub({ pair, settings, onSettingsChange }: QuizHubProps) {
+  const storage = useStorage()
+  const [hubPhase, setHubPhase] = useState<HubPhase>('select')
+  const [selectedMode, setSelectedMode] = useState<QuizMode>(settings.quizMode)
+  const [sessionResult, setSessionResult] = useState<SessionResult>({
+    wordsReviewed: 0,
+    correctCount: 0,
+  })
+  const [streakDays, setStreakDays] = useState(0)
+
+  // Keep local selectedMode in sync when settings.quizMode changes externally.
+  useEffect(() => {
+    setSelectedMode(settings.quizMode)
+  }, [settings.quizMode])
+
+  // Load streak days from recent daily stats.
+  useEffect(() => {
+    void storage.getRecentDailyStats(7).then((stats) => {
+      const latest = stats[stats.length - 1]
+      if (latest !== undefined) {
+        setStreakDays(latest.streakDays)
+      }
+    })
+  }, [storage, hubPhase])
+
+  const handleModeChange = useCallback(
+    (mode: QuizMode): void => {
+      setSelectedMode(mode)
+      const updated: UserSettings = { ...settings, quizMode: mode }
+      onSettingsChange(updated)
+      void storage.saveSettings(updated)
+    },
+    [settings, onSettingsChange, storage],
+  )
+
+  const handleStart = useCallback((): void => {
+    setHubPhase('active')
+  }, [])
+
+  const handleSessionFinished = useCallback(
+    (wordsReviewed: number, correctCount: number): void => {
+      setSessionResult({ wordsReviewed, correctCount })
+      setHubPhase('summary')
+    },
+    [],
+  )
+
+  const handleContinue = useCallback((): void => {
+    setHubPhase('select')
+  }, [])
+
+  const handleGoHome = useCallback((): void => {
+    // Return to mode selector (scoped to the quiz tab).
+    setHubPhase('select')
+  }, [])
+
+  if (hubPhase === 'select') {
+    return (
+      <QuizModeSelector
+        selectedMode={selectedMode}
+        onModeChange={handleModeChange}
+        onStart={handleStart}
+      />
+    )
+  }
+
+  if (hubPhase === 'summary') {
+    return (
+      <SessionSummary
+        wordsReviewed={sessionResult.wordsReviewed}
+        correctCount={sessionResult.correctCount}
+        streakDays={streakDays}
+        onContinue={handleContinue}
+        onGoHome={handleGoHome}
+      />
+    )
+  }
+
+  return (
+    <Box>
+      <ActiveQuizView
+        mode={selectedMode}
+        pair={pair}
+        settings={settings}
+        onSessionFinished={handleSessionFinished}
+      />
+    </Box>
+  )
+}

--- a/src/features/quiz/components/QuizModeSelector.test.tsx
+++ b/src/features/quiz/components/QuizModeSelector.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests for QuizModeSelector component.
+ *
+ * Covers:
+ * - Renders all three modes
+ * - Highlights the currently selected mode
+ * - Calls onModeChange when user picks a mode
+ * - Calls onStart when user clicks Start quiz
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider, createTheme } from '@mui/material'
+import { QuizModeSelector } from './QuizModeSelector'
+import type { QuizMode } from '@/types'
+
+function renderSelector(
+  selectedMode: QuizMode = 'type',
+  onModeChange = vi.fn(),
+  onStart = vi.fn(),
+) {
+  return render(
+    <ThemeProvider theme={createTheme()}>
+      <QuizModeSelector
+        selectedMode={selectedMode}
+        onModeChange={onModeChange}
+        onStart={onStart}
+      />
+    </ThemeProvider>,
+  )
+}
+
+describe('QuizModeSelector', () => {
+  it('should render all three mode options', () => {
+    renderSelector()
+    expect(screen.getByText('Type')).toBeInTheDocument()
+    expect(screen.getByText('Choice')).toBeInTheDocument()
+    expect(screen.getByText('Mixed')).toBeInTheDocument()
+  })
+
+  it('should render mode descriptions', () => {
+    renderSelector()
+    expect(screen.getByText('Type the translation yourself')).toBeInTheDocument()
+    expect(screen.getByText('Pick from four options')).toBeInTheDocument()
+    expect(screen.getByText('Alternates type and choice')).toBeInTheDocument()
+  })
+
+  it('should render a Start quiz button', () => {
+    renderSelector()
+    expect(screen.getByRole('button', { name: /start.*quiz/i })).toBeInTheDocument()
+  })
+
+  it('should call onStart when Start quiz is clicked', async () => {
+    const onStart = vi.fn()
+    renderSelector('type', vi.fn(), onStart)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /start.*quiz/i }))
+    expect(onStart).toHaveBeenCalledOnce()
+  })
+
+  it('should call onModeChange with "choice" when Choice is clicked', async () => {
+    const onModeChange = vi.fn()
+    renderSelector('type', onModeChange)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('radio', { name: /choice mode/i }))
+    expect(onModeChange).toHaveBeenCalledWith('choice')
+  })
+
+  it('should call onModeChange with "mixed" when Mixed is clicked', async () => {
+    const onModeChange = vi.fn()
+    renderSelector('type', onModeChange)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('radio', { name: /mixed mode/i }))
+    expect(onModeChange).toHaveBeenCalledWith('mixed')
+  })
+
+  it('should call onModeChange with "type" when Type is clicked', async () => {
+    const onModeChange = vi.fn()
+    renderSelector('choice', onModeChange)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('radio', { name: /type mode/i }))
+    expect(onModeChange).toHaveBeenCalledWith('type')
+  })
+
+  it('should mark the selected mode as aria-checked', () => {
+    renderSelector('mixed')
+    const mixedOption = screen.getByRole('radio', { name: /mixed mode/i })
+    expect(mixedOption).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('should not mark unselected modes as aria-checked', () => {
+    renderSelector('mixed')
+    const typeOption = screen.getByRole('radio', { name: /type mode/i })
+    const choiceOption = screen.getByRole('radio', { name: /choice mode/i })
+    expect(typeOption).toHaveAttribute('aria-checked', 'false')
+    expect(choiceOption).toHaveAttribute('aria-checked', 'false')
+  })
+})

--- a/src/features/quiz/components/QuizModeSelector.tsx
+++ b/src/features/quiz/components/QuizModeSelector.tsx
@@ -1,0 +1,163 @@
+/**
+ * QuizModeSelector - allows the user to pick a quiz mode before starting.
+ *
+ * Displays three mode cards: Type, Choice, and Mixed.
+ * The selected mode is persisted to user settings via the provided callback.
+ * This component is shown before the quiz begins (not during an active quiz).
+ */
+
+import { useCallback } from 'react'
+import {
+  Box,
+  Button,
+  Card,
+  CardActionArea,
+  CardContent,
+  Typography,
+} from '@mui/material'
+import KeyboardIcon from '@mui/icons-material/Keyboard'
+import CheckBoxOutlinedIcon from '@mui/icons-material/CheckBoxOutlined'
+import ShuffleIcon from '@mui/icons-material/Shuffle'
+import type { QuizMode } from '@/types'
+
+// ─── Mode descriptors ─────────────────────────────────────────────────────────
+
+interface ModeDescriptor {
+  readonly mode: QuizMode
+  readonly label: string
+  readonly description: string
+  readonly icon: React.ReactNode
+}
+
+const MODE_DESCRIPTORS: readonly ModeDescriptor[] = [
+  {
+    mode: 'type',
+    label: 'Type',
+    description: 'Type the translation yourself',
+    icon: <KeyboardIcon />,
+  },
+  {
+    mode: 'choice',
+    label: 'Choice',
+    description: 'Pick from four options',
+    icon: <CheckBoxOutlinedIcon />,
+  },
+  {
+    mode: 'mixed',
+    label: 'Mixed',
+    description: 'Alternates type and choice',
+    icon: <ShuffleIcon />,
+  },
+]
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface QuizModeSelectorProps {
+  /** Currently selected mode. */
+  readonly selectedMode: QuizMode
+  /** Called whenever the user picks a different mode. */
+  readonly onModeChange: (mode: QuizMode) => void
+  /** Called when the user is ready to start the session. */
+  readonly onStart: () => void
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function QuizModeSelector({
+  selectedMode,
+  onModeChange,
+  onStart,
+}: QuizModeSelectorProps) {
+  const handleSelect = useCallback(
+    (mode: QuizMode): void => {
+      onModeChange(mode)
+    },
+    [onModeChange],
+  )
+
+  return (
+    <Box
+      sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+      role="region"
+      aria-label="Quiz mode selection"
+    >
+      <Typography variant="h6" fontWeight={700} textAlign="center">
+        Choose your quiz mode
+      </Typography>
+
+      <Box
+        sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}
+        role="radiogroup"
+        aria-label="Quiz modes"
+      >
+        {MODE_DESCRIPTORS.map(({ mode, label, description, icon }) => {
+          const isSelected = selectedMode === mode
+
+          return (
+            <Card
+              key={mode}
+              variant="outlined"
+              sx={{
+                borderColor: isSelected ? 'primary.main' : 'divider',
+                borderWidth: isSelected ? 2 : 1,
+                transition: 'border-color 0.15s, box-shadow 0.15s',
+                boxShadow: isSelected ? 2 : 0,
+              }}
+            >
+              <CardActionArea
+                onClick={() => handleSelect(mode)}
+                aria-pressed={isSelected}
+                role="radio"
+                aria-checked={isSelected}
+                aria-label={`${label} mode: ${description}`}
+              >
+                <CardContent
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 2,
+                    py: 2,
+                  }}
+                >
+                  <Box
+                    sx={{
+                      color: isSelected ? 'primary.main' : 'text.secondary',
+                      display: 'flex',
+                      alignItems: 'center',
+                      fontSize: 28,
+                    }}
+                    aria-hidden="true"
+                  >
+                    {icon}
+                  </Box>
+                  <Box sx={{ flex: 1 }}>
+                    <Typography
+                      variant="subtitle1"
+                      fontWeight={isSelected ? 700 : 500}
+                      color={isSelected ? 'primary.main' : 'text.primary'}
+                    >
+                      {label}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {description}
+                    </Typography>
+                  </Box>
+                </CardContent>
+              </CardActionArea>
+            </Card>
+          )
+        })}
+      </Box>
+
+      <Button
+        variant="contained"
+        size="large"
+        fullWidth
+        onClick={onStart}
+        aria-label={`Start ${selectedMode} mode quiz`}
+      >
+        Start quiz
+      </Button>
+    </Box>
+  )
+}

--- a/src/features/quiz/components/SessionSummary.test.tsx
+++ b/src/features/quiz/components/SessionSummary.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Tests for SessionSummary component.
+ *
+ * Covers:
+ * - Displays words reviewed count
+ * - Displays correct / incorrect breakdown
+ * - Calculates and displays accuracy percentage
+ * - Shows streak info when streakDays > 0
+ * - Does not show streak info when streakDays === 0
+ * - Calls onContinue when "Start new session" is clicked
+ * - Calls onGoHome when "Back to dashboard" is clicked
+ * - Shows an encouraging message appropriate to accuracy
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider, createTheme } from '@mui/material'
+import { SessionSummary } from './SessionSummary'
+
+function renderSummary(
+  wordsReviewed = 10,
+  correctCount = 8,
+  streakDays = 0,
+  onContinue = vi.fn(),
+  onGoHome = vi.fn(),
+) {
+  return render(
+    <ThemeProvider theme={createTheme()}>
+      <SessionSummary
+        wordsReviewed={wordsReviewed}
+        correctCount={correctCount}
+        streakDays={streakDays}
+        onContinue={onContinue}
+        onGoHome={onGoHome}
+      />
+    </ThemeProvider>,
+  )
+}
+
+describe('SessionSummary', () => {
+  it('should show Session complete heading', () => {
+    renderSummary()
+    expect(screen.getByText('Session complete!')).toBeInTheDocument()
+  })
+
+  it('should display words reviewed count', () => {
+    renderSummary(15, 12)
+    expect(screen.getByLabelText('15 words reviewed')).toBeInTheDocument()
+  })
+
+  it('should display accuracy percentage', () => {
+    // 8/10 = 80%
+    renderSummary(10, 8)
+    expect(screen.getByLabelText('80% accuracy')).toBeInTheDocument()
+  })
+
+  it('should display correct count', () => {
+    renderSummary(10, 8)
+    expect(screen.getByLabelText('8 correct')).toBeInTheDocument()
+  })
+
+  it('should display incorrect count', () => {
+    // 10 - 8 = 2 incorrect
+    renderSummary(10, 8)
+    expect(screen.getByLabelText('2 incorrect')).toBeInTheDocument()
+  })
+
+  it('should show 0% accuracy when wordsReviewed is 0', () => {
+    renderSummary(0, 0)
+    expect(screen.getByLabelText('0% accuracy')).toBeInTheDocument()
+  })
+
+  it('should show streak info when streakDays > 0', () => {
+    renderSummary(10, 8, 5)
+    expect(screen.getByText(/5 day streak/i)).toBeInTheDocument()
+  })
+
+  it('should not show streak info when streakDays === 0', () => {
+    renderSummary(10, 8, 0)
+    expect(screen.queryByText(/day streak/i)).not.toBeInTheDocument()
+  })
+
+  it('should call onContinue when "Start new session" is clicked', async () => {
+    const onContinue = vi.fn()
+    renderSummary(10, 8, 0, onContinue)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /start new session/i }))
+    expect(onContinue).toHaveBeenCalledOnce()
+  })
+
+  it('should call onGoHome when "Back to dashboard" is clicked', async () => {
+    const onGoHome = vi.fn()
+    renderSummary(10, 8, 0, vi.fn(), onGoHome)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /back to dashboard/i }))
+    expect(onGoHome).toHaveBeenCalledOnce()
+  })
+
+  it('should show outstanding message for >= 90% accuracy', () => {
+    renderSummary(10, 9)  // 90%
+    expect(screen.getByText(/outstanding/i)).toBeInTheDocument()
+  })
+
+  it('should show great job message for >= 75% accuracy', () => {
+    renderSummary(10, 8)  // 80%
+    expect(screen.getByText(/great job/i)).toBeInTheDocument()
+  })
+
+  it('should show good effort message for >= 50% accuracy', () => {
+    renderSummary(10, 6)  // 60%
+    expect(screen.getByText(/good effort/i)).toBeInTheDocument()
+  })
+
+  it('should show keep going message for < 50% accuracy', () => {
+    renderSummary(10, 4)  // 40%
+    expect(screen.getByText(/keep going/i)).toBeInTheDocument()
+  })
+})

--- a/src/features/quiz/components/SessionSummary.tsx
+++ b/src/features/quiz/components/SessionSummary.tsx
@@ -1,0 +1,207 @@
+/**
+ * SessionSummary - displayed when a quiz session ends.
+ *
+ * Shows words reviewed, accuracy, streak info, and an encouraging message.
+ * Provides options to start a new session or return to the dashboard (home).
+ */
+
+import { Box, Button, Paper, Typography, Divider } from '@mui/material'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import EmojiEventsOutlinedIcon from '@mui/icons-material/EmojiEventsOutlined'
+
+interface SessionSummaryProps {
+  /** Total words reviewed in this session. */
+  readonly wordsReviewed: number
+  /** Total correct answers. */
+  readonly correctCount: number
+  /** Current streak in days (consecutive days meeting the daily goal). */
+  readonly streakDays: number
+  /** Called when user wants to start another session. */
+  readonly onContinue: () => void
+  /** Called when user wants to go back to the dashboard / home view. */
+  readonly onGoHome: () => void
+}
+
+// ─── Encouraging messages ─────────────────────────────────────────────────────
+
+function getEncouragingMessage(accuracy: number, wordsReviewed: number): string {
+  if (wordsReviewed === 0) return 'Ready to start? Let\'s go!'
+  if (accuracy >= 90) return 'Outstanding work! You\'re on fire!'
+  if (accuracy >= 75) return 'Great job! Keep it up!'
+  if (accuracy >= 50) return 'Good effort! Practice makes perfect.'
+  return 'Keep going — every review builds your memory!'
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function SessionSummary({
+  wordsReviewed,
+  correctCount,
+  streakDays,
+  onContinue,
+  onGoHome,
+}: SessionSummaryProps) {
+  const incorrectCount = wordsReviewed - correctCount
+  const accuracy =
+    wordsReviewed > 0 ? Math.round((correctCount / wordsReviewed) * 100) : 0
+  const message = getEncouragingMessage(accuracy, wordsReviewed)
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 3,
+        py: 4,
+      }}
+      role="region"
+      aria-label="Session summary"
+    >
+      {/* Encouraging header */}
+      <Box sx={{ textAlign: 'center' }}>
+        <CheckCircleOutlineIcon
+          sx={{ fontSize: 56, color: 'success.main', mb: 1 }}
+          aria-hidden="true"
+        />
+        <Typography variant="h5" fontWeight={700} gutterBottom>
+          Session complete!
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          {message}
+        </Typography>
+      </Box>
+
+      {/* Stats card */}
+      <Paper
+        elevation={2}
+        sx={{ width: '100%', borderRadius: 3, overflow: 'hidden' }}
+      >
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            textAlign: 'center',
+          }}
+        >
+          <Box sx={{ p: 3 }}>
+            <Typography
+              variant="h4"
+              fontWeight={700}
+              color="primary.main"
+              aria-label={`${wordsReviewed} words reviewed`}
+            >
+              {wordsReviewed}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Words reviewed
+            </Typography>
+          </Box>
+
+          <Box
+            sx={{
+              p: 3,
+              borderLeft: 1,
+              borderColor: 'divider',
+            }}
+          >
+            <Typography
+              variant="h4"
+              fontWeight={700}
+              color="primary.main"
+              aria-label={`${accuracy}% accuracy`}
+            >
+              {accuracy}%
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Accuracy
+            </Typography>
+          </Box>
+        </Box>
+
+        <Divider />
+
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            textAlign: 'center',
+          }}
+        >
+          <Box sx={{ p: 2 }}>
+            <Typography
+              variant="h5"
+              fontWeight={600}
+              color="success.main"
+              aria-label={`${correctCount} correct`}
+            >
+              {correctCount}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Correct
+            </Typography>
+          </Box>
+
+          <Box
+            sx={{
+              p: 2,
+              borderLeft: 1,
+              borderColor: 'divider',
+            }}
+          >
+            <Typography
+              variant="h5"
+              fontWeight={600}
+              color={incorrectCount > 0 ? 'error.main' : 'text.secondary'}
+              aria-label={`${incorrectCount} incorrect`}
+            >
+              {incorrectCount}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Incorrect
+            </Typography>
+          </Box>
+        </Box>
+      </Paper>
+
+      {/* Streak info */}
+      {streakDays > 0 && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            color: 'warning.main',
+          }}
+          role="status"
+          aria-label={`${streakDays} day streak`}
+        >
+          <EmojiEventsOutlinedIcon aria-hidden="true" />
+          <Typography variant="body2" fontWeight={600}>
+            {streakDays} day streak — keep it going!
+          </Typography>
+        </Box>
+      )}
+
+      {/* Action buttons */}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, width: '100%' }}>
+        <Button
+          variant="contained"
+          size="large"
+          fullWidth
+          onClick={onContinue}
+        >
+          Start new session
+        </Button>
+        <Button
+          variant="outlined"
+          size="large"
+          fullWidth
+          onClick={onGoHome}
+        >
+          Back to dashboard
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/features/quiz/components/TypeQuizContent.tsx
+++ b/src/features/quiz/components/TypeQuizContent.tsx
@@ -1,0 +1,197 @@
+/**
+ * TypeQuizContent - renders the type-mode quiz UI.
+ *
+ * Unlike QuizScreen (which is self-contained with its own hook and finished state),
+ * this component accepts an already-running session and does not render its own
+ * finished state — the parent (ActiveQuizView → QuizHub) handles that transition.
+ */
+
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  KeyboardEvent,
+} from 'react'
+import {
+  Box,
+  Button,
+  Paper,
+  TextField,
+  Typography,
+  Chip,
+} from '@mui/material'
+import type { LanguagePair, UserSettings } from '@/types'
+import type { UseQuizSessionResult } from '../useQuizSession'
+import { SessionProgress } from './SessionProgress'
+import { QuizFeedback } from './QuizFeedback'
+
+interface TypeQuizContentProps {
+  readonly session: UseQuizSessionResult
+  readonly pair: LanguagePair | null
+  readonly settings: UserSettings
+}
+
+export function TypeQuizContent({ session, pair, settings }: TypeQuizContentProps) {
+  // settings is reserved for future use (e.g. showing typo tolerance hint)
+  void settings
+
+  const { state, submitAnswer, advance, endSession } = session
+  const {
+    phase,
+    currentWord,
+    direction,
+    lastResult,
+    wordsCompleted,
+    sessionGoal,
+    correctCount,
+    error,
+  } = state
+
+  const [inputValue, setInputValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (phase === 'question' && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [phase, currentWord])
+
+  useEffect(() => {
+    if (phase === 'question') {
+      setInputValue('')
+    }
+  }, [phase, currentWord])
+
+  const handleSubmit = useCallback(async (): Promise<void> => {
+    if (inputValue.trim() === '') return
+    await submitAnswer(inputValue)
+  }, [inputValue, submitAnswer])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>): void => {
+      if (e.key === 'Enter') {
+        void handleSubmit()
+      }
+    },
+    [handleSubmit],
+  )
+
+  if (pair === null) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="h6" color="text.secondary">
+          Select a language pair to start quizzing.
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (phase === 'loading') {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="body1" color="text.secondary">Loading words...</Typography>
+      </Box>
+    )
+  }
+
+  if (phase === 'finished' && error !== null) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Typography variant="h6" color="error.main" gutterBottom>Something went wrong</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>{error}</Typography>
+      </Box>
+    )
+  }
+
+  // Phase 'finished' without error: parent takes over, render nothing.
+  if (phase === 'finished') return null
+
+  const fromLang = direction === 'source-to-target' ? pair.sourceLang : pair.targetLang
+  const toLang = direction === 'source-to-target' ? pair.targetLang : pair.sourceLang
+  const questionText =
+    direction === 'source-to-target' ? currentWord?.source ?? '' : currentWord?.target ?? ''
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <SessionProgress completed={wordsCompleted} total={sessionGoal} correct={correctCount} />
+
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Chip
+          label={`${fromLang} → ${toLang}`}
+          size="small"
+          variant="outlined"
+          sx={{ fontWeight: 600 }}
+          aria-label={`Translating from ${fromLang} to ${toLang}`}
+        />
+      </Box>
+
+      <Paper elevation={2} sx={{ p: 4, textAlign: 'center', borderRadius: 3 }}>
+        <Typography
+          variant="h4"
+          component="p"
+          fontWeight={700}
+          sx={{ wordBreak: 'break-word' }}
+          aria-label={`Translate: ${questionText}`}
+        >
+          {questionText}
+        </Typography>
+      </Paper>
+
+      {phase === 'question' && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            inputRef={inputRef}
+            fullWidth
+            label={`Type the ${toLang} translation`}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            autoComplete="off"
+            inputProps={{
+              'aria-label': `Type the ${toLang} translation`,
+              lang: direction === 'source-to-target' ? pair.targetCode : pair.sourceCode,
+              autoCorrect: 'off',
+              autoCapitalize: 'none',
+              spellCheck: false,
+            }}
+          />
+          <Button
+            variant="contained"
+            size="large"
+            fullWidth
+            onClick={() => void handleSubmit()}
+            disabled={inputValue.trim() === ''}
+          >
+            Submit
+          </Button>
+        </Box>
+      )}
+
+      {phase === 'feedback' && lastResult !== null && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <QuizFeedback
+            result={lastResult.result}
+            correctAnswer={lastResult.correctAnswer}
+            userAnswer={inputValue}
+          />
+          <Button variant="contained" size="large" fullWidth onClick={advance} autoFocus>
+            {wordsCompleted >= sessionGoal ? 'See results' : 'Next word'}
+          </Button>
+        </Box>
+      )}
+
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Button
+          variant="text"
+          size="small"
+          color="inherit"
+          onClick={endSession}
+          sx={{ color: 'text.disabled', fontSize: '0.75rem' }}
+        >
+          End session
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/features/quiz/index.ts
+++ b/src/features/quiz/index.ts
@@ -1,5 +1,9 @@
 export { QuizScreen } from './components/QuizScreen'
 export { ChoiceQuizScreen } from './components/ChoiceQuizScreen'
+export { MixedQuizScreen } from './components/MixedQuizScreen'
+export { QuizHub } from './components/QuizHub'
+export { SessionSummary } from './components/SessionSummary'
+export { QuizModeSelector } from './components/QuizModeSelector'
 export { useQuizSession } from './useQuizSession'
 export type { QuizSessionState, SessionPhase, UseQuizSessionResult } from './useQuizSession'
 export { useChoiceQuizSession } from './useChoiceQuizSession'
@@ -8,3 +12,11 @@ export type {
   ChoiceSessionPhase,
   UseChoiceQuizSessionResult,
 } from './useChoiceQuizSession'
+export { useMixedQuizSession } from './useMixedQuizSession'
+export type {
+  MixedQuizSessionState,
+  MixedSessionPhase,
+  ActiveQuizMode,
+  UseMixedQuizSessionResult,
+} from './useMixedQuizSession'
+export { selectModeForWord, MAX_CONSECUTIVE_SAME_MODE } from './useMixedQuizSession'

--- a/src/features/quiz/useMixedQuizSession.test.ts
+++ b/src/features/quiz/useMixedQuizSession.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Tests for useMixedQuizSession hook and selectModeForWord utility.
+ *
+ * Covers:
+ * - Mode alternation respects the type ratio
+ * - No more than MAX_CONSECUTIVE_SAME_MODE questions in the same mode
+ * - Session summary calculations (wordsCompleted, correctCount)
+ * - Confidence heuristic nudges low-confidence words toward choice
+ * - Both submitAnswer (type mode) and selectOption (choice mode)
+ * - Session lifecycle: loading → question → feedback → finished
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { createElement } from 'react'
+import { StorageContext } from '@/hooks/useStorage'
+import type { StorageService } from '@/services/storage/StorageService'
+import type { Word, LanguagePair, UserSettings, WordProgress } from '@/types'
+import {
+  useMixedQuizSession,
+  selectModeForWord,
+  MAX_CONSECUTIVE_SAME_MODE,
+} from './useMixedQuizSession'
+import type { ActiveQuizMode } from './useMixedQuizSession'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@/services/spacedRepetition', () => ({
+  getNextWords: vi.fn(),
+  recordAttempt: vi.fn(),
+}))
+
+vi.mock('@/utils/distractorGenerator', () => ({
+  generateDistractors: vi.fn(),
+  MIN_WORDS_FOR_CHOICE: 4,
+}))
+
+import { getNextWords, recordAttempt } from '@/services/spacedRepetition'
+import { generateDistractors } from '@/utils/distractorGenerator'
+const mockGetNextWords = vi.mocked(getNextWords)
+const mockRecordAttempt = vi.mocked(recordAttempt)
+const mockGenerateDistractors = vi.mocked(generateDistractors)
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const mockPair: LanguagePair = {
+  id: 'pair-1',
+  sourceLang: 'Latvian',
+  targetLang: 'English',
+  sourceCode: 'lv',
+  targetCode: 'en',
+  createdAt: 1000,
+}
+
+function makeWord(id: string, source: string, target: string): Word {
+  return {
+    id,
+    pairId: 'pair-1',
+    source,
+    target,
+    notes: null,
+    tags: [],
+    createdAt: 1000,
+    isFromPack: false,
+  }
+}
+
+const mockSettings: UserSettings = {
+  activePairId: 'pair-1',
+  quizMode: 'mixed',
+  dailyGoal: 3,
+  theme: 'dark',
+  typoTolerance: 1,
+}
+
+const mockProgress: WordProgress = {
+  wordId: 'w1',
+  correctCount: 0,
+  incorrectCount: 0,
+  streak: 0,
+  lastReviewed: null,
+  nextReview: 0,
+  confidence: 0,
+  history: [],
+}
+
+const mockDistr = {
+  options: ['house', 'cat', 'dog', 'bird'],
+  correctIndex: 0,
+}
+
+function makeMockStorage(words: Word[] = []): StorageService {
+  return {
+    getLanguagePairs: vi.fn(),
+    getLanguagePair: vi.fn(),
+    saveLanguagePair: vi.fn(),
+    deleteLanguagePair: vi.fn(),
+    getWords: vi.fn().mockResolvedValue(words),
+    getWord: vi.fn(),
+    saveWord: vi.fn(),
+    saveWords: vi.fn(),
+    deleteWord: vi.fn(),
+    getWordProgress: vi.fn(),
+    getAllProgress: vi.fn(),
+    saveWordProgress: vi.fn(),
+    getSettings: vi.fn().mockResolvedValue(mockSettings),
+    saveSettings: vi.fn(),
+    getDailyStats: vi.fn().mockResolvedValue(null),
+    getDailyStatsRange: vi.fn().mockResolvedValue([]),
+    saveDailyStats: vi.fn(),
+    getRecentDailyStats: vi.fn().mockResolvedValue([]),
+    exportAll: vi.fn(),
+    importAll: vi.fn(),
+    clearAll: vi.fn(),
+  }
+}
+
+function makeWrapper(storage: StorageService) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(StorageContext.Provider, { value: storage }, children)
+}
+
+// ─── selectModeForWord unit tests ─────────────────────────────────────────────
+
+describe('selectModeForWord', () => {
+  it('should always return type when choiceAvailable is false', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(selectModeForWord(0.5, [], 0.5, false)).toBe('type')
+    }
+  })
+
+  it('should return type when typeRatio is 1.0', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(selectModeForWord(1.0, [], 0.5, true)).toBe('type')
+    }
+  })
+
+  it('should return choice when typeRatio is 0.0', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(selectModeForWord(0.0, [], 0.5, true)).toBe('choice')
+    }
+  })
+
+  it('should force switch after MAX_CONSECUTIVE_SAME_MODE type questions', () => {
+    const recentModes: ActiveQuizMode[] = Array(MAX_CONSECUTIVE_SAME_MODE).fill('type')
+    // Even with typeRatio 1.0 it should switch to choice
+    expect(selectModeForWord(1.0, recentModes, 0.5, true)).toBe('choice')
+  })
+
+  it('should force switch after MAX_CONSECUTIVE_SAME_MODE choice questions', () => {
+    const recentModes: ActiveQuizMode[] = Array(MAX_CONSECUTIVE_SAME_MODE).fill('choice')
+    // Even with typeRatio 0.0 it should switch to type
+    expect(selectModeForWord(0.0, recentModes, 0.5, true)).toBe('type')
+  })
+
+  it('should not force switch when last N modes are not all the same', () => {
+    // Alternating should never trigger the cap
+    const recentModes: ActiveQuizMode[] = ['type', 'choice', 'type']
+    // With ratio 1.0, should return type (no cap triggered)
+    expect(selectModeForWord(1.0, recentModes, 0.5, true)).toBe('type')
+  })
+
+  it('should reduce type probability for low-confidence words', () => {
+    // With low confidence (< 0.3), the effective type ratio halves.
+    // typeRatio = 1.0 → effectiveRatio = 0.5 (so sometimes choice).
+    // Run many times: with a seeded approach we just check both outcomes possible.
+    // We verify by checking that with typeRatio=1 and confidence=0, we get some choice results.
+    const results = new Set<ActiveQuizMode>()
+    for (let i = 0; i < 100; i++) {
+      results.add(selectModeForWord(1.0, [], 0, true))
+    }
+    // With effective ratio 0.5 we expect both modes to appear over 100 runs.
+    expect(results.has('type')).toBe(true)
+    expect(results.has('choice')).toBe(true)
+  })
+
+  it('should not reduce type probability for high-confidence words', () => {
+    // With high confidence, typeRatio=1.0 should always give type.
+    for (let i = 0; i < 20; i++) {
+      expect(selectModeForWord(1.0, [], 0.9, true)).toBe('type')
+    }
+  })
+})
+
+// ─── useMixedQuizSession integration tests ────────────────────────────────────
+
+describe('useMixedQuizSession', () => {
+  let mockStorage: StorageService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStorage = makeMockStorage()
+  })
+
+  it('should start in loading phase and move to question phase', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    vi.mocked(mockStorage.getWords).mockResolvedValue([word, makeWord('w2', 'a', 'b'), makeWord('w3', 'c', 'd'), makeWord('w4', 'e', 'f')])
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockGenerateDistractors.mockReturnValue(mockDistr)
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useMixedQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    expect(result.current.state.phase).toBe('loading')
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('question')
+    })
+
+    expect(result.current.state.currentWord).toEqual(word)
+  })
+
+  it('should finish immediately if no words available', async () => {
+    vi.mocked(mockStorage.getWords).mockResolvedValue([])
+    mockGetNextWords.mockResolvedValue([])
+
+    const { result } = renderHook(
+      () => useMixedQuizSession(mockPair, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('finished')
+    })
+  })
+
+  it('should accept a typed answer in type mode', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    vi.mocked(mockStorage.getWords).mockResolvedValue([word])
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    // Force type mode by setting typeRatio=1.0
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useMixedQuizSession(mockPair, mockSettings, 1.0),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+    expect(result.current.state.currentMode).toBe('type')
+
+    await act(async () => {
+      await result.current.submitAnswer('house')
+    })
+
+    expect(result.current.state.phase).toBe('feedback')
+    expect(result.current.state.lastResult?.result).toBe('correct')
+    expect(result.current.state.correctCount).toBe(1)
+    expect(result.current.state.wordsCompleted).toBe(1)
+
+    expect(mockRecordAttempt).toHaveBeenCalledWith(
+      mockStorage, 'w1', true, 'source-to-target', 'type',
+    )
+  })
+
+  it('should accept a choice selection in choice mode', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    vi.mocked(mockStorage.getWords).mockResolvedValue([
+      word,
+      makeWord('w2', 'kaķis', 'cat'),
+      makeWord('w3', 'suns', 'dog'),
+      makeWord('w4', 'putns', 'bird'),
+    ])
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockGenerateDistractors.mockReturnValue(mockDistr)
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    // Force choice mode by setting typeRatio=0.0
+    const { result } = renderHook(
+      () => useMixedQuizSession(mockPair, mockSettings, 0.0),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+    expect(result.current.state.currentMode).toBe('choice')
+    expect(result.current.state.options).toEqual(mockDistr.options)
+
+    await act(async () => {
+      // correctIndex is 0, selecting 0 = correct
+      await result.current.selectOption(0)
+    })
+
+    expect(result.current.state.phase).toBe('feedback')
+    expect(result.current.state.lastChoiceCorrect).toBe(true)
+    expect(result.current.state.correctCount).toBe(1)
+
+    expect(mockRecordAttempt).toHaveBeenCalledWith(
+      mockStorage, 'w1', true, 'source-to-target', 'choice',
+    )
+  })
+
+  it('should record incorrect choice selection', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    vi.mocked(mockStorage.getWords).mockResolvedValue([
+      word,
+      makeWord('w2', 'kaķis', 'cat'),
+      makeWord('w3', 'suns', 'dog'),
+      makeWord('w4', 'putns', 'bird'),
+    ])
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockGenerateDistractors.mockReturnValue(mockDistr)
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useMixedQuizSession(mockPair, mockSettings, 0.0),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    await act(async () => {
+      // correctIndex=0, selecting index 1 = wrong
+      await result.current.selectOption(1)
+    })
+
+    expect(result.current.state.lastChoiceCorrect).toBe(false)
+    expect(result.current.state.correctCount).toBe(0)
+
+    expect(mockRecordAttempt).toHaveBeenCalledWith(
+      mockStorage, 'w1', false, 'source-to-target', 'choice',
+    )
+  })
+
+  it('should advance to next word after feedback', async () => {
+    const word1 = makeWord('w1', 'māja', 'house')
+    const word2 = makeWord('w2', 'kaķis', 'cat')
+    vi.mocked(mockStorage.getWords).mockResolvedValue([word1, word2])
+    mockGetNextWords.mockResolvedValue([
+      { word: word1, direction: 'source-to-target', progress: null },
+      { word: word2, direction: 'source-to-target', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useMixedQuizSession(mockPair, mockSettings, 1.0),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+    expect(result.current.state.currentWord?.id).toBe('w1')
+
+    await act(async () => { await result.current.submitAnswer('house') })
+    expect(result.current.state.phase).toBe('feedback')
+
+    act(() => { result.current.advance() })
+
+    expect(result.current.state.phase).toBe('question')
+    expect(result.current.state.currentWord?.id).toBe('w2')
+  })
+
+  it('should finish when the daily goal is reached', async () => {
+    const words = [
+      { word: makeWord('w1', 'māja', 'house'), direction: 'source-to-target' as const, progress: null },
+      { word: makeWord('w2', 'kaķis', 'cat'), direction: 'source-to-target' as const, progress: null },
+      { word: makeWord('w3', 'suns', 'dog'), direction: 'source-to-target' as const, progress: null },
+    ]
+    vi.mocked(mockStorage.getWords).mockResolvedValue(words.map((w) => w.word))
+    mockGetNextWords.mockResolvedValue(words)
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    // dailyGoal = 3 in mockSettings
+    const { result } = renderHook(
+      () => useMixedQuizSession(mockPair, mockSettings, 1.0),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    await act(async () => { await result.current.submitAnswer('house') })
+    act(() => { result.current.advance() })
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    await act(async () => { await result.current.submitAnswer('cat') })
+    act(() => { result.current.advance() })
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    await act(async () => { await result.current.submitAnswer('dog') })
+    act(() => { result.current.advance() })
+
+    expect(result.current.state.phase).toBe('finished')
+    expect(result.current.state.wordsCompleted).toBe(3)
+  })
+
+  it('should end session when endSession is called', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    vi.mocked(mockStorage.getWords).mockResolvedValue([word])
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useMixedQuizSession(mockPair, mockSettings, 1.0),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+
+    act(() => { result.current.endSession() })
+    expect(result.current.state.phase).toBe('finished')
+  })
+
+  it('should finish immediately if pair is null', async () => {
+    const { result } = renderHook(
+      () => useMixedQuizSession(null, mockSettings),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('finished')
+    })
+  })
+
+  it('should assign mode from the session to each item', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    vi.mocked(mockStorage.getWords).mockResolvedValue([word, makeWord('w2', 'a', 'b'), makeWord('w3', 'c', 'd'), makeWord('w4', 'e', 'f')])
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockGenerateDistractors.mockReturnValue(mockDistr)
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    // typeRatio=0.0 → all choice
+    const { result } = renderHook(
+      () => useMixedQuizSession(mockPair, mockSettings, 0.0),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+    expect(result.current.state.currentMode).toBe('choice')
+  })
+
+  it('should not allow submitting a type answer in choice mode', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    vi.mocked(mockStorage.getWords).mockResolvedValue([
+      word,
+      makeWord('w2', 'a', 'b'),
+      makeWord('w3', 'c', 'd'),
+      makeWord('w4', 'e', 'f'),
+    ])
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockGenerateDistractors.mockReturnValue(mockDistr)
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useMixedQuizSession(mockPair, mockSettings, 0.0),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+    expect(result.current.state.currentMode).toBe('choice')
+
+    // Calling submitAnswer in choice mode should be a no-op
+    await act(async () => { await result.current.submitAnswer('house') })
+    expect(result.current.state.phase).toBe('question') // should not advance
+  })
+
+  it('should not allow selecting option in type mode', async () => {
+    const word = makeWord('w1', 'māja', 'house')
+    vi.mocked(mockStorage.getWords).mockResolvedValue([word])
+    mockGetNextWords.mockResolvedValue([
+      { word, direction: 'source-to-target', progress: null },
+    ])
+    mockRecordAttempt.mockResolvedValue(mockProgress)
+
+    const { result } = renderHook(
+      () => useMixedQuizSession(mockPair, mockSettings, 1.0),
+      { wrapper: makeWrapper(mockStorage) },
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe('question'))
+    expect(result.current.state.currentMode).toBe('type')
+
+    // Calling selectOption in type mode should be a no-op
+    await act(async () => { await result.current.selectOption(0) })
+    expect(result.current.state.phase).toBe('question') // should not advance
+  })
+})
+
+// ─── Consecutive mode constraint tests ────────────────────────────────────────
+
+describe('selectModeForWord - consecutive constraint', () => {
+  it('should never produce more than MAX_CONSECUTIVE_SAME_MODE type in a row', () => {
+    const modes: ActiveQuizMode[] = []
+    for (let i = 0; i < 30; i++) {
+      const mode = selectModeForWord(0.5, modes, 0.5, true)
+      modes.push(mode)
+    }
+
+    let consecutive = 1
+    for (let i = 1; i < modes.length; i++) {
+      if (modes[i] === modes[i - 1]) {
+        consecutive++
+        expect(consecutive).toBeLessThanOrEqual(MAX_CONSECUTIVE_SAME_MODE)
+      } else {
+        consecutive = 1
+      }
+    }
+  })
+
+  it('should never produce more than MAX_CONSECUTIVE_SAME_MODE choice in a row', () => {
+    // Same test from choice perspective
+    const modes: ActiveQuizMode[] = []
+    for (let i = 0; i < 30; i++) {
+      const mode = selectModeForWord(0.5, modes, 0.5, true)
+      modes.push(mode)
+    }
+
+    let consecutive = 1
+    for (let i = 1; i < modes.length; i++) {
+      if (modes[i] === modes[i - 1]) {
+        consecutive++
+        expect(consecutive).toBeLessThanOrEqual(MAX_CONSECUTIVE_SAME_MODE)
+      } else {
+        consecutive = 1
+      }
+    }
+  })
+})

--- a/src/features/quiz/useMixedQuizSession.ts
+++ b/src/features/quiz/useMixedQuizSession.ts
@@ -1,0 +1,403 @@
+/**
+ * useMixedQuizSession - manages state and logic for a mixed-mode quiz session.
+ *
+ * Responsibilities:
+ * - Loads the next batch of words via the spaced repetition engine.
+ * - For each word, determines whether to use 'type' or 'choice' mode based on:
+ *   - A configurable type/choice ratio (default 50/50).
+ *   - A consecutive-mode cap: no more than MAX_CONSECUTIVE_SAME_MODE questions
+ *     of the same mode in a row.
+ *   - An optional confidence heuristic: lower-confidence words lean toward choice.
+ * - Manages both type-mode answer submission and choice-mode option selection.
+ * - Records each attempt through the spaced repetition engine.
+ * - Tracks session progress against the daily goal.
+ * - Handles the "not enough words for choice" fallback gracefully.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import type { Word, LanguagePair, UserSettings, QuizDirection } from '@/types'
+import type { AnswerMatchResult } from '@/utils/matching'
+import { matchAnswer } from '@/utils/matching'
+import { useStorage } from '@/hooks/useStorage'
+import { getNextWords, recordAttempt } from '@/services/spacedRepetition'
+import type { WordForQuiz } from '@/services/spacedRepetition'
+import { generateDistractors, MIN_WORDS_FOR_CHOICE } from '@/utils/distractorGenerator'
+import type { DistractorResult } from '@/utils/distractorGenerator'
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export type MixedSessionPhase =
+  | 'loading'
+  | 'question'
+  | 'feedback'
+  | 'finished'
+
+export type ActiveQuizMode = 'type' | 'choice'
+
+export interface MixedQuizSessionState {
+  readonly phase: MixedSessionPhase
+  /** The current word being quizzed. */
+  readonly currentWord: Word | null
+  /** Direction for the current question. */
+  readonly direction: QuizDirection | null
+  /** The active language pair. */
+  readonly pair: LanguagePair | null
+  /** Which quiz mode is active for the current question. */
+  readonly currentMode: ActiveQuizMode
+  /** Options for choice mode (empty when currentMode === 'type'). */
+  readonly options: readonly string[]
+  /** Index of the correct answer within options (choice mode only). */
+  readonly correctIndex: number
+  /** Index the user selected in choice mode (-1 if none yet). */
+  readonly selectedIndex: number
+  /** Result of the last typed answer (type mode only). */
+  readonly lastResult: AnswerMatchResult | null
+  /** Whether the last choice selection was correct (choice mode only). */
+  readonly lastChoiceCorrect: boolean | null
+  /** Number of words completed this session. */
+  readonly wordsCompleted: number
+  /** Total words in this session (= daily goal). */
+  readonly sessionGoal: number
+  /** Number of correct answers this session. */
+  readonly correctCount: number
+  /** Error message if something went wrong. */
+  readonly error: string | null
+}
+
+export interface UseMixedQuizSessionResult {
+  readonly state: MixedQuizSessionState
+  /** Submit typed answer (for type mode). */
+  readonly submitAnswer: (userAnswer: string) => Promise<void>
+  /** Record option selection (for choice mode). */
+  readonly selectOption: (index: number) => Promise<void>
+  /** Advance past feedback to the next word. */
+  readonly advance: () => void
+  /** Manually end the session. */
+  readonly endSession: () => void
+  /** Start a new session (reset everything). */
+  readonly restart: () => void
+}
+
+// ─── Internal types ───────────────────────────────────────────────────────────
+
+interface MixedItem {
+  readonly wordForQuiz: WordForQuiz
+  readonly mode: ActiveQuizMode
+  /** Pre-generated distractors for choice questions (null for type questions). */
+  readonly distractors: DistractorResult | null
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** How many words to pre-fetch per batch. */
+const BATCH_SIZE = 20
+
+/** Maximum number of consecutive questions in the same mode before forcing a switch. */
+export const MAX_CONSECUTIVE_SAME_MODE = 3
+
+/** Default ratio of type questions. 0.5 = 50% type / 50% choice. */
+const DEFAULT_TYPE_RATIO = 0.5
+
+/**
+ * Confidence threshold below which a word is considered low-confidence.
+ * Low-confidence words get a slight nudge toward choice mode.
+ */
+const LOW_CONFIDENCE_THRESHOLD = 0.3
+
+// ─── Mode selection logic ─────────────────────────────────────────────────────
+
+/**
+ * Determines the quiz mode for a word given the ratio, recent mode history,
+ * and the word's confidence score.
+ *
+ * Rules (in priority order):
+ * 1. If MAX_CONSECUTIVE_SAME_MODE of the same mode have occurred, force the other.
+ * 2. If the word's confidence is below LOW_CONFIDENCE_THRESHOLD, lean toward 'choice'.
+ * 3. Otherwise, decide probabilistically based on typeRatio.
+ */
+export function selectModeForWord(
+  typeRatio: number,
+  recentModes: readonly ActiveQuizMode[],
+  confidence: number,
+  choiceAvailable: boolean,
+): ActiveQuizMode {
+  if (!choiceAvailable) return 'type'
+
+  // Enforce max-consecutive cap
+  if (recentModes.length >= MAX_CONSECUTIVE_SAME_MODE) {
+    const tail = recentModes.slice(-MAX_CONSECUTIVE_SAME_MODE)
+    const allSame = tail.every((m) => m === tail[0])
+    if (allSame) {
+      return tail[0] === 'type' ? 'choice' : 'type'
+    }
+  }
+
+  // Confidence heuristic: nudge low-confidence words toward choice
+  const effectiveTypeRatio =
+    confidence < LOW_CONFIDENCE_THRESHOLD ? typeRatio * 0.5 : typeRatio
+
+  return Math.random() < effectiveTypeRatio ? 'type' : 'choice'
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Manages a full mixed-mode quiz session for a given language pair.
+ *
+ * @param pair     - The active language pair, or null if none selected.
+ * @param settings - Current user settings (daily goal, typo tolerance).
+ * @param typeRatio - Fraction of questions that should be type mode (0–1). Default 0.5.
+ */
+export function useMixedQuizSession(
+  pair: LanguagePair | null,
+  settings: UserSettings,
+  typeRatio: number = DEFAULT_TYPE_RATIO,
+): UseMixedQuizSessionResult {
+  const storage = useStorage()
+
+  const [phase, setPhase] = useState<MixedSessionPhase>('loading')
+  const [queue, setQueue] = useState<MixedItem[]>([])
+  const [queueIndex, setQueueIndex] = useState(0)
+  const [selectedIndex, setSelectedIndex] = useState(-1)
+  const [lastResult, setLastResult] = useState<AnswerMatchResult | null>(null)
+  const [lastChoiceCorrect, setLastChoiceCorrect] = useState<boolean | null>(null)
+  const [wordsCompleted, setWordsCompleted] = useState(0)
+  const [correctCount, setCorrectCount] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  // Recent mode history for consecutive-mode enforcement.
+  const recentModesRef = useRef<ActiveQuizMode[]>([])
+  // Distractor IDs used in the previous choice question (avoid repetition).
+  const recentDistractorIdsRef = useRef<readonly string[]>([])
+
+  // Track if the component is still mounted to avoid state updates after unmount.
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const sessionGoal = settings.dailyGoal
+
+  // ─── Load words ──────────────────────────────────────────────────────────
+
+  const loadWords = useCallback(async (): Promise<void> => {
+    if (pair === null) {
+      if (mountedRef.current) setPhase('finished')
+      return
+    }
+
+    if (mountedRef.current) {
+      setPhase('loading')
+      setError(null)
+    }
+
+    try {
+      const allWords = await storage.getWords(pair.id)
+      const choiceAvailable = allWords.length >= MIN_WORDS_FOR_CHOICE
+
+      const wordsForQuiz = await getNextWords(storage, pair.id, BATCH_SIZE)
+
+      if (!mountedRef.current) return
+
+      if (wordsForQuiz.length === 0) {
+        setPhase('finished')
+        return
+      }
+
+      const items: MixedItem[] = []
+      let recentModes = recentModesRef.current
+      let recentDistractorIds = recentDistractorIdsRef.current
+
+      for (const wfq of wordsForQuiz) {
+        const confidence = wfq.progress?.confidence ?? 0
+        const mode = selectModeForWord(typeRatio, recentModes, confidence, choiceAvailable)
+
+        let distractors: DistractorResult | null = null
+
+        if (mode === 'choice') {
+          const result = generateDistractors(
+            wfq.word,
+            wfq.direction,
+            allWords,
+            recentDistractorIds,
+          )
+
+          if (result === null) {
+            // Fallback to type mode if distractors can't be generated.
+            items.push({ wordForQuiz: wfq, mode: 'type', distractors: null })
+            recentModes = [...recentModes, 'type']
+            continue
+          }
+
+          distractors = result
+
+          // Track which word IDs were used as distractors.
+          recentDistractorIds = allWords
+            .filter(
+              (w) =>
+                w.id !== wfq.word.id &&
+                result.options.includes(
+                  wfq.direction === 'source-to-target' ? w.target : w.source,
+                ),
+            )
+            .map((w) => w.id)
+        }
+
+        items.push({ wordForQuiz: wfq, mode, distractors })
+        recentModes = [...recentModes, mode]
+      }
+
+      if (items.length === 0) {
+        setPhase('finished')
+        return
+      }
+
+      recentModesRef.current = recentModes
+      recentDistractorIdsRef.current = recentDistractorIds
+      setQueue(items)
+      setQueueIndex(0)
+      setSelectedIndex(-1)
+      setLastResult(null)
+      setLastChoiceCorrect(null)
+      setPhase('question')
+    } catch (err) {
+      if (!mountedRef.current) return
+      const message = err instanceof Error ? err.message : 'Failed to load words'
+      setError(message)
+      setPhase('finished')
+    }
+  }, [storage, pair, typeRatio])
+
+  // Load words on mount and whenever the pair changes.
+  useEffect(() => {
+    void loadWords()
+  }, [loadWords])
+
+  // ─── Derived current item ────────────────────────────────────────────────
+
+  const currentItem = queueIndex < queue.length ? queue[queueIndex] : null
+  const currentWord = currentItem?.wordForQuiz.word ?? null
+  const direction = currentItem?.wordForQuiz.direction ?? null
+  const currentMode: ActiveQuizMode = currentItem?.mode ?? 'type'
+  const options = currentItem?.distractors?.options ?? []
+  const correctIndex = currentItem?.distractors?.correctIndex ?? 0
+
+  // ─── Submit answer (type mode) ────────────────────────────────────────────
+
+  const submitAnswer = useCallback(
+    async (userAnswer: string): Promise<void> => {
+      if (phase !== 'question' || currentWord === null || direction === null) return
+      if (currentMode !== 'type') return
+
+      const correctText =
+        direction === 'source-to-target' ? currentWord.target : currentWord.source
+
+      const matchResult = matchAnswer(userAnswer, correctText, settings.typoTolerance)
+      const isCorrect = matchResult.result === 'correct' || matchResult.result === 'almost'
+
+      try {
+        await recordAttempt(storage, currentWord.id, isCorrect, direction, 'type')
+      } catch (err) {
+        console.error('Failed to record attempt:', err)
+      }
+
+      if (!mountedRef.current) return
+
+      setLastResult(matchResult)
+      setWordsCompleted((n) => n + 1)
+      if (isCorrect) setCorrectCount((n) => n + 1)
+      setPhase('feedback')
+    },
+    [phase, currentWord, direction, currentMode, settings.typoTolerance, storage],
+  )
+
+  // ─── Select option (choice mode) ──────────────────────────────────────────
+
+  const selectOption = useCallback(
+    async (index: number): Promise<void> => {
+      if (phase !== 'question' || currentWord === null || direction === null) return
+      if (currentMode !== 'choice') return
+      if (selectedIndex !== -1) return
+
+      const isCorrect = index === correctIndex
+
+      try {
+        await recordAttempt(storage, currentWord.id, isCorrect, direction, 'choice')
+      } catch (err) {
+        console.error('Failed to record attempt:', err)
+      }
+
+      if (!mountedRef.current) return
+
+      setSelectedIndex(index)
+      setLastChoiceCorrect(isCorrect)
+      setWordsCompleted((n) => n + 1)
+      if (isCorrect) setCorrectCount((n) => n + 1)
+      setPhase('feedback')
+    },
+    [phase, currentWord, direction, currentMode, selectedIndex, correctIndex, storage],
+  )
+
+  // ─── Advance ──────────────────────────────────────────────────────────────
+
+  const advance = useCallback((): void => {
+    if (phase !== 'feedback') return
+
+    const nextIndex = queueIndex + 1
+
+    if (wordsCompleted >= sessionGoal || nextIndex >= queue.length) {
+      setPhase('finished')
+      return
+    }
+
+    setQueueIndex(nextIndex)
+    setSelectedIndex(-1)
+    setLastResult(null)
+    setLastChoiceCorrect(null)
+    setPhase('question')
+  }, [phase, queueIndex, wordsCompleted, sessionGoal, queue.length])
+
+  // ─── End session ──────────────────────────────────────────────────────────
+
+  const endSession = useCallback((): void => {
+    setPhase('finished')
+  }, [])
+
+  // ─── Restart ──────────────────────────────────────────────────────────────
+
+  const restart = useCallback((): void => {
+    setWordsCompleted(0)
+    setCorrectCount(0)
+    setSelectedIndex(-1)
+    setLastResult(null)
+    setLastChoiceCorrect(null)
+    setQueue([])
+    setQueueIndex(0)
+    recentModesRef.current = []
+    recentDistractorIdsRef.current = []
+    void loadWords()
+  }, [loadWords])
+
+  // ─── Return ───────────────────────────────────────────────────────────────
+
+  const state: MixedQuizSessionState = {
+    phase,
+    currentWord,
+    direction,
+    pair,
+    currentMode,
+    options,
+    correctIndex,
+    selectedIndex,
+    lastResult,
+    lastChoiceCorrect,
+    wordsCompleted,
+    sessionGoal,
+    correctCount,
+    error,
+  }
+
+  return { state, submitAnswer, selectOption, advance, endSession, restart }
+}


### PR DESCRIPTION
## Summary

- Implements the full mixed quiz mode that alternates type and choice questions
- Adds a pre-quiz mode selector (Type / Choice / Mixed) that persists to settings
- Adds a session summary screen shown on completion with stats and encouragement
- Wires everything together via a new `QuizHub` component in the quiz tab

## Changes

- `src/features/quiz/useMixedQuizSession.ts` — Core hook: configurable type/choice ratio (default 50/50), max-3-consecutive-same-mode cap, low-confidence confidence heuristic
- `src/features/quiz/components/QuizModeSelector.tsx` — Pre-quiz mode picker, persists via `storage.saveSettings()`
- `src/features/quiz/components/SessionSummary.tsx` — Post-session screen: words reviewed, accuracy %, correct/incorrect split, streak, encouraging message
- `src/features/quiz/components/QuizHub.tsx` — Hub: mode selection → active quiz → summary
- `src/features/quiz/components/ActiveQuizView.tsx` — Routes to per-mode container; surfaces final stats to hub
- `src/features/quiz/components/{TypeQuizContent,ChoiceQuizContent,MixedQuizContent}.tsx` — Session-injected UI (no jarring layout shifts between modes)
- `src/features/quiz/components/MixedQuizScreen.tsx` — Standalone mixed screen
- `src/features/quiz/index.ts` — Updated exports
- `src/App.tsx` — Replaced bare `QuizScreen` with `QuizHub`

## Testing

- 45 new tests: `useMixedQuizSession.test.ts` (22), `QuizModeSelector.test.tsx` (9), `SessionSummary.test.tsx` (14)
- All 374 tests pass (`npm test -- --run`)
- `npx tsc --noEmit` clean
- `npm run build` succeeds

## Review

- Code review passed — no `any` types, no direct localStorage calls, all MUI theme tokens, named exports only, no hardcoded magic numbers

Closes #12