### PR TITLE
fix: use BASE_URL for starter pack fetch paths (#40)

### DIFF
--- a/src/services/starterPacks.test.ts
+++ b/src/services/starterPacks.test.ts
@@ -145,7 +145,7 @@ describe('loadPack', () => {
 
     const result = await loadPack('test-pack')
     expect(result).toEqual(pack)
-    expect(fetch).toHaveBeenCalledWith('/starter-packs/test-pack.json')
+    expect(fetch).toHaveBeenCalledWith('/lexio/starter-packs/test-pack.json')
   })
 
   it('should throw when the pack fetch fails', async () => {

--- a/src/services/starterPacks.ts
+++ b/src/services/starterPacks.ts
@@ -39,10 +39,12 @@ export function packMatchesPair(
 
 /**
  * Fetches the pack manifest and returns the list of available pack IDs.
- * The manifest lives at /starter-packs/manifest.json.
+ * The manifest lives at <BASE_URL>starter-packs/manifest.json.
+ * BASE_URL is provided by Vite and equals '/lexio/' in production, '/' in dev.
  */
 export async function listPackIds(): Promise<readonly string[]> {
-  const response = await fetch('/starter-packs/manifest.json')
+  const base = import.meta.env.BASE_URL
+  const response = await fetch(`${base}starter-packs/manifest.json`)
   if (!response.ok) {
     throw new Error(`Failed to load pack manifest: ${response.status} ${response.statusText}`)
   }
@@ -52,10 +54,12 @@ export async function listPackIds(): Promise<readonly string[]> {
 
 /**
  * Loads a starter pack by ID from the public directory.
- * Fetches /starter-packs/<id>.json and returns the parsed StarterPack.
+ * Fetches <BASE_URL>starter-packs/<id>.json and returns the parsed StarterPack.
+ * BASE_URL is provided by Vite and equals '/lexio/' in production, '/' in dev.
  */
 export async function loadPack(id: string): Promise<StarterPack> {
-  const response = await fetch(`/starter-packs/${id}.json`)
+  const base = import.meta.env.BASE_URL
+  const response = await fetch(`${base}starter-packs/${id}.json`)
   if (!response.ok) {
     throw new Error(`Failed to load pack "${id}": ${response.status} ${response.statusText}`)
   }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary

- Replace hardcoded \`/starter-packs/manifest.json\` and \`/starter-packs/<id>.json\` fetch paths with \`import.meta.env.BASE_URL\` prefix
- Add \`src/vite-env.d.ts\` with \`/// <reference types="vite/client" />\` so TypeScript recognises \`import.meta.env\`
- Update the \`loadPack\` test URL assertion to expect \`/lexio/starter-packs/test-pack.json\` (matches Vite config \`base: '/lexio/'\`)

## Changes

- \`src/services/starterPacks.ts\` - two fetch calls updated to use \`BASE_URL\`
- \`src/services/starterPacks.test.ts\` - URL assertion updated
- \`src/vite-env.d.ts\` - new file, Vite client type reference

## Testing

- All 359 tests pass (\`npm test -- --run\`)
- TypeScript clean (\`npx tsc --noEmit\`)
- Production build passes (\`npm run build\`)

Closes #40