### PR TITLE
fix: starter pack dialog reopens after install (#44)

### DIFF
--- a/src/features/words/components/WordListScreen.tsx
+++ b/src/features/words/components/WordListScreen.tsx
@@ -100,10 +100,9 @@ export function WordListScreen({ activePair }: WordListScreenProps) {
     )
   }
 
-  // Empty state
-  if (words.length === 0) {
-    return (
-      <>
+  return (
+    <>
+      {words.length === 0 ? (
         <Box sx={{ py: 8, textAlign: 'center' }}>
           <Typography variant="h6" gutterBottom fontWeight={700}>
             No words yet
@@ -128,64 +127,48 @@ export function WordListScreen({ activePair }: WordListScreenProps) {
             </Button>
           </Stack>
         </Box>
+      ) : (
+        <>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+            <Typography variant="h6" fontWeight={700}>
+              {activePair.sourceLang} → {activePair.targetLang}
+            </Typography>
+            <Stack direction="row" spacing={1}>
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<LibraryBooksIcon />}
+                onClick={handleOpenPackBrowser}
+              >
+                Packs
+              </Button>
+              <Button variant="outlined" size="small" onClick={() => handleOpenAdd(true)}>
+                Quick add
+              </Button>
+              <Button
+                variant="contained"
+                size="small"
+                startIcon={<AddIcon />}
+                onClick={() => handleOpenAdd(false)}
+              >
+                Add word
+              </Button>
+            </Stack>
+          </Box>
 
-        <WordFormDialog
-          open={formOpen}
-          word={wordToEdit}
-          quickAddMode={quickAddMode}
-          onClose={handleCloseForm}
-          onSubmit={handleSubmit}
-        />
+          <WordList
+            words={words}
+            progressMap={progressMap}
+            onEdit={handleOpenEdit}
+            onDelete={deleteWord}
+            onBulkDelete={deleteWords}
+          />
+        </>
+      )}
 
-        <PackBrowserDialog
-          open={packBrowserOpen}
-          pairId={activePair.id}
-          pairSourceCode={activePair.sourceCode}
-          pairTargetCode={activePair.targetCode}
-          onClose={handleClosePackBrowser}
-          onInstalled={handlePackInstalled}
-        />
-      </>
-    )
-  }
-
-  return (
-    <>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
-        <Typography variant="h6" fontWeight={700}>
-          {activePair.sourceLang} → {activePair.targetLang}
-        </Typography>
-        <Stack direction="row" spacing={1}>
-          <Button
-            variant="outlined"
-            size="small"
-            startIcon={<LibraryBooksIcon />}
-            onClick={handleOpenPackBrowser}
-          >
-            Packs
-          </Button>
-          <Button variant="outlined" size="small" onClick={() => handleOpenAdd(true)}>
-            Quick add
-          </Button>
-          <Button
-            variant="contained"
-            size="small"
-            startIcon={<AddIcon />}
-            onClick={() => handleOpenAdd(false)}
-          >
-            Add word
-          </Button>
-        </Stack>
-      </Box>
-
-      <WordList
-        words={words}
-        progressMap={progressMap}
-        onEdit={handleOpenEdit}
-        onDelete={deleteWord}
-        onBulkDelete={deleteWords}
-      />
-
+      {/* Dialogs rendered once, outside conditionals, so their lifecycle is not
+          tied to which branch is active. This prevents the dialog from reopening
+          when a pack install transitions words.length from 0 to >0. */}
       <WordFormDialog
         open={formOpen}
         word={wordToEdit}


### PR DESCRIPTION
## Summary

- Fixes a bug where installing a starter pack from the empty state caused the dialog to briefly close then immediately reopen
- Root cause: `PackBrowserDialog` (and `WordFormDialog`) were duplicated inside both conditional branches (`words.length === 0` and `words.length > 0`). On pack install, `refresh()` transitions the list from empty to populated, unmounting the empty-state dialog (cancelling its 1.5s close timer) and mounting a fresh instance with `packBrowserOpen` still `true`
- Fix: move both dialogs outside the conditional branches so a single stable instance is always mounted, regardless of which content branch is active

## Changes

- `src/features/words/components/WordListScreen.tsx` - refactored to render `WordFormDialog` and `PackBrowserDialog` once at the bottom of the component, outside the ternary conditional

## Testing

- All 371 tests pass (`npm test -- --run`)
- TypeScript strict mode passes (`npx tsc --noEmit`)
- Production build passes (`npm run build`)
- Acceptance criteria verified:
  - Installing a starter pack from empty state closes dialog and does not reopen
  - Dialog still accessible from both empty state ("Starter packs" button) and word list header ("Packs" button)

## Review

- Structural fix only - no logic changes, no new state, no new deps

Closes #44