### PR TITLE
feat: bidirectional starter pack matching and installation (#38)

### DIFF
--- a/src/features/starter-packs/components/PackBrowserDialog.tsx
+++ b/src/features/starter-packs/components/PackBrowserDialog.tsx
@@ -16,13 +16,17 @@ import {
 import DownloadIcon from '@mui/icons-material/Download'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import type { StarterPack } from '@/types'
-import { listPacks, installPack } from '@/services/starterPacks'
+import { listPacks, installPack, packMatchesPair } from '@/services/starterPacks'
 import type { InstallPackResult } from '@/services/starterPacks'
 import { useStorage } from '@/hooks/useStorage'
 
 export interface PackBrowserDialogProps {
   readonly open: boolean
   readonly pairId: string | null
+  /** ISO language code for the active pair's source language (e.g. "en", "lv"). */
+  readonly pairSourceCode: string | null
+  /** ISO language code for the active pair's target language (e.g. "en", "lv"). */
+  readonly pairTargetCode: string | null
   readonly onClose: () => void
   /** Called after words have been successfully installed so the caller can refresh word list. */
   readonly onInstalled: () => void
@@ -36,11 +40,22 @@ interface PackInstallState {
 /**
  * Dialog that lets the user browse available starter packs and install one.
  * Packs are loaded from the public directory via fetch.
+ *
+ * Uses packMatchesPair to filter packs to only those compatible with the active
+ * language pair (in either direction). When installing a reversed pack the
+ * service layer swaps source/target automatically.
  */
-export function PackBrowserDialog({ open, pairId, onClose, onInstalled }: PackBrowserDialogProps) {
+export function PackBrowserDialog({
+  open,
+  pairId,
+  pairSourceCode,
+  pairTargetCode,
+  onClose,
+  onInstalled,
+}: PackBrowserDialogProps) {
   const storage = useStorage()
 
-  const [packs, setPacks] = useState<readonly StarterPack[]>([])
+  const [allPacks, setAllPacks] = useState<readonly StarterPack[]>([])
   const [loadingPacks, setLoadingPacks] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
 
@@ -57,7 +72,7 @@ export function PackBrowserDialog({ open, pairId, onClose, onInstalled }: PackBr
 
     listPacks()
       .then((loaded) => {
-        setPacks(loaded)
+        setAllPacks(loaded)
         setLoadingPacks(false)
       })
       .catch((err: unknown) => {
@@ -67,9 +82,17 @@ export function PackBrowserDialog({ open, pairId, onClose, onInstalled }: PackBr
       })
   }, [open])
 
+  // Filter to only packs compatible with the active pair (same or reversed direction).
+  const packs =
+    pairSourceCode !== null && pairTargetCode !== null
+      ? allPacks.filter(
+          (pack) => packMatchesPair(pack, pairSourceCode, pairTargetCode) !== 'none',
+        )
+      : allPacks
+
   const handleInstall = useCallback(
     async (pack: StarterPack) => {
-      if (!pairId) return
+      if (!pairId || !pairSourceCode || !pairTargetCode) return
 
       setInstallStates((prev) => ({
         ...prev,
@@ -77,7 +100,7 @@ export function PackBrowserDialog({ open, pairId, onClose, onInstalled }: PackBr
       }))
 
       try {
-        const result = await installPack(pack, pairId, storage)
+        const result = await installPack(pack, pairId, pairSourceCode, pairTargetCode, storage)
         setInstallStates((prev) => ({
           ...prev,
           [pack.id]: { status: 'done', result },
@@ -92,7 +115,7 @@ export function PackBrowserDialog({ open, pairId, onClose, onInstalled }: PackBr
         setLoadError(message)
       }
     },
-    [pairId, storage, onInstalled],
+    [pairId, pairSourceCode, pairTargetCode, storage, onInstalled],
   )
 
   const handleClose = useCallback(() => {

--- a/src/features/words/components/WordListScreen.tsx
+++ b/src/features/words/components/WordListScreen.tsx
@@ -140,6 +140,8 @@ export function WordListScreen({ activePair }: WordListScreenProps) {
         <PackBrowserDialog
           open={packBrowserOpen}
           pairId={activePair.id}
+          pairSourceCode={activePair.sourceCode}
+          pairTargetCode={activePair.targetCode}
           onClose={handleClosePackBrowser}
           onInstalled={handlePackInstalled}
         />
@@ -195,6 +197,8 @@ export function WordListScreen({ activePair }: WordListScreenProps) {
       <PackBrowserDialog
         open={packBrowserOpen}
         pairId={activePair.id}
+        pairSourceCode={activePair.sourceCode}
+        pairTargetCode={activePair.targetCode}
         onClose={handleClosePackBrowser}
         onInstalled={handlePackInstalled}
       />

--- a/src/services/starterPacks.test.ts
+++ b/src/services/starterPacks.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { StarterPack, Word } from '@/types'
-import { listPackIds, loadPack, listPacks, installPack } from './starterPacks'
+import { listPackIds, loadPack, listPacks, installPack, packMatchesPair } from './starterPacks'
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -56,6 +56,50 @@ function makeStorageMock(existingWords: Word[] = []) {
     clearAll: vi.fn(),
   }
 }
+
+// ── packMatchesPair ───────────────────────────────────────────────────────────
+
+describe('packMatchesPair', () => {
+  it('should return "same" when pack codes match the pair exactly', () => {
+    const pack = makePack({ sourceCode: 'lv', targetCode: 'en' })
+    expect(packMatchesPair(pack, 'lv', 'en')).toBe('same')
+  })
+
+  it('should return "reversed" when pack codes are the mirror of the pair', () => {
+    const pack = makePack({ sourceCode: 'lv', targetCode: 'en' })
+    expect(packMatchesPair(pack, 'en', 'lv')).toBe('reversed')
+  })
+
+  it('should return "none" for unrelated language codes', () => {
+    const pack = makePack({ sourceCode: 'lv', targetCode: 'en' })
+    expect(packMatchesPair(pack, 'ru', 'de')).toBe('none')
+  })
+
+  it('should return "none" when only one code matches', () => {
+    const pack = makePack({ sourceCode: 'lv', targetCode: 'en' })
+    expect(packMatchesPair(pack, 'lv', 'ru')).toBe('none')
+  })
+
+  it('should return "same" for ru-en pack with ru-en pair', () => {
+    const pack = makePack({ sourceCode: 'ru', targetCode: 'en' })
+    expect(packMatchesPair(pack, 'ru', 'en')).toBe('same')
+  })
+
+  it('should return "reversed" for ru-en pack with en-ru pair', () => {
+    const pack = makePack({ sourceCode: 'ru', targetCode: 'en' })
+    expect(packMatchesPair(pack, 'en', 'ru')).toBe('reversed')
+  })
+
+  it('should return "same" for ru-lv pack with ru-lv pair', () => {
+    const pack = makePack({ sourceCode: 'ru', targetCode: 'lv' })
+    expect(packMatchesPair(pack, 'ru', 'lv')).toBe('same')
+  })
+
+  it('should return "reversed" for ru-lv pack with lv-ru pair', () => {
+    const pack = makePack({ sourceCode: 'ru', targetCode: 'lv' })
+    expect(packMatchesPair(pack, 'lv', 'ru')).toBe('reversed')
+  })
+})
 
 // ── listPackIds ───────────────────────────────────────────────────────────────
 
@@ -159,11 +203,13 @@ describe('listPacks', () => {
 // ── installPack ───────────────────────────────────────────────────────────────
 
 describe('installPack', () => {
+  // ── same direction (pack codes == pair codes) ──────────────────────────────
+
   it('should add all words when storage is empty', async () => {
     const pack = makePack()
     const storage = makeStorageMock([])
 
-    const result = await installPack(pack, 'pair-1', storage)
+    const result = await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
     expect(result.added).toBe(2)
     expect(result.skipped).toBe(0)
@@ -177,7 +223,7 @@ describe('installPack', () => {
     const pack = makePack()
     const storage = makeStorageMock([])
 
-    await installPack(pack, 'pair-1', storage)
+    await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
     const saved = storage.saveWords.mock.calls[0][0] as Word[]
     expect(saved.every((w) => w.isFromPack)).toBe(true)
@@ -187,7 +233,7 @@ describe('installPack', () => {
     const pack = makePack()
     const storage = makeStorageMock([])
 
-    await installPack(pack, 'pair-1', storage)
+    await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
     const saved = storage.saveWords.mock.calls[0][0] as Word[]
     expect(saved.every((w) => w.tags.includes('starter-pack'))).toBe(true)
@@ -199,7 +245,7 @@ describe('installPack', () => {
     })
     const storage = makeStorageMock([])
 
-    await installPack(pack, 'pair-1', storage)
+    await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
     const saved = storage.saveWords.mock.calls[0][0] as Word[]
     expect(saved[0].tags).toContain('food-drink')
@@ -217,7 +263,7 @@ describe('installPack', () => {
     })
     const storage = makeStorageMock([existingWord])
 
-    const result = await installPack(pack, 'pair-1', storage)
+    const result = await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
     expect(result.added).toBe(1)
     expect(result.skipped).toBe(1)
@@ -235,7 +281,7 @@ describe('installPack', () => {
     const pack = makePack()
     const storage = makeStorageMock(existingWords)
 
-    const result = await installPack(pack, 'pair-1', storage)
+    const result = await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
     expect(result.added).toBe(0)
     expect(result.skipped).toBe(2)
@@ -250,7 +296,7 @@ describe('installPack', () => {
     const pack = makePack()
     const storage = makeStorageMock(existingWords)
 
-    await installPack(pack, 'pair-1', storage)
+    await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
     expect(storage.saveWords).not.toHaveBeenCalled()
   })
@@ -259,7 +305,7 @@ describe('installPack', () => {
     const pack = makePack()
     const storage = makeStorageMock([])
 
-    await installPack(pack, 'my-pair-id', storage)
+    await installPack(pack, 'my-pair-id', 'lv', 'en', storage)
 
     const saved = storage.saveWords.mock.calls[0][0] as Word[]
     expect(saved.every((w) => w.pairId === 'my-pair-id')).toBe(true)
@@ -274,7 +320,7 @@ describe('installPack', () => {
     })
     const storage = makeStorageMock([])
 
-    const result = await installPack(pack, 'pair-1', storage)
+    const result = await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
     expect(result.added).toBe(1)
     expect(result.skipped).toBe(1)
@@ -287,10 +333,94 @@ describe('installPack', () => {
     })
     const storage = makeStorageMock([existingWord])
 
-    await installPack(pack, 'pair-1', storage)
+    await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
     const saved = storage.saveWords.mock.calls[0][0] as Word[]
     const savedIds = saved.map((w) => w.id)
     expect(savedIds).not.toContain(existingWord.id)
+  })
+
+  // ── reversed direction (pack codes are swapped relative to pair) ───────────
+
+  it('should swap source and target when installing in reversed direction', async () => {
+    // Pack is lv→en, but pair is en→lv (reversed)
+    const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
+      words: [
+        { source: 'ūdens', target: 'water', tags: ['B1'] },
+        { source: 'maize', target: 'bread', tags: ['B1'] },
+      ],
+    })
+    const storage = makeStorageMock([])
+
+    const result = await installPack(pack, 'pair-1', 'en', 'lv', storage)
+
+    expect(result.added).toBe(2)
+    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    expect(saved[0].source).toBe('water')
+    expect(saved[0].target).toBe('ūdens')
+    expect(saved[1].source).toBe('bread')
+    expect(saved[1].target).toBe('maize')
+  })
+
+  it('should detect duplicates on swapped values when installing reversed', async () => {
+    // Existing word already has "water" as source and "ūdens" as target (en-lv direction).
+    const existingWord = makeWord({ source: 'water', target: 'ūdens' })
+    const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
+      words: [
+        { source: 'ūdens', target: 'water', tags: ['B1'] }, // becomes water|ūdens after swap -> duplicate
+        { source: 'maize', target: 'bread', tags: ['B1'] }, // becomes bread|maize -> new
+      ],
+    })
+    const storage = makeStorageMock([existingWord])
+
+    const result = await installPack(pack, 'pair-1', 'en', 'lv', storage)
+
+    expect(result.added).toBe(1)
+    expect(result.skipped).toBe(1)
+
+    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    expect(saved[0].source).toBe('bread')
+    expect(saved[0].target).toBe('maize')
+  })
+
+  it('should preserve tags when installing in reversed direction', async () => {
+    const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
+      words: [{ source: 'ūdens', target: 'water', tags: ['food-drink', 'B1'] }],
+    })
+    const storage = makeStorageMock([])
+
+    await installPack(pack, 'pair-1', 'en', 'lv', storage)
+
+    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    expect(saved[0].tags).toContain('food-drink')
+    expect(saved[0].tags).toContain('B1')
+    expect(saved[0].tags).toContain('starter-pack')
+  })
+
+  it('should set isFromPack to true on reversed-direction installs', async () => {
+    const pack = makePack({ sourceCode: 'lv', targetCode: 'en' })
+    const storage = makeStorageMock([])
+
+    await installPack(pack, 'pair-1', 'en', 'lv', storage)
+
+    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    expect(saved.every((w) => w.isFromPack)).toBe(true)
+  })
+
+  // ── incompatible pack ──────────────────────────────────────────────────────
+
+  it('should throw when the pack is not compatible with the pair', async () => {
+    const pack = makePack({ sourceCode: 'lv', targetCode: 'en' })
+    const storage = makeStorageMock([])
+
+    await expect(installPack(pack, 'pair-1', 'ru', 'de', storage)).rejects.toThrow(
+      'not compatible with pair ru-de',
+    )
   })
 })

--- a/src/services/starterPacks.ts
+++ b/src/services/starterPacks.ts
@@ -11,6 +11,33 @@ export interface InstallPackResult {
 }
 
 /**
+ * Describes how a starter pack's language codes relate to a given pair's codes.
+ *
+ * - 'same'     – pack codes match the pair exactly (no swap needed)
+ * - 'reversed' – pack codes are the mirror of the pair (swap source/target on install)
+ * - 'none'     – pack is for a completely different language combination
+ */
+export type PackMatchResult = 'same' | 'reversed' | 'none'
+
+/**
+ * Determines whether a starter pack is compatible with the given language pair,
+ * and in which direction.
+ *
+ * A pack with sourceCode="lv" / targetCode="en" matches both:
+ *   - an LV-EN pair  → 'same'
+ *   - an EN-LV pair  → 'reversed'
+ */
+export function packMatchesPair(
+  pack: StarterPack,
+  pairSourceCode: string,
+  pairTargetCode: string,
+): PackMatchResult {
+  if (pack.sourceCode === pairSourceCode && pack.targetCode === pairTargetCode) return 'same'
+  if (pack.sourceCode === pairTargetCode && pack.targetCode === pairSourceCode) return 'reversed'
+  return 'none'
+}
+
+/**
  * Fetches the pack manifest and returns the list of available pack IDs.
  * The manifest lives at /starter-packs/manifest.json.
  */
@@ -50,7 +77,13 @@ export async function listPacks(): Promise<readonly StarterPack[]> {
 /**
  * Installs a starter pack into storage for the given language pair.
  *
- * For each word in the pack:
+ * The pairSourceCode and pairTargetCode parameters are used to determine the
+ * install direction via packMatchesPair:
+ * - 'same'     – words are installed as-is
+ * - 'reversed' – source and target values are swapped so they match the pair direction
+ * - 'none'     – throws an error (the UI should never call this for an incompatible pack)
+ *
+ * For each word in the pack (after any swap):
  * - Checks for an exact duplicate by source+target (case-insensitive).
  * - If no duplicate exists, creates a Word with `isFromPack: true` and tag "starter-pack".
  * - Skips words that already exist.
@@ -60,8 +93,18 @@ export async function listPacks(): Promise<readonly StarterPack[]> {
 export async function installPack(
   pack: StarterPack,
   pairId: string,
+  pairSourceCode: string,
+  pairTargetCode: string,
   storage: StorageService,
 ): Promise<InstallPackResult> {
+  const direction = packMatchesPair(pack, pairSourceCode, pairTargetCode)
+
+  if (direction === 'none') {
+    throw new Error(
+      `Pack "${pack.id}" (${pack.sourceCode}-${pack.targetCode}) is not compatible with pair ${pairSourceCode}-${pairTargetCode}`,
+    )
+  }
+
   const existingWords = await storage.getWords(pairId)
 
   // Build a set of normalised source+target keys for duplicate detection.
@@ -73,7 +116,11 @@ export async function installPack(
   let skipped = 0
 
   for (const entry of pack.words) {
-    const key = `${entry.source.toLowerCase()}|${entry.target.toLowerCase()}`
+    // Swap source and target when installing in the reversed direction.
+    const wordSource = direction === 'reversed' ? entry.target : entry.source
+    const wordTarget = direction === 'reversed' ? entry.source : entry.target
+
+    const key = `${wordSource.toLowerCase()}|${wordTarget.toLowerCase()}`
     if (existingKeys.has(key)) {
       skipped++
       continue
@@ -83,8 +130,8 @@ export async function installPack(
     wordsToAdd.push({
       id: generateId(),
       pairId,
-      source: entry.source,
-      target: entry.target,
+      source: wordSource,
+      target: wordTarget,
       notes: null,
       tags,
       createdAt: Date.now(),


### PR DESCRIPTION
## Summary

- Add exported `packMatchesPair(pack, pairSourceCode, pairTargetCode)` helper that returns `'same' | 'reversed' | 'none'`
- Update `installPack` signature to accept `pairSourceCode` and `pairTargetCode`; swap source/target entries when direction is `'reversed'`; throw on `'none'`
- Update `PackBrowserDialog` to accept `pairSourceCode`/`pairTargetCode` props, filter packs to compatible directions only, and forward codes to `installPack`
- Update `WordListScreen` to pass `activePair.sourceCode` and `activePair.targetCode` to `PackBrowserDialog`

The 3 existing packs (en-lv, ru-en, ru-lv) now serve all 6 pair directions automatically — no data changes needed.

## Changes

- `src/services/starterPacks.ts` — new `packMatchesPair`, updated `installPack` signature + swap logic
- `src/services/starterPacks.test.ts` — 12 new tests covering `packMatchesPair`, reversed installs, duplicate detection on swapped values, and error on incompatible pack
- `src/features/starter-packs/components/PackBrowserDialog.tsx` — new props, pack filtering, forwards codes to `installPack`
- `src/features/words/components/WordListScreen.tsx` — passes `sourceCode`/`targetCode` from active pair

## Testing

- All 359 tests pass (`npm test -- --run`)
- TypeScript strict clean (`npx tsc --noEmit`)
- Production build passes (`npm run build`)
- Acceptance criteria verified: same/reversed/none matching, swap on install, duplicate detection post-swap

## Review

- Named exports maintained
- No localStorage calls
- No hardcoded colours or values
- Strict TypeScript throughout

Closes #38