### PR TITLE
refactor: extract shared test utilities and QuizLayout to fix code duplication (#52)

### DIFF
--- a/src/features/language-pairs/useLanguagePairs.test.ts
+++ b/src/features/language-pairs/useLanguagePairs.test.ts
@@ -1,48 +1,24 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
+import { act } from '@testing-library/react'
 import { useLanguagePairs } from './useLanguagePairs'
 import type { StorageService } from '@/services/storage'
 import type { LanguagePair, UserSettings, Word } from '@/types'
-import { StorageContext } from '@/hooks/useStorage'
-import { createElement } from 'react'
-import type { ReactNode } from 'react'
+import { createMockPair, createMockWord, createMockSettings } from '@/test/fixtures'
+import { createMockStorage } from '@/test/mockStorage'
+import { renderHookWithStorage } from '@/test/renderWithStorage'
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const DEFAULT_SETTINGS: UserSettings = {
-  activePairId: null,
-  quizMode: 'mixed',
-  dailyGoal: 20,
-  theme: 'dark',
-  typoTolerance: 1,
-}
+const DEFAULT_SETTINGS = createMockSettings({ activePairId: null, theme: 'dark' })
 
 function makePair(overrides: Partial<LanguagePair> = {}): LanguagePair {
-  return {
-    id: 'pair-1',
-    sourceLang: 'English',
-    sourceCode: 'en',
-    targetLang: 'Latvian',
-    targetCode: 'lv',
-    createdAt: 1000000,
-    ...overrides,
-  }
+  return createMockPair(overrides)
 }
 
 function makeWord(overrides: Partial<Word> = {}): Word {
-  return {
-    id: 'word-1',
-    pairId: 'pair-1',
-    source: 'house',
-    target: 'māja',
-    notes: null,
-    tags: [],
-    createdAt: 1000000,
-    isFromPack: false,
-    ...overrides,
-  }
+  return createMockWord(overrides)
 }
 
 function makeStorage(
@@ -52,7 +28,7 @@ function makeStorage(
   const storedPairs = [...pairs]
   const storedSettings = { ...settings }
 
-  return {
+  return createMockStorage({
     getLanguagePairs: vi.fn().mockImplementation(async () => [...storedPairs]),
     getLanguagePair: vi
       .fn()
@@ -70,27 +46,7 @@ function makeStorage(
     saveSettings: vi.fn().mockImplementation(async (s: UserSettings) => {
       Object.assign(storedSettings, s)
     }),
-    getWords: vi.fn().mockResolvedValue([]),
-    getWord: vi.fn().mockResolvedValue(null),
-    saveWord: vi.fn().mockResolvedValue(undefined),
-    saveWords: vi.fn().mockResolvedValue(undefined),
-    deleteWord: vi.fn().mockResolvedValue(undefined),
-    getWordProgress: vi.fn().mockResolvedValue(null),
-    getAllProgress: vi.fn().mockResolvedValue([]),
-    saveWordProgress: vi.fn().mockResolvedValue(undefined),
-    getDailyStats: vi.fn().mockResolvedValue(null),
-    getDailyStatsRange: vi.fn().mockResolvedValue([]),
-    saveDailyStats: vi.fn().mockResolvedValue(undefined),
-    getRecentDailyStats: vi.fn().mockResolvedValue([]),
-    exportAll: vi.fn().mockResolvedValue('{}'),
-    importAll: vi.fn().mockResolvedValue(undefined),
-    clearAll: vi.fn().mockResolvedValue(undefined),
-  } as StorageService
-}
-
-function makeWrapper(storage: StorageService) {
-  return ({ children }: { children: ReactNode }) =>
-    createElement(StorageContext.Provider, { value: storage }, children)
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -105,9 +61,7 @@ describe('useLanguagePairs', () => {
   describe('initial load', () => {
     it('should start in loading state', () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
       expect(result.current.loading).toBe(true)
     })
 
@@ -115,9 +69,7 @@ describe('useLanguagePairs', () => {
       const pair = makePair()
       const storage = makeStorage([pair])
 
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -128,12 +80,10 @@ describe('useLanguagePairs', () => {
 
     it('should set activePair from settings on mount', async () => {
       const pair = makePair()
-      const settings: UserSettings = { ...DEFAULT_SETTINGS, activePairId: 'pair-1' }
+      const settings = createMockSettings({ activePairId: 'pair-1' })
       const storage = makeStorage([pair], settings)
 
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -143,9 +93,7 @@ describe('useLanguagePairs', () => {
     it('should have null activePair when settings has no active pair', async () => {
       const storage = makeStorage()
 
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -156,9 +104,7 @@ describe('useLanguagePairs', () => {
   describe('createPair', () => {
     it('should add a new pair to the list', async () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -178,9 +124,7 @@ describe('useLanguagePairs', () => {
 
     it('should set the new pair as active by default', async () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -199,9 +143,7 @@ describe('useLanguagePairs', () => {
 
     it('should not set pair as active when setActive is false', async () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -222,9 +164,7 @@ describe('useLanguagePairs', () => {
 
     it('should persist the pair to storage', async () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -244,9 +184,7 @@ describe('useLanguagePairs', () => {
 
     it('should trim whitespace from inputs', async () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -277,12 +215,10 @@ describe('useLanguagePairs', () => {
         sourceCode: 'de',
         targetCode: 'fr',
       })
-      const settings: UserSettings = { ...DEFAULT_SETTINGS, activePairId: 'pair-1' }
+      const settings = createMockSettings({ activePairId: 'pair-1' })
       const storage = makeStorage([pair1, pair2], settings)
 
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
       expect(result.current.activePair?.id).toBe('pair-1')
@@ -298,9 +234,7 @@ describe('useLanguagePairs', () => {
       const pair = makePair()
       const storage = makeStorage([pair])
 
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -319,9 +253,7 @@ describe('useLanguagePairs', () => {
       const pair = makePair()
       const storage = makeStorage([pair])
 
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -336,9 +268,7 @@ describe('useLanguagePairs', () => {
       const pair = makePair()
       const storage = makeStorage([pair])
 
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -351,12 +281,10 @@ describe('useLanguagePairs', () => {
 
     it('should clear activePair when the active pair is deleted', async () => {
       const pair = makePair()
-      const settings: UserSettings = { ...DEFAULT_SETTINGS, activePairId: 'pair-1' }
+      const settings = createMockSettings({ activePairId: 'pair-1' })
       const storage = makeStorage([pair], settings)
 
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
       expect(result.current.activePair?.id).toBe('pair-1')
@@ -377,12 +305,10 @@ describe('useLanguagePairs', () => {
         sourceLang: 'German',
         targetLang: 'French',
       })
-      const settings: UserSettings = { ...DEFAULT_SETTINGS, activePairId: 'pair-1' }
+      const settings = createMockSettings({ activePairId: 'pair-1' })
       const storage = makeStorage([pair1, pair2], settings)
 
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 
@@ -400,9 +326,7 @@ describe('useLanguagePairs', () => {
       const storage = makeStorage([pair])
       vi.mocked(storage.getWords).mockResolvedValue([word1, word2])
 
-      const { result } = renderHook(() => useLanguagePairs(), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useLanguagePairs(), storage)
 
       await act(async () => {})
 

--- a/src/features/quiz/components/ChoiceQuizContent.tsx
+++ b/src/features/quiz/components/ChoiceQuizContent.tsx
@@ -5,12 +5,12 @@
  */
 
 import React, { useCallback } from 'react'
-import { Box, Button, Paper, Typography, Chip, Alert } from '@mui/material'
+import { Box, Button, Typography, Alert } from '@mui/material'
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined'
 import type { LanguagePair } from '@/types'
 import type { UseQuizSessionResult } from '../useQuizSession'
-import { SessionProgress } from './SessionProgress'
+import { QuizLayout } from './QuizLayout'
 import { MIN_WORDS_FOR_CHOICE } from '@/utils/distractorGenerator'
 
 type OptionState = 'default' | 'correct' | 'incorrect' | 'reveal'
@@ -157,36 +157,16 @@ export function ChoiceQuizContent({ session, pair }: ChoiceQuizContentProps) {
   const isAnswered = selectedIndex !== -1
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-      <SessionProgress completed={wordsCompleted} total={sessionGoal} correct={correctCount} />
-
-      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-        <Chip
-          label={`${fromLang} → ${toLang}`}
-          size="small"
-          variant="outlined"
-          sx={{ fontWeight: 600 }}
-          aria-label={`Translating from ${fromLang} to ${toLang}`}
-        />
-      </Box>
-
-      <Paper elevation={2} sx={{ p: 4, textAlign: 'center', borderRadius: 3 }}>
-        <Typography
-          variant="h4"
-          component="p"
-          fontWeight={700}
-          sx={{ wordBreak: 'break-word' }}
-          aria-label={`Translate: ${questionText}`}
-        >
-          {questionText}
-        </Typography>
-        {currentWord?.notes != null && currentWord.notes !== '' && (
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 1, fontStyle: 'italic' }}>
-            {currentWord.notes}
-          </Typography>
-        )}
-      </Paper>
-
+    <QuizLayout
+      fromLang={fromLang}
+      toLang={toLang}
+      questionText={questionText}
+      notes={currentWord?.notes}
+      wordsCompleted={wordsCompleted}
+      sessionGoal={sessionGoal}
+      correctCount={correctCount}
+      onEndSession={endSession}
+    >
       <Box
         sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}
         role="group"
@@ -235,18 +215,6 @@ export function ChoiceQuizContent({ session, pair }: ChoiceQuizContentProps) {
           {wordsCompleted >= sessionGoal ? 'See results' : 'Next word'}
         </Button>
       )}
-
-      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-        <Button
-          variant="text"
-          size="small"
-          color="inherit"
-          onClick={endSession}
-          sx={{ color: 'text.disabled', fontSize: '0.75rem' }}
-        >
-          End session
-        </Button>
-      </Box>
-    </Box>
+    </QuizLayout>
   )
 }

--- a/src/features/quiz/components/QuizLayout.tsx
+++ b/src/features/quiz/components/QuizLayout.tsx
@@ -1,0 +1,87 @@
+/**
+ * QuizLayout - shared chrome rendered by both TypeQuizContent and ChoiceQuizContent.
+ *
+ * Renders:
+ *   - SessionProgress bar
+ *   - Direction chip (fromLang → toLang)
+ *   - Word card (Paper with the question text and optional notes)
+ *   - children (the mode-specific input area)
+ *   - End session button
+ *
+ * This is a thin, stateless wrapper. All logic lives in the parent content components.
+ */
+
+import type { ReactNode } from 'react'
+import { Box, Button, Chip, Paper, Typography } from '@mui/material'
+import { SessionProgress } from './SessionProgress'
+
+interface QuizLayoutProps {
+  readonly fromLang: string
+  readonly toLang: string
+  readonly questionText: string
+  readonly notes?: string | null
+  readonly wordsCompleted: number
+  readonly sessionGoal: number
+  readonly correctCount: number
+  readonly onEndSession: () => void
+  readonly children: ReactNode
+}
+
+export function QuizLayout({
+  fromLang,
+  toLang,
+  questionText,
+  notes,
+  wordsCompleted,
+  sessionGoal,
+  correctCount,
+  onEndSession,
+  children,
+}: QuizLayoutProps) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <SessionProgress completed={wordsCompleted} total={sessionGoal} correct={correctCount} />
+
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Chip
+          label={`${fromLang} → ${toLang}`}
+          size="small"
+          variant="outlined"
+          sx={{ fontWeight: 600 }}
+          aria-label={`Translating from ${fromLang} to ${toLang}`}
+        />
+      </Box>
+
+      <Paper elevation={2} sx={{ p: 4, textAlign: 'center', borderRadius: 3 }}>
+        <Typography
+          variant="h4"
+          component="p"
+          fontWeight={700}
+          sx={{ wordBreak: 'break-word' }}
+          aria-label={`Translate: ${questionText}`}
+        >
+          {questionText}
+        </Typography>
+        {notes != null && notes !== '' && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1, fontStyle: 'italic' }}>
+            {notes}
+          </Typography>
+        )}
+      </Paper>
+
+      {children}
+
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Button
+          variant="text"
+          size="small"
+          color="inherit"
+          onClick={onEndSession}
+          sx={{ color: 'text.disabled', fontSize: '0.75rem' }}
+        >
+          End session
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/features/quiz/components/TypeQuizContent.tsx
+++ b/src/features/quiz/components/TypeQuizContent.tsx
@@ -7,10 +7,10 @@
  */
 
 import { useState, useCallback, useEffect, useRef, type KeyboardEvent } from 'react'
-import { Box, Button, Paper, TextField, Typography, Chip } from '@mui/material'
+import { Box, Button, TextField, Typography } from '@mui/material'
 import type { LanguagePair, UserSettings } from '@/types'
 import type { UseQuizSessionResult } from '../useQuizSession'
-import { SessionProgress } from './SessionProgress'
+import { QuizLayout } from './QuizLayout'
 import { QuizFeedback } from './QuizFeedback'
 
 interface TypeQuizContentProps {
@@ -106,31 +106,15 @@ export function TypeQuizContent({ session, pair, settings }: TypeQuizContentProp
     direction === 'source-to-target' ? (currentWord?.source ?? '') : (currentWord?.target ?? '')
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-      <SessionProgress completed={wordsCompleted} total={sessionGoal} correct={correctCount} />
-
-      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-        <Chip
-          label={`${fromLang} → ${toLang}`}
-          size="small"
-          variant="outlined"
-          sx={{ fontWeight: 600 }}
-          aria-label={`Translating from ${fromLang} to ${toLang}`}
-        />
-      </Box>
-
-      <Paper elevation={2} sx={{ p: 4, textAlign: 'center', borderRadius: 3 }}>
-        <Typography
-          variant="h4"
-          component="p"
-          fontWeight={700}
-          sx={{ wordBreak: 'break-word' }}
-          aria-label={`Translate: ${questionText}`}
-        >
-          {questionText}
-        </Typography>
-      </Paper>
-
+    <QuizLayout
+      fromLang={fromLang}
+      toLang={toLang}
+      questionText={questionText}
+      wordsCompleted={wordsCompleted}
+      sessionGoal={sessionGoal}
+      correctCount={correctCount}
+      onEndSession={endSession}
+    >
       {phase === 'question' && (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
           <TextField
@@ -173,18 +157,6 @@ export function TypeQuizContent({ session, pair, settings }: TypeQuizContentProp
           </Button>
         </Box>
       )}
-
-      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-        <Button
-          variant="text"
-          size="small"
-          color="inherit"
-          onClick={endSession}
-          sx={{ color: 'text.disabled', fontSize: '0.75rem' }}
-        >
-          End session
-        </Button>
-      </Box>
-    </Box>
+    </QuizLayout>
   )
 }

--- a/src/features/quiz/useQuizSession.test.ts
+++ b/src/features/quiz/useQuizSession.test.ts
@@ -11,14 +11,19 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, act, waitFor } from '@testing-library/react'
-import type { ReactNode } from 'react'
-import { createElement } from 'react'
-import { StorageContext } from '@/hooks/useStorage'
+import { act, waitFor } from '@testing-library/react'
 import type { StorageService } from '@/services/storage/StorageService'
-import type { Word, LanguagePair, UserSettings, WordProgress } from '@/types'
+import type { Word } from '@/types'
 import { useQuizSession, selectModeForWord, MAX_CONSECUTIVE_SAME_MODE } from './useQuizSession'
 import type { ActiveQuizMode } from './useQuizSession'
+import {
+  createMockPair,
+  createMockWord,
+  createMockProgress,
+  createMockSettings,
+} from '@/test/fixtures'
+import { createMockStorage } from '@/test/mockStorage'
+import { renderHookWithStorage } from '@/test/renderWithStorage'
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -40,29 +45,19 @@ const mockGenerateDistractors = vi.mocked(generateDistractors)
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
-const mockPair: LanguagePair = {
+const mockPair = createMockPair({
   id: 'pair-1',
   sourceLang: 'Latvian',
   targetLang: 'English',
   sourceCode: 'lv',
   targetCode: 'en',
-  createdAt: 1000,
-}
+})
 
 function makeWord(id: string, source: string, target: string): Word {
-  return {
-    id,
-    pairId: 'pair-1',
-    source,
-    target,
-    notes: null,
-    tags: [],
-    createdAt: 1000,
-    isFromPack: false,
-  }
+  return createMockWord({ id, pairId: 'pair-1', source, target, createdAt: 1000 })
 }
 
-const mockProgress: WordProgress = {
+const mockProgress = createMockProgress({
   wordId: 'w1',
   correctCount: 0,
   incorrectCount: 0,
@@ -71,7 +66,7 @@ const mockProgress: WordProgress = {
   nextReview: 0,
   confidence: 0,
   history: [],
-}
+})
 
 const mockDistr = {
   options: ['house', 'cat', 'dog', 'bird'],
@@ -89,37 +84,6 @@ const fourWords = [
   makeWord('w3', 'suns', 'dog'),
   makeWord('w4', 'galds', 'table'),
 ]
-
-function makeMockStorage(words: Word[] = []): StorageService {
-  return {
-    getLanguagePairs: vi.fn(),
-    getLanguagePair: vi.fn(),
-    saveLanguagePair: vi.fn(),
-    deleteLanguagePair: vi.fn(),
-    getWords: vi.fn().mockResolvedValue(words),
-    getWord: vi.fn(),
-    saveWord: vi.fn(),
-    saveWords: vi.fn(),
-    deleteWord: vi.fn(),
-    getWordProgress: vi.fn(),
-    getAllProgress: vi.fn(),
-    saveWordProgress: vi.fn(),
-    getSettings: vi.fn(),
-    saveSettings: vi.fn(),
-    getDailyStats: vi.fn().mockResolvedValue(null),
-    getDailyStatsRange: vi.fn().mockResolvedValue([]),
-    saveDailyStats: vi.fn(),
-    getRecentDailyStats: vi.fn().mockResolvedValue([]),
-    exportAll: vi.fn(),
-    importAll: vi.fn(),
-    clearAll: vi.fn(),
-  }
-}
-
-function makeWrapper(storage: StorageService) {
-  return ({ children }: { children: ReactNode }) =>
-    createElement(StorageContext.Provider, { value: storage }, children)
-}
 
 // ─── selectModeForWord unit tests ─────────────────────────────────────────────
 
@@ -196,18 +160,18 @@ describe('selectModeForWord', () => {
 // ─── Type mode ────────────────────────────────────────────────────────────────
 
 describe('useQuizSession - type mode', () => {
-  const typeSettings: UserSettings = {
+  const typeSettings = createMockSettings({
     activePairId: 'pair-1',
     quizMode: 'type',
     dailyGoal: 3,
     theme: 'dark',
     typoTolerance: 1,
-  }
+  })
 
   let mockStorage: StorageService
 
   beforeEach(() => {
-    mockStorage = makeMockStorage()
+    mockStorage = createMockStorage()
     vi.clearAllMocks()
     mockRecordAttempt.mockResolvedValue(mockProgress)
   })
@@ -216,9 +180,10 @@ describe('useQuizSession - type mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, typeSettings, 'type'),
+      mockStorage,
+    )
 
     expect(result.current.state.phase).toBe('loading')
 
@@ -233,9 +198,10 @@ describe('useQuizSession - type mode', () => {
   it('should finish immediately if no words are available', async () => {
     mockGetNextWords.mockResolvedValue([])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, typeSettings, 'type'),
+      mockStorage,
+    )
 
     await waitFor(() => {
       expect(result.current.state.phase).toBe('finished')
@@ -243,9 +209,10 @@ describe('useQuizSession - type mode', () => {
   })
 
   it('should finish immediately if pair is null', async () => {
-    const { result } = renderHook(() => useQuizSession(null, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(null, typeSettings, 'type'),
+      mockStorage,
+    )
 
     await waitFor(() => {
       expect(result.current.state.phase).toBe('finished')
@@ -256,9 +223,10 @@ describe('useQuizSession - type mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, typeSettings, 'type'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
 
@@ -270,9 +238,10 @@ describe('useQuizSession - type mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, typeSettings, 'type'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
 
@@ -287,9 +256,10 @@ describe('useQuizSession - type mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, typeSettings, 'type'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     await act(async () => {
@@ -312,9 +282,10 @@ describe('useQuizSession - type mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, typeSettings, 'type'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     await act(async () => {
@@ -336,9 +307,9 @@ describe('useQuizSession - type mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(
+    const { result } = renderHookWithStorage(
       () => useQuizSession(mockPair, { ...typeSettings, typoTolerance: 1 }, 'type'),
-      { wrapper: makeWrapper(mockStorage) },
+      mockStorage,
     )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
@@ -366,9 +337,10 @@ describe('useQuizSession - type mode', () => {
       { word: word2, direction: 'source-to-target', progress: null },
     ])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, typeSettings, 'type'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     expect(result.current.state.currentWord?.id).toBe('w1')
@@ -406,9 +378,10 @@ describe('useQuizSession - type mode', () => {
     ]
     mockGetNextWords.mockResolvedValue(words)
 
-    const { result } = renderHook(() => useQuizSession(mockPair, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, typeSettings, 'type'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
 
@@ -443,9 +416,10 @@ describe('useQuizSession - type mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, typeSettings, 'type'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
 
@@ -460,9 +434,10 @@ describe('useQuizSession - type mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'target-to-source', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, typeSettings, 'type'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     expect(result.current.state.direction).toBe('target-to-source')
@@ -485,9 +460,9 @@ describe('useQuizSession - type mode', () => {
   it('should provide session goal from settings dailyGoal', async () => {
     mockGetNextWords.mockResolvedValue([])
 
-    const { result } = renderHook(
+    const { result } = renderHookWithStorage(
       () => useQuizSession(mockPair, { ...typeSettings, dailyGoal: 15 }, 'type'),
-      { wrapper: makeWrapper(mockStorage) },
+      mockStorage,
     )
 
     await waitFor(() => expect(result.current.state.phase).toBe('finished'))
@@ -498,9 +473,10 @@ describe('useQuizSession - type mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, typeSettings, 'type'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, typeSettings, 'type'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     expect(result.current.state.currentMode).toBe('type')
@@ -516,18 +492,20 @@ describe('useQuizSession - type mode', () => {
 // ─── Choice mode ──────────────────────────────────────────────────────────────
 
 describe('useQuizSession - choice mode', () => {
-  const choiceSettings: UserSettings = {
+  const choiceSettings = createMockSettings({
     activePairId: 'pair-1',
     quizMode: 'choice',
     dailyGoal: 3,
     theme: 'dark',
     typoTolerance: 1,
-  }
+  })
 
   let mockStorage: StorageService
 
   beforeEach(() => {
-    mockStorage = makeMockStorage(fourWords)
+    mockStorage = createMockStorage({
+      getWords: vi.fn().mockResolvedValue(fourWords),
+    })
     vi.clearAllMocks()
     mockRecordAttempt.mockResolvedValue(mockProgress)
     mockGenerateDistractors.mockReturnValue(mockDistractorResult)
@@ -537,9 +515,10 @@ describe('useQuizSession - choice mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     expect(result.current.state.phase).toBe('loading')
 
@@ -552,19 +531,22 @@ describe('useQuizSession - choice mode', () => {
   })
 
   it('should show not-enough-words phase when fewer than MIN_WORDS_FOR_CHOICE words', async () => {
-    const tinyStorage = makeMockStorage([
-      makeWord('w1', 'māja', 'house'),
-      makeWord('w2', 'kaķis', 'cat'),
-      makeWord('w3', 'suns', 'dog'),
-      // only 3 words - below MIN_WORDS_FOR_CHOICE (4)
-    ])
+    const tinyStorage = createMockStorage({
+      getWords: vi.fn().mockResolvedValue([
+        makeWord('w1', 'māja', 'house'),
+        makeWord('w2', 'kaķis', 'cat'),
+        makeWord('w3', 'suns', 'dog'),
+        // only 3 words - below MIN_WORDS_FOR_CHOICE (4)
+      ]),
+    })
     mockGetNextWords.mockResolvedValue([
       { word: makeWord('w1', 'māja', 'house'), direction: 'source-to-target', progress: null },
     ])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(tinyStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      tinyStorage,
+    )
 
     await waitFor(() => {
       expect(result.current.state.phase).toBe('not-enough-words')
@@ -574,9 +556,10 @@ describe('useQuizSession - choice mode', () => {
   it('should finish immediately if no words are returned by getNextWords', async () => {
     mockGetNextWords.mockResolvedValue([])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => {
       expect(result.current.state.phase).toBe('finished')
@@ -584,9 +567,10 @@ describe('useQuizSession - choice mode', () => {
   })
 
   it('should finish immediately if pair is null', async () => {
-    const { result } = renderHook(() => useQuizSession(null, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(null, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => {
       expect(result.current.state.phase).toBe('finished')
@@ -597,9 +581,10 @@ describe('useQuizSession - choice mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
 
@@ -612,9 +597,10 @@ describe('useQuizSession - choice mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
 
@@ -630,9 +616,10 @@ describe('useQuizSession - choice mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     await act(async () => {
@@ -655,9 +642,10 @@ describe('useQuizSession - choice mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     // Select index 0 = 'cat', but correct is index 1 = 'house'
@@ -681,9 +669,10 @@ describe('useQuizSession - choice mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
 
@@ -708,9 +697,10 @@ describe('useQuizSession - choice mode', () => {
       { word: word2, direction: 'source-to-target', progress: null },
     ])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     expect(result.current.state.currentWord?.id).toBe('w1')
@@ -749,9 +739,10 @@ describe('useQuizSession - choice mode', () => {
     ]
     mockGetNextWords.mockResolvedValue(wordsForQuiz)
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
 
@@ -786,9 +777,10 @@ describe('useQuizSession - choice mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
 
@@ -806,9 +798,10 @@ describe('useQuizSession - choice mode', () => {
       correctIndex: 1,
     })
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     expect(result.current.state.direction).toBe('target-to-source')
@@ -830,9 +823,10 @@ describe('useQuizSession - choice mode', () => {
     const word = makeWord('w1', 'māja', 'house')
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, choiceSettings, 'choice'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, choiceSettings, 'choice'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     expect(result.current.state.currentMode).toBe('choice')
@@ -848,19 +842,19 @@ describe('useQuizSession - choice mode', () => {
 // ─── Mixed mode ───────────────────────────────────────────────────────────────
 
 describe('useQuizSession - mixed mode', () => {
-  const mixedSettings: UserSettings = {
+  const mixedSettings = createMockSettings({
     activePairId: 'pair-1',
     quizMode: 'mixed',
     dailyGoal: 3,
     theme: 'dark',
     typoTolerance: 1,
-  }
+  })
 
   let mockStorage: StorageService
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockStorage = makeMockStorage()
+    mockStorage = createMockStorage()
     mockRecordAttempt.mockResolvedValue(mockProgress)
   })
 
@@ -875,9 +869,10 @@ describe('useQuizSession - mixed mode', () => {
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
     mockGenerateDistractors.mockReturnValue(mockDistr)
 
-    const { result } = renderHook(() => useQuizSession(mockPair, mixedSettings, 'mixed'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, mixedSettings, 'mixed'),
+      mockStorage,
+    )
 
     expect(result.current.state.phase).toBe('loading')
 
@@ -892,9 +887,10 @@ describe('useQuizSession - mixed mode', () => {
     vi.mocked(mockStorage.getWords).mockResolvedValue([])
     mockGetNextWords.mockResolvedValue([])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, mixedSettings, 'mixed'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, mixedSettings, 'mixed'),
+      mockStorage,
+    )
 
     await waitFor(() => {
       expect(result.current.state.phase).toBe('finished')
@@ -902,9 +898,10 @@ describe('useQuizSession - mixed mode', () => {
   })
 
   it('should finish immediately if pair is null', async () => {
-    const { result } = renderHook(() => useQuizSession(null, mixedSettings, 'mixed'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(null, mixedSettings, 'mixed'),
+      mockStorage,
+    )
 
     await waitFor(() => {
       expect(result.current.state.phase).toBe('finished')
@@ -921,9 +918,10 @@ describe('useQuizSession - mixed mode', () => {
     // Since only 1 word, choice is unavailable -> falls back to type
     mockRecordAttempt.mockResolvedValue(mockProgress)
 
-    const { result } = renderHook(() => useQuizSession(mockPair, mixedSettings, 'mixed'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, mixedSettings, 'mixed'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     // With only 1 word, choice is unavailable so mode must be type
@@ -963,9 +961,10 @@ describe('useQuizSession - mixed mode', () => {
     // Use Math.random mock to force choice mode
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.99) // > any typeRatio → choice
 
-    const { result } = renderHook(() => useQuizSession(mockPair, mixedSettings, 'mixed'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, mixedSettings, 'mixed'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     expect(result.current.state.currentMode).toBe('choice')
@@ -1002,9 +1001,10 @@ describe('useQuizSession - mixed mode', () => {
 
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.99) // force choice
 
-    const { result } = renderHook(() => useQuizSession(mockPair, mixedSettings, 'mixed'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, mixedSettings, 'mixed'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     expect(result.current.state.currentMode).toBe('choice')
@@ -1023,9 +1023,10 @@ describe('useQuizSession - mixed mode', () => {
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
     // With 1 word, choice unavailable → type mode forced
 
-    const { result } = renderHook(() => useQuizSession(mockPair, mixedSettings, 'mixed'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, mixedSettings, 'mixed'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     expect(result.current.state.currentMode).toBe('type')
@@ -1048,9 +1049,10 @@ describe('useQuizSession - mixed mode', () => {
     // Force type mode for simplicity
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0) // 0 < typeRatio → type
 
-    const { result } = renderHook(() => useQuizSession(mockPair, mixedSettings, 'mixed'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, mixedSettings, 'mixed'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
     expect(result.current.state.currentWord?.id).toBe('w1')
@@ -1093,9 +1095,10 @@ describe('useQuizSession - mixed mode', () => {
     // Force type mode so we can use submitAnswer
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
 
-    const { result } = renderHook(() => useQuizSession(mockPair, mixedSettings, 'mixed'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, mixedSettings, 'mixed'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
 
@@ -1133,9 +1136,10 @@ describe('useQuizSession - mixed mode', () => {
     vi.mocked(mockStorage.getWords).mockResolvedValue([word])
     mockGetNextWords.mockResolvedValue([{ word, direction: 'source-to-target', progress: null }])
 
-    const { result } = renderHook(() => useQuizSession(mockPair, mixedSettings, 'mixed'), {
-      wrapper: makeWrapper(mockStorage),
-    })
+    const { result } = renderHookWithStorage(
+      () => useQuizSession(mockPair, mixedSettings, 'mixed'),
+      mockStorage,
+    )
 
     await waitFor(() => expect(result.current.state.phase).toBe('question'))
 

--- a/src/features/starter-packs/components/PackBrowserDialog.test.tsx
+++ b/src/features/starter-packs/components/PackBrowserDialog.test.tsx
@@ -1,19 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, act } from '@testing-library/react'
+import { screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { createElement } from 'react'
-import type { ReactNode } from 'react'
 import { PackBrowserDialog } from './PackBrowserDialog'
-import { StorageContext } from '@/hooks/useStorage'
-import type { StorageService } from '@/services/storage'
-import type { StarterPack } from '@/types'
+import { createMockStarterPack } from '@/test/fixtures'
+import { createMockStorage } from '@/test/mockStorage'
+import { renderWithStorage } from '@/test/renderWithStorage'
 import * as starterPacksService from '@/services/starterPacks'
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const MOCK_PACK: StarterPack = {
+const MOCK_PACK = createMockStarterPack({
   id: 'en-lv-b1b2',
   name: 'English-Latvian B1-B2',
   description: 'Common English-Latvian vocabulary at B1-B2 level',
@@ -24,42 +22,7 @@ const MOCK_PACK: StarterPack = {
     { source: 'house', target: 'māja', tags: [] },
     { source: 'cat', target: 'kaķis', tags: [] },
   ],
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeStorage(): StorageService {
-  return {
-    getLanguagePairs: vi.fn().mockResolvedValue([]),
-    getLanguagePair: vi.fn().mockResolvedValue(null),
-    saveLanguagePair: vi.fn().mockResolvedValue(undefined),
-    deleteLanguagePair: vi.fn().mockResolvedValue(undefined),
-    getSettings: vi.fn().mockResolvedValue(null),
-    saveSettings: vi.fn().mockResolvedValue(undefined),
-    getWords: vi.fn().mockResolvedValue([]),
-    getWord: vi.fn().mockResolvedValue(null),
-    saveWord: vi.fn().mockResolvedValue(undefined),
-    saveWords: vi.fn().mockResolvedValue(undefined),
-    deleteWord: vi.fn().mockResolvedValue(undefined),
-    getWordProgress: vi.fn().mockResolvedValue(null),
-    getAllProgress: vi.fn().mockResolvedValue([]),
-    saveWordProgress: vi.fn().mockResolvedValue(undefined),
-    getDailyStats: vi.fn().mockResolvedValue(null),
-    getDailyStatsRange: vi.fn().mockResolvedValue([]),
-    saveDailyStats: vi.fn().mockResolvedValue(undefined),
-    getRecentDailyStats: vi.fn().mockResolvedValue([]),
-    exportAll: vi.fn().mockResolvedValue('{}'),
-    importAll: vi.fn().mockResolvedValue(undefined),
-    clearAll: vi.fn().mockResolvedValue(undefined),
-  } as StorageService
-}
-
-function makeWrapper(storage: StorageService) {
-  return ({ children }: { children: ReactNode }) =>
-    createElement(StorageContext.Provider, { value: storage }, children)
-}
+})
 
 const DEFAULT_PROPS = {
   open: true,
@@ -81,15 +44,13 @@ describe('PackBrowserDialog', () => {
 
   it('should not render dialog content when open is false', () => {
     vi.spyOn(starterPacksService, 'listPacks').mockResolvedValue([])
-    render(<PackBrowserDialog {...DEFAULT_PROPS} open={false} />, {
-      wrapper: makeWrapper(makeStorage()),
-    })
+    renderWithStorage(<PackBrowserDialog {...DEFAULT_PROPS} open={false} />, createMockStorage())
     expect(screen.queryByText('Browse starter packs')).not.toBeInTheDocument()
   })
 
   it('should render dialog title when open is true', async () => {
     vi.spyOn(starterPacksService, 'listPacks').mockResolvedValue([MOCK_PACK])
-    render(<PackBrowserDialog {...DEFAULT_PROPS} />, { wrapper: makeWrapper(makeStorage()) })
+    renderWithStorage(<PackBrowserDialog {...DEFAULT_PROPS} />, createMockStorage())
     await waitFor(() => {
       expect(screen.getByText('Browse starter packs')).toBeInTheDocument()
     })
@@ -98,13 +59,13 @@ describe('PackBrowserDialog', () => {
   it('should show loading indicator while packs are loading', () => {
     // Never resolves, so loading stays true
     vi.spyOn(starterPacksService, 'listPacks').mockReturnValue(new Promise(() => {}))
-    render(<PackBrowserDialog {...DEFAULT_PROPS} />, { wrapper: makeWrapper(makeStorage()) })
+    renderWithStorage(<PackBrowserDialog {...DEFAULT_PROPS} />, createMockStorage())
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
 
   it('should show "No starter packs available" when list is empty', async () => {
     vi.spyOn(starterPacksService, 'listPacks').mockResolvedValue([])
-    render(<PackBrowserDialog {...DEFAULT_PROPS} />, { wrapper: makeWrapper(makeStorage()) })
+    renderWithStorage(<PackBrowserDialog {...DEFAULT_PROPS} />, createMockStorage())
     await waitFor(() => {
       expect(screen.getByText(/No starter packs available/i)).toBeInTheDocument()
     })
@@ -112,7 +73,7 @@ describe('PackBrowserDialog', () => {
 
   it('should display pack name and description after load', async () => {
     vi.spyOn(starterPacksService, 'listPacks').mockResolvedValue([MOCK_PACK])
-    render(<PackBrowserDialog {...DEFAULT_PROPS} />, { wrapper: makeWrapper(makeStorage()) })
+    renderWithStorage(<PackBrowserDialog {...DEFAULT_PROPS} />, createMockStorage())
     await waitFor(() => {
       expect(screen.getByText('English-Latvian B1-B2')).toBeInTheDocument()
       expect(
@@ -123,7 +84,7 @@ describe('PackBrowserDialog', () => {
 
   it('should show error message when listPacks fails', async () => {
     vi.spyOn(starterPacksService, 'listPacks').mockRejectedValue(new Error('Network error'))
-    render(<PackBrowserDialog {...DEFAULT_PROPS} />, { wrapper: makeWrapper(makeStorage()) })
+    renderWithStorage(<PackBrowserDialog {...DEFAULT_PROPS} />, createMockStorage())
     await waitFor(() => {
       expect(screen.getByText('Network error')).toBeInTheDocument()
     })
@@ -133,9 +94,10 @@ describe('PackBrowserDialog', () => {
     const user = userEvent.setup()
     const onClose = vi.fn()
     vi.spyOn(starterPacksService, 'listPacks').mockResolvedValue([MOCK_PACK])
-    render(<PackBrowserDialog {...DEFAULT_PROPS} onClose={onClose} />, {
-      wrapper: makeWrapper(makeStorage()),
-    })
+    renderWithStorage(
+      <PackBrowserDialog {...DEFAULT_PROPS} onClose={onClose} />,
+      createMockStorage(),
+    )
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /^Close$/i })).toBeInTheDocument()
     })
@@ -151,9 +113,10 @@ describe('PackBrowserDialog', () => {
     vi.spyOn(starterPacksService, 'listPacks').mockResolvedValue([MOCK_PACK])
     vi.spyOn(starterPacksService, 'installPack').mockResolvedValue({ added: 2, skipped: 0 })
 
-    render(<PackBrowserDialog {...DEFAULT_PROPS} onInstalled={onInstalled} onClose={onClose} />, {
-      wrapper: makeWrapper(makeStorage()),
-    })
+    renderWithStorage(
+      <PackBrowserDialog {...DEFAULT_PROPS} onInstalled={onInstalled} onClose={onClose} />,
+      createMockStorage(),
+    )
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Install/i })).toBeInTheDocument()
@@ -175,7 +138,7 @@ describe('PackBrowserDialog', () => {
     vi.spyOn(starterPacksService, 'listPacks').mockResolvedValue([MOCK_PACK])
     vi.spyOn(starterPacksService, 'installPack').mockResolvedValue({ added: 2, skipped: 1 })
 
-    render(<PackBrowserDialog {...DEFAULT_PROPS} />, { wrapper: makeWrapper(makeStorage()) })
+    renderWithStorage(<PackBrowserDialog {...DEFAULT_PROPS} />, createMockStorage())
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Install/i })).toBeInTheDocument()
@@ -197,9 +160,10 @@ describe('PackBrowserDialog', () => {
     vi.spyOn(starterPacksService, 'listPacks').mockResolvedValue([MOCK_PACK])
     vi.spyOn(starterPacksService, 'installPack').mockResolvedValue({ added: 2, skipped: 0 })
 
-    render(<PackBrowserDialog {...DEFAULT_PROPS} onClose={onClose} />, {
-      wrapper: makeWrapper(makeStorage()),
-    })
+    renderWithStorage(
+      <PackBrowserDialog {...DEFAULT_PROPS} onClose={onClose} />,
+      createMockStorage(),
+    )
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Install/i })).toBeInTheDocument()
@@ -238,9 +202,10 @@ describe('PackBrowserDialog', () => {
     vi.spyOn(starterPacksService, 'listPacks').mockResolvedValue([MOCK_PACK])
     vi.spyOn(starterPacksService, 'installPack').mockResolvedValue({ added: 2, skipped: 0 })
 
-    render(<PackBrowserDialog {...DEFAULT_PROPS} onInstalled={onInstalled} onClose={onClose} />, {
-      wrapper: makeWrapper(makeStorage()),
-    })
+    renderWithStorage(
+      <PackBrowserDialog {...DEFAULT_PROPS} onInstalled={onInstalled} onClose={onClose} />,
+      createMockStorage(),
+    )
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Install/i })).toBeInTheDocument()
@@ -268,9 +233,10 @@ describe('PackBrowserDialog', () => {
     vi.spyOn(starterPacksService, 'listPacks').mockResolvedValue([MOCK_PACK])
     vi.spyOn(starterPacksService, 'installPack').mockRejectedValue(new Error('Install failed'))
 
-    render(<PackBrowserDialog {...DEFAULT_PROPS} onClose={onClose} />, {
-      wrapper: makeWrapper(makeStorage()),
-    })
+    renderWithStorage(
+      <PackBrowserDialog {...DEFAULT_PROPS} onClose={onClose} />,
+      createMockStorage(),
+    )
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Install/i })).toBeInTheDocument()

--- a/src/features/words/components/WordList.test.tsx
+++ b/src/features/words/components/WordList.test.tsx
@@ -3,23 +3,18 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { WordList } from './WordList'
 import type { Word, WordProgress } from '@/types'
+import { createMockWord, createMockProgress } from '@/test/fixtures'
 
 function makeWord(overrides: Partial<Word> = {}): Word {
-  return {
+  return createMockWord({
     id: `word-${Math.random()}`,
-    pairId: 'pair-1',
-    source: 'house',
-    target: 'māja',
-    notes: null,
-    tags: [],
     createdAt: Date.now(),
-    isFromPack: false,
     ...overrides,
-  }
+  })
 }
 
 function makeProgress(wordId: string, confidence: number): WordProgress {
-  return {
+  return createMockProgress({
     wordId,
     correctCount: 5,
     incorrectCount: 1,
@@ -27,8 +22,7 @@ function makeProgress(wordId: string, confidence: number): WordProgress {
     lastReviewed: Date.now(),
     nextReview: Date.now() + 86400000,
     confidence,
-    history: [],
-  }
+  })
 }
 
 const defaultProps = {

--- a/src/features/words/components/WordListScreen.test.tsx
+++ b/src/features/words/components/WordListScreen.test.tsx
@@ -1,82 +1,43 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { createElement } from 'react'
-import type { ReactNode } from 'react'
 import { WordListScreen } from './WordListScreen'
-import { StorageContext } from '@/hooks/useStorage'
 import type { StorageService } from '@/services/storage'
-import type { LanguagePair, Word, UserSettings } from '@/types'
+import type { Word } from '@/types'
+import { createMockPair, createMockWord, createMockSettings } from '@/test/fixtures'
+import { createMockStorage } from '@/test/mockStorage'
+import { renderWithStorage } from '@/test/renderWithStorage'
 
-const DEFAULT_SETTINGS: UserSettings = {
-  activePairId: 'pair-1',
-  quizMode: 'mixed',
-  dailyGoal: 20,
-  theme: 'dark',
-  typoTolerance: 1,
-}
-
-const DEFAULT_PAIR: LanguagePair = {
+const DEFAULT_PAIR = createMockPair({
   id: 'pair-1',
   sourceLang: 'English',
   sourceCode: 'en',
   targetLang: 'Latvian',
   targetCode: 'lv',
-  createdAt: 1_000_000,
-}
+})
+
+const DEFAULT_SETTINGS = createMockSettings({ activePairId: 'pair-1' })
 
 function makeWord(overrides: Partial<Word> = {}): Word {
-  return {
-    id: 'word-1',
-    pairId: 'pair-1',
-    source: 'house',
-    target: 'māja',
-    notes: null,
-    tags: [],
-    createdAt: 1_000_000,
-    isFromPack: false,
-    ...overrides,
-  }
+  return createMockWord(overrides)
 }
 
 function makeStorage(words: Word[] = []): StorageService {
   const storedWords = [...words]
-  return {
+  return createMockStorage({
     getLanguagePairs: vi.fn().mockResolvedValue([DEFAULT_PAIR]),
     getLanguagePair: vi.fn().mockResolvedValue(DEFAULT_PAIR),
-    saveLanguagePair: vi.fn().mockResolvedValue(undefined),
-    deleteLanguagePair: vi.fn().mockResolvedValue(undefined),
     getSettings: vi.fn().mockResolvedValue(DEFAULT_SETTINGS),
-    saveSettings: vi.fn().mockResolvedValue(undefined),
 
     getWords: vi.fn().mockImplementation(async () => [...storedWords]),
-    getWord: vi.fn().mockResolvedValue(null),
     saveWord: vi.fn().mockImplementation(async (word: Word) => {
       storedWords.push(word)
     }),
-    saveWords: vi.fn().mockResolvedValue(undefined),
     deleteWord: vi.fn().mockImplementation(async (id: string) => {
       const idx = storedWords.findIndex((w) => w.id === id)
       if (idx >= 0) storedWords.splice(idx, 1)
     }),
-
-    getWordProgress: vi.fn().mockResolvedValue(null),
-    getAllProgress: vi.fn().mockResolvedValue([]),
-    saveWordProgress: vi.fn().mockResolvedValue(undefined),
-
-    getDailyStats: vi.fn().mockResolvedValue(null),
-    getDailyStatsRange: vi.fn().mockResolvedValue([]),
-    saveDailyStats: vi.fn().mockResolvedValue(undefined),
-    getRecentDailyStats: vi.fn().mockResolvedValue([]),
-    exportAll: vi.fn().mockResolvedValue('{}'),
-    importAll: vi.fn().mockResolvedValue(undefined),
-    clearAll: vi.fn().mockResolvedValue(undefined),
-  } as StorageService
-}
-
-function makeWrapper(storage: StorageService) {
-  return ({ children }: { children: ReactNode }) =>
-    createElement(StorageContext.Provider, { value: storage }, children)
+  })
 }
 
 describe('WordListScreen', () => {
@@ -85,12 +46,12 @@ describe('WordListScreen', () => {
   })
 
   it('should show "no pair" message when activePair is null', () => {
-    render(<WordListScreen activePair={null} />, { wrapper: makeWrapper(makeStorage()) })
+    renderWithStorage(<WordListScreen activePair={null} />, makeStorage())
     expect(screen.getByText(/No language pair selected/i)).toBeInTheDocument()
   })
 
   it('should show empty state when no words exist', async () => {
-    render(<WordListScreen activePair={DEFAULT_PAIR} />, { wrapper: makeWrapper(makeStorage([])) })
+    renderWithStorage(<WordListScreen activePair={DEFAULT_PAIR} />, makeStorage([]))
 
     await waitFor(() => {
       expect(screen.getByText(/No words yet/i)).toBeInTheDocument()
@@ -98,7 +59,7 @@ describe('WordListScreen', () => {
   })
 
   it('should show "Add your first word" button in empty state', async () => {
-    render(<WordListScreen activePair={DEFAULT_PAIR} />, { wrapper: makeWrapper(makeStorage([])) })
+    renderWithStorage(<WordListScreen activePair={DEFAULT_PAIR} />, makeStorage([]))
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Add your first word/i })).toBeInTheDocument()
@@ -107,9 +68,7 @@ describe('WordListScreen', () => {
 
   it('should show word list when words exist', async () => {
     const word = makeWord({ source: 'house', target: 'māja' })
-    render(<WordListScreen activePair={DEFAULT_PAIR} />, {
-      wrapper: makeWrapper(makeStorage([word])),
-    })
+    renderWithStorage(<WordListScreen activePair={DEFAULT_PAIR} />, makeStorage([word]))
 
     await waitFor(() => {
       expect(screen.getByText('house')).toBeInTheDocument()
@@ -119,9 +78,7 @@ describe('WordListScreen', () => {
 
   it('should show pair name as heading when words exist', async () => {
     const word = makeWord()
-    render(<WordListScreen activePair={DEFAULT_PAIR} />, {
-      wrapper: makeWrapper(makeStorage([word])),
-    })
+    renderWithStorage(<WordListScreen activePair={DEFAULT_PAIR} />, makeStorage([word]))
 
     await waitFor(() => {
       expect(screen.getByText('English → Latvian')).toBeInTheDocument()
@@ -131,9 +88,7 @@ describe('WordListScreen', () => {
   it('should open add word dialog when "Add word" is clicked', async () => {
     const user = userEvent.setup()
     const word = makeWord()
-    render(<WordListScreen activePair={DEFAULT_PAIR} />, {
-      wrapper: makeWrapper(makeStorage([word])),
-    })
+    renderWithStorage(<WordListScreen activePair={DEFAULT_PAIR} />, makeStorage([word]))
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Add word/i })).toBeInTheDocument()
@@ -146,7 +101,7 @@ describe('WordListScreen', () => {
 
   it('should add a word and show it in the list', async () => {
     const user = userEvent.setup()
-    render(<WordListScreen activePair={DEFAULT_PAIR} />, { wrapper: makeWrapper(makeStorage([])) })
+    renderWithStorage(<WordListScreen activePair={DEFAULT_PAIR} />, makeStorage([]))
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Add your first word/i })).toBeInTheDocument()
@@ -167,9 +122,7 @@ describe('WordListScreen', () => {
   it('should open edit dialog when edit button is clicked', async () => {
     const user = userEvent.setup()
     const word = makeWord({ source: 'house', target: 'māja' })
-    render(<WordListScreen activePair={DEFAULT_PAIR} />, {
-      wrapper: makeWrapper(makeStorage([word])),
-    })
+    renderWithStorage(<WordListScreen activePair={DEFAULT_PAIR} />, makeStorage([word]))
 
     await waitFor(() => {
       expect(screen.getByText('house')).toBeInTheDocument()
@@ -184,9 +137,7 @@ describe('WordListScreen', () => {
   it('should delete a word when confirmed', async () => {
     const user = userEvent.setup()
     const word = makeWord({ source: 'house', target: 'māja' })
-    render(<WordListScreen activePair={DEFAULT_PAIR} />, {
-      wrapper: makeWrapper(makeStorage([word])),
-    })
+    renderWithStorage(<WordListScreen activePair={DEFAULT_PAIR} />, makeStorage([word]))
 
     await waitFor(() => {
       expect(screen.getByText('house')).toBeInTheDocument()

--- a/src/features/words/useWords.test.ts
+++ b/src/features/words/useWords.test.ts
@@ -1,63 +1,35 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { useWords } from './useWords'
-import type { StorageService } from '@/services/storage'
-import type { Word, WordProgress, UserSettings } from '@/types'
-import { StorageContext } from '@/hooks/useStorage'
 import { createElement } from 'react'
 import type { ReactNode } from 'react'
+import { useWords } from './useWords'
+import type { StorageService } from '@/services/storage'
+import type { Word, WordProgress } from '@/types'
+import { StorageContext } from '@/hooks/useStorage'
+import { createMockWord, createMockProgress, createMockSettings } from '@/test/fixtures'
+import { createMockStorage } from '@/test/mockStorage'
+import { renderHookWithStorage } from '@/test/renderWithStorage'
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const DEFAULT_SETTINGS: UserSettings = {
-  activePairId: 'pair-1',
-  quizMode: 'mixed',
-  dailyGoal: 20,
-  theme: 'dark',
-  typoTolerance: 1,
-}
+const DEFAULT_SETTINGS = createMockSettings({ activePairId: 'pair-1', quizMode: 'mixed' })
 
 function makeWord(overrides: Partial<Word> = {}): Word {
-  return {
-    id: 'word-1',
-    pairId: 'pair-1',
-    source: 'house',
-    target: 'māja',
-    notes: null,
-    tags: [],
-    createdAt: 1_000_000,
-    isFromPack: false,
-    ...overrides,
-  }
+  return createMockWord(overrides)
 }
 
 function makeProgress(overrides: Partial<WordProgress> = {}): WordProgress {
-  return {
-    wordId: 'word-1',
-    correctCount: 3,
-    incorrectCount: 1,
-    streak: 2,
-    lastReviewed: 1_000_000,
-    nextReview: 2_000_000,
-    confidence: 0.6,
-    history: [],
-    ...overrides,
-  }
+  return createMockProgress(overrides)
 }
 
 function makeStorage(words: Word[] = [], progress: WordProgress[] = []): StorageService {
   const storedWords = [...words]
   const storedProgress = [...progress]
 
-  return {
-    getLanguagePairs: vi.fn().mockResolvedValue([]),
-    getLanguagePair: vi.fn().mockResolvedValue(null),
-    saveLanguagePair: vi.fn().mockResolvedValue(undefined),
-    deleteLanguagePair: vi.fn().mockResolvedValue(undefined),
+  return createMockStorage({
     getSettings: vi.fn().mockResolvedValue(DEFAULT_SETTINGS),
-    saveSettings: vi.fn().mockResolvedValue(undefined),
 
     getWords: vi.fn().mockImplementation(async () => [...storedWords]),
     getWord: vi
@@ -68,29 +40,13 @@ function makeStorage(words: Word[] = [], progress: WordProgress[] = []): Storage
       if (idx >= 0) storedWords[idx] = word
       else storedWords.push(word)
     }),
-    saveWords: vi.fn().mockResolvedValue(undefined),
     deleteWord: vi.fn().mockImplementation(async (id: string) => {
       const idx = storedWords.findIndex((w) => w.id === id)
       if (idx >= 0) storedWords.splice(idx, 1)
     }),
 
-    getWordProgress: vi.fn().mockResolvedValue(null),
     getAllProgress: vi.fn().mockImplementation(async () => [...storedProgress]),
-    saveWordProgress: vi.fn().mockResolvedValue(undefined),
-
-    getDailyStats: vi.fn().mockResolvedValue(null),
-    getDailyStatsRange: vi.fn().mockResolvedValue([]),
-    saveDailyStats: vi.fn().mockResolvedValue(undefined),
-    getRecentDailyStats: vi.fn().mockResolvedValue([]),
-    exportAll: vi.fn().mockResolvedValue('{}'),
-    importAll: vi.fn().mockResolvedValue(undefined),
-    clearAll: vi.fn().mockResolvedValue(undefined),
-  } as StorageService
-}
-
-function makeWrapper(storage: StorageService) {
-  return ({ children }: { children: ReactNode }) =>
-    createElement(StorageContext.Provider, { value: storage }, children)
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -105,17 +61,13 @@ describe('useWords', () => {
   describe('initial load', () => {
     it('should start in loading state when pairId is provided', () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
       expect(result.current.loading).toBe(true)
     })
 
     it('should immediately be not loading when pairId is null', async () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useWords(null), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords(null), storage)
       await act(async () => {})
       expect(result.current.loading).toBe(false)
       expect(result.current.words).toHaveLength(0)
@@ -125,9 +77,7 @@ describe('useWords', () => {
       const word = makeWord()
       const storage = makeStorage([word])
 
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -141,9 +91,7 @@ describe('useWords', () => {
       const progress = makeProgress()
       const storage = makeStorage([word], [progress])
 
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -153,6 +101,11 @@ describe('useWords', () => {
     it('should clear words when pairId becomes null', async () => {
       const word = makeWord()
       const storage = makeStorage([word])
+
+      const makeWrapper =
+        (s: StorageService) =>
+        ({ children }: { children: ReactNode }) =>
+          createElement(StorageContext.Provider, { value: s }, children)
 
       const { result, rerender } = renderHook(
         ({ pairId }: { pairId: string | null }) => useWords(pairId),
@@ -174,9 +127,7 @@ describe('useWords', () => {
   describe('addWord', () => {
     it('should add a new word and return it', async () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -198,9 +149,7 @@ describe('useWords', () => {
 
     it('should save the word to storage', async () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -221,9 +170,7 @@ describe('useWords', () => {
     it('should prevent exact duplicates (case-insensitive) and return null', async () => {
       const word = makeWord({ source: 'Cat', target: 'Kaķis' })
       const storage = makeStorage([word])
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -244,9 +191,7 @@ describe('useWords', () => {
     it('should allow words with same source but different target', async () => {
       const word = makeWord({ source: 'cat', target: 'kaķis' })
       const storage = makeStorage([word])
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -266,9 +211,7 @@ describe('useWords', () => {
 
     it('should trim whitespace from source and target', async () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -287,9 +230,7 @@ describe('useWords', () => {
 
     it('should set isFromPack to false for user-added words', async () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -310,9 +251,7 @@ describe('useWords', () => {
     it('should update an existing word in state', async () => {
       const word = makeWord({ source: 'house', target: 'māja' })
       const storage = makeStorage([word])
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -335,9 +274,7 @@ describe('useWords', () => {
     it('should persist the updated word to storage', async () => {
       const word = makeWord()
       const storage = makeStorage([word])
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -357,9 +294,7 @@ describe('useWords', () => {
 
     it('should do nothing when wordId does not exist', async () => {
       const storage = makeStorage()
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -380,9 +315,7 @@ describe('useWords', () => {
     it('should remove the word from state', async () => {
       const word = makeWord()
       const storage = makeStorage([word])
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
       expect(result.current.words).toHaveLength(1)
@@ -397,9 +330,7 @@ describe('useWords', () => {
     it('should call storage.deleteWord', async () => {
       const word = makeWord()
       const storage = makeStorage([word])
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 
@@ -414,9 +345,7 @@ describe('useWords', () => {
       const word = makeWord()
       const progress = makeProgress()
       const storage = makeStorage([word], [progress])
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
       expect(result.current.progressMap.has('word-1')).toBe(true)
@@ -437,9 +366,7 @@ describe('useWords', () => {
         makeWord({ id: 'w3', source: 'bird' }),
       ]
       const storage = makeStorage(words)
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
       expect(result.current.words).toHaveLength(3)
@@ -455,9 +382,7 @@ describe('useWords', () => {
     it('should call storage.deleteWord for each id', async () => {
       const words = [makeWord({ id: 'w1' }), makeWord({ id: 'w2' })]
       const storage = makeStorage(words)
-      const { result } = renderHook(() => useWords('pair-1'), {
-        wrapper: makeWrapper(storage),
-      })
+      const { result } = renderHookWithStorage(() => useWords('pair-1'), storage)
 
       await act(async () => {})
 

--- a/src/hooks/useThemeMode.test.ts
+++ b/src/hooks/useThemeMode.test.ts
@@ -1,47 +1,9 @@
 import { describe, it, expect, beforeEach, vi, type MockInstance } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useThemeMode } from './useThemeMode'
-import type { StorageService } from '@/services/storage/StorageService'
+import { createMockSettings } from '@/test/fixtures'
+import { createMockStorage } from '@/test/mockStorage'
 import type { UserSettings } from '@/types'
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeSettings(theme: UserSettings['theme']): UserSettings {
-  return {
-    activePairId: null,
-    quizMode: 'mixed',
-    dailyGoal: 20,
-    theme,
-    typoTolerance: 1,
-  }
-}
-
-function makeStorage(theme: UserSettings['theme']): StorageService {
-  const settings: UserSettings = makeSettings(theme)
-
-  return {
-    getSettings: vi.fn().mockResolvedValue({ ...settings }),
-    saveSettings: vi.fn().mockImplementation(async (updated: UserSettings) => {
-      Object.assign(settings, updated)
-    }),
-    // Unused methods – cast to satisfy the interface
-    getLanguagePairs: vi.fn(),
-    saveLanguagePair: vi.fn(),
-    deleteLanguagePair: vi.fn(),
-    getWords: vi.fn(),
-    saveWord: vi.fn(),
-    saveWords: vi.fn(),
-    deleteWord: vi.fn(),
-    getWordProgress: vi.fn(),
-    getAllProgress: vi.fn(),
-    saveWordProgress: vi.fn(),
-    getDailyStats: vi.fn(),
-    saveDailyStats: vi.fn(),
-    getRecentDailyStats: vi.fn(),
-  } as unknown as StorageService
-}
 
 // ---------------------------------------------------------------------------
 // matchMedia mock
@@ -78,7 +40,11 @@ describe('useThemeMode', () => {
 
   it('should initialise with dark mode when settings.theme is "dark"', async () => {
     mockMatchMedia(false)
-    const storage = makeStorage('dark')
+    const settings = createMockSettings({ theme: 'dark' })
+    const storage = createMockStorage({
+      getSettings: vi.fn().mockResolvedValue(settings),
+      saveSettings: vi.fn().mockResolvedValue(undefined),
+    })
     const { result } = renderHook(() => useThemeMode(storage))
 
     await act(async () => {})
@@ -89,7 +55,11 @@ describe('useThemeMode', () => {
 
   it('should initialise with light mode when settings.theme is "light"', async () => {
     mockMatchMedia(false)
-    const storage = makeStorage('light')
+    const settings = createMockSettings({ theme: 'light' })
+    const storage = createMockStorage({
+      getSettings: vi.fn().mockResolvedValue(settings),
+      saveSettings: vi.fn().mockResolvedValue(undefined),
+    })
     const { result } = renderHook(() => useThemeMode(storage))
 
     await act(async () => {})
@@ -100,7 +70,11 @@ describe('useThemeMode', () => {
 
   it('should resolve "system" to "dark" when OS prefers dark', async () => {
     mockMatchMedia(true)
-    const storage = makeStorage('system')
+    const settings = createMockSettings({ theme: 'system' })
+    const storage = createMockStorage({
+      getSettings: vi.fn().mockResolvedValue(settings),
+      saveSettings: vi.fn().mockResolvedValue(undefined),
+    })
     const { result } = renderHook(() => useThemeMode(storage))
 
     await act(async () => {})
@@ -111,7 +85,11 @@ describe('useThemeMode', () => {
 
   it('should resolve "system" to "light" when OS prefers light', async () => {
     mockMatchMedia(false)
-    const storage = makeStorage('system')
+    const settings = createMockSettings({ theme: 'system' })
+    const storage = createMockStorage({
+      getSettings: vi.fn().mockResolvedValue(settings),
+      saveSettings: vi.fn().mockResolvedValue(undefined),
+    })
     const { result } = renderHook(() => useThemeMode(storage))
 
     await act(async () => {})
@@ -122,7 +100,14 @@ describe('useThemeMode', () => {
 
   it('should persist the new preference when setPreference is called', async () => {
     mockMatchMedia(false)
-    const storage = makeStorage('dark')
+    const settings = createMockSettings({ theme: 'dark' })
+    const storedSettings = { ...settings }
+    const storage = createMockStorage({
+      getSettings: vi.fn().mockImplementation(async () => ({ ...storedSettings })),
+      saveSettings: vi.fn().mockImplementation(async (updated: UserSettings) => {
+        Object.assign(storedSettings, updated)
+      }),
+    })
     const { result } = renderHook(() => useThemeMode(storage))
 
     await act(async () => {})
@@ -137,7 +122,14 @@ describe('useThemeMode', () => {
 
   it('should update mode to dark when switching to "dark" preference', async () => {
     mockMatchMedia(false)
-    const storage = makeStorage('light')
+    const settings = createMockSettings({ theme: 'light' })
+    const storedSettings = { ...settings }
+    const storage = createMockStorage({
+      getSettings: vi.fn().mockImplementation(async () => ({ ...storedSettings })),
+      saveSettings: vi.fn().mockImplementation(async (updated: UserSettings) => {
+        Object.assign(storedSettings, updated)
+      }),
+    })
     const { result } = renderHook(() => useThemeMode(storage))
 
     await act(async () => {})
@@ -150,7 +142,14 @@ describe('useThemeMode', () => {
 
   it('should load settings only once on mount', async () => {
     mockMatchMedia(false)
-    const storage = makeStorage('dark')
+    const settings = createMockSettings({ theme: 'dark' })
+    const storedSettings = { ...settings }
+    const storage = createMockStorage({
+      getSettings: vi.fn().mockImplementation(async () => ({ ...storedSettings })),
+      saveSettings: vi.fn().mockImplementation(async (updated: UserSettings) => {
+        Object.assign(storedSettings, updated)
+      }),
+    })
     const { result } = renderHook(() => useThemeMode(storage))
 
     await act(async () => {})

--- a/src/services/starterPacks.test.ts
+++ b/src/services/starterPacks.test.ts
@@ -1,60 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { StarterPack, Word } from '@/types'
+import type { Word } from '@/types'
 import { listPackIds, loadPack, listPacks, installPack, packMatchesPair } from './starterPacks'
+import { createMockStarterPack, createMockWord } from '@/test/fixtures'
+import { createMockStorage } from '@/test/mockStorage'
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-const makePack = (overrides: Partial<StarterPack> = {}): StarterPack => ({
-  id: 'test-pack',
-  name: 'Test Pack',
-  description: 'A pack for testing',
-  sourceCode: 'lv',
-  targetCode: 'en',
-  level: 'B1',
-  words: [
-    { source: 'ūdens', target: 'water', tags: ['B1'] },
-    { source: 'maize', target: 'bread', tags: ['B1'] },
-  ],
-  ...overrides,
-})
+const makePack = createMockStarterPack
 
-const makeWord = (overrides: Partial<Word> = {}): Word => ({
-  id: 'w1',
-  pairId: 'pair-1',
-  source: 'ūdens',
-  target: 'water',
-  notes: null,
-  tags: ['B1', 'starter-pack'],
-  createdAt: 1000,
-  isFromPack: true,
-  ...overrides,
-})
+function makeWord(overrides: Partial<Word> = {}): Word {
+  return createMockWord({
+    id: 'w1',
+    pairId: 'pair-1',
+    source: 'house',
+    target: 'māja',
+    tags: ['B1', 'starter-pack'],
+    createdAt: 1000,
+    isFromPack: true,
+    ...overrides,
+  })
+}
 
 function makeStorageMock(existingWords: Word[] = []) {
-  return {
+  return createMockStorage({
     getWords: vi.fn().mockResolvedValue(existingWords),
     saveWords: vi.fn().mockResolvedValue(undefined),
-    // Unused methods - only included for type compatibility
-    getLanguagePairs: vi.fn(),
-    getLanguagePair: vi.fn(),
-    saveLanguagePair: vi.fn(),
-    deleteLanguagePair: vi.fn(),
-    getWord: vi.fn(),
-    saveWord: vi.fn(),
-    deleteWord: vi.fn(),
-    getWordProgress: vi.fn(),
-    getAllProgress: vi.fn(),
-    saveWordProgress: vi.fn(),
-    getSettings: vi.fn(),
-    saveSettings: vi.fn(),
-    getDailyStats: vi.fn(),
-    getDailyStatsRange: vi.fn(),
-    saveDailyStats: vi.fn(),
-    getRecentDailyStats: vi.fn(),
-    exportAll: vi.fn(),
-    importAll: vi.fn(),
-    clearAll: vi.fn(),
-  }
+  })
 }
 
 // ── packMatchesPair ───────────────────────────────────────────────────────────
@@ -212,7 +183,14 @@ describe('installPack', () => {
   // ── same direction (pack codes == pair codes) ──────────────────────────────
 
   it('should add all words when storage is empty', async () => {
-    const pack = makePack()
+    const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
+      words: [
+        { source: 'ūdens', target: 'water', tags: ['B1'] },
+        { source: 'maize', target: 'bread', tags: ['B1'] },
+      ],
+    })
     const storage = makeStorageMock([])
 
     const result = await installPack(pack, 'pair-1', 'lv', 'en', storage)
@@ -221,39 +199,55 @@ describe('installPack', () => {
     expect(result.skipped).toBe(0)
     expect(storage.saveWords).toHaveBeenCalledOnce()
 
-    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    const saved = vi.mocked(storage.saveWords).mock.calls[0][0] as Word[]
     expect(saved).toHaveLength(2)
   })
 
   it('should set isFromPack to true on all installed words', async () => {
-    const pack = makePack()
+    const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
+      words: [
+        { source: 'ūdens', target: 'water', tags: ['B1'] },
+        { source: 'maize', target: 'bread', tags: ['B1'] },
+      ],
+    })
     const storage = makeStorageMock([])
 
     await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
-    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    const saved = vi.mocked(storage.saveWords).mock.calls[0][0] as Word[]
     expect(saved.every((w) => w.isFromPack)).toBe(true)
   })
 
   it('should add the "starter-pack" tag to all installed words', async () => {
-    const pack = makePack()
+    const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
+      words: [
+        { source: 'ūdens', target: 'water', tags: ['B1'] },
+        { source: 'maize', target: 'bread', tags: ['B1'] },
+      ],
+    })
     const storage = makeStorageMock([])
 
     await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
-    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    const saved = vi.mocked(storage.saveWords).mock.calls[0][0] as Word[]
     expect(saved.every((w) => w.tags.includes('starter-pack'))).toBe(true)
   })
 
   it('should preserve the original tags alongside "starter-pack"', async () => {
     const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
       words: [{ source: 'ūdens', target: 'water', tags: ['food-drink', 'B1'] }],
     })
     const storage = makeStorageMock([])
 
     await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
-    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    const saved = vi.mocked(storage.saveWords).mock.calls[0][0] as Word[]
     expect(saved[0].tags).toContain('food-drink')
     expect(saved[0].tags).toContain('B1')
     expect(saved[0].tags).toContain('starter-pack')
@@ -262,6 +256,8 @@ describe('installPack', () => {
   it('should skip words that already exist (case-insensitive match)', async () => {
     const existingWord = makeWord({ source: 'Ūdens', target: 'Water' })
     const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
       words: [
         { source: 'ūdens', target: 'water', tags: ['B1'] }, // duplicate
         { source: 'maize', target: 'bread', tags: ['B1'] }, // new
@@ -274,7 +270,7 @@ describe('installPack', () => {
     expect(result.added).toBe(1)
     expect(result.skipped).toBe(1)
 
-    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    const saved = vi.mocked(storage.saveWords).mock.calls[0][0] as Word[]
     expect(saved).toHaveLength(1)
     expect(saved[0].source).toBe('maize')
   })
@@ -284,7 +280,14 @@ describe('installPack', () => {
       makeWord({ id: 'w1', source: 'ūdens', target: 'water' }),
       makeWord({ id: 'w2', source: 'maize', target: 'bread' }),
     ]
-    const pack = makePack()
+    const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
+      words: [
+        { source: 'ūdens', target: 'water', tags: ['B1'] },
+        { source: 'maize', target: 'bread', tags: ['B1'] },
+      ],
+    })
     const storage = makeStorageMock(existingWords)
 
     const result = await installPack(pack, 'pair-1', 'lv', 'en', storage)
@@ -299,7 +302,14 @@ describe('installPack', () => {
       makeWord({ id: 'w1', source: 'ūdens', target: 'water' }),
       makeWord({ id: 'w2', source: 'maize', target: 'bread' }),
     ]
-    const pack = makePack()
+    const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
+      words: [
+        { source: 'ūdens', target: 'water', tags: ['B1'] },
+        { source: 'maize', target: 'bread', tags: ['B1'] },
+      ],
+    })
     const storage = makeStorageMock(existingWords)
 
     await installPack(pack, 'pair-1', 'lv', 'en', storage)
@@ -308,17 +318,26 @@ describe('installPack', () => {
   })
 
   it('should assign the correct pairId to all installed words', async () => {
-    const pack = makePack()
+    const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
+      words: [
+        { source: 'ūdens', target: 'water', tags: ['B1'] },
+        { source: 'maize', target: 'bread', tags: ['B1'] },
+      ],
+    })
     const storage = makeStorageMock([])
 
     await installPack(pack, 'my-pair-id', 'lv', 'en', storage)
 
-    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    const saved = vi.mocked(storage.saveWords).mock.calls[0][0] as Word[]
     expect(saved.every((w) => w.pairId === 'my-pair-id')).toBe(true)
   })
 
   it('should handle intra-pack duplicates (same word twice in the pack)', async () => {
     const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
       words: [
         { source: 'ūdens', target: 'water', tags: ['B1'] },
         { source: 'ūdens', target: 'water', tags: ['B1'] }, // duplicate entry
@@ -335,13 +354,15 @@ describe('installPack', () => {
   it('should not modify existing words in storage', async () => {
     const existingWord = makeWord()
     const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
       words: [{ source: 'maize', target: 'bread', tags: ['B1'] }],
     })
     const storage = makeStorageMock([existingWord])
 
     await installPack(pack, 'pair-1', 'lv', 'en', storage)
 
-    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    const saved = vi.mocked(storage.saveWords).mock.calls[0][0] as Word[]
     const savedIds = saved.map((w) => w.id)
     expect(savedIds).not.toContain(existingWord.id)
   })
@@ -363,7 +384,7 @@ describe('installPack', () => {
     const result = await installPack(pack, 'pair-1', 'en', 'lv', storage)
 
     expect(result.added).toBe(2)
-    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    const saved = vi.mocked(storage.saveWords).mock.calls[0][0] as Word[]
     expect(saved[0].source).toBe('water')
     expect(saved[0].target).toBe('ūdens')
     expect(saved[1].source).toBe('bread')
@@ -388,7 +409,7 @@ describe('installPack', () => {
     expect(result.added).toBe(1)
     expect(result.skipped).toBe(1)
 
-    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    const saved = vi.mocked(storage.saveWords).mock.calls[0][0] as Word[]
     expect(saved[0].source).toBe('bread')
     expect(saved[0].target).toBe('maize')
   })
@@ -403,19 +424,26 @@ describe('installPack', () => {
 
     await installPack(pack, 'pair-1', 'en', 'lv', storage)
 
-    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    const saved = vi.mocked(storage.saveWords).mock.calls[0][0] as Word[]
     expect(saved[0].tags).toContain('food-drink')
     expect(saved[0].tags).toContain('B1')
     expect(saved[0].tags).toContain('starter-pack')
   })
 
   it('should set isFromPack to true on reversed-direction installs', async () => {
-    const pack = makePack({ sourceCode: 'lv', targetCode: 'en' })
+    const pack = makePack({
+      sourceCode: 'lv',
+      targetCode: 'en',
+      words: [
+        { source: 'ūdens', target: 'water', tags: ['B1'] },
+        { source: 'maize', target: 'bread', tags: ['B1'] },
+      ],
+    })
     const storage = makeStorageMock([])
 
     await installPack(pack, 'pair-1', 'en', 'lv', storage)
 
-    const saved = storage.saveWords.mock.calls[0][0] as Word[]
+    const saved = vi.mocked(storage.saveWords).mock.calls[0][0] as Word[]
     expect(saved.every((w) => w.isFromPack)).toBe(true)
   })
 

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared test data factories.
+ *
+ * Each factory returns a complete, valid object with sensible defaults.
+ * Pass overrides to customise only the fields that matter for a specific test.
+ *
+ * Usage:
+ *   const word = createMockWord({ source: 'māja' })
+ *   const pair = createMockPair({ sourceCode: 'ru' })
+ */
+
+import type {
+  LanguagePair,
+  Word,
+  WordProgress,
+  UserSettings,
+  DailyStats,
+  StarterPack,
+} from '@/types'
+
+export function createMockPair(overrides: Partial<LanguagePair> = {}): LanguagePair {
+  return {
+    id: 'pair-1',
+    sourceLang: 'English',
+    sourceCode: 'en',
+    targetLang: 'Latvian',
+    targetCode: 'lv',
+    createdAt: 1_000_000,
+    ...overrides,
+  }
+}
+
+export function createMockWord(overrides: Partial<Word> = {}): Word {
+  return {
+    id: 'word-1',
+    pairId: 'pair-1',
+    source: 'house',
+    target: 'māja',
+    notes: null,
+    tags: [],
+    createdAt: 1_000_000,
+    isFromPack: false,
+    ...overrides,
+  }
+}
+
+export function createMockProgress(overrides: Partial<WordProgress> = {}): WordProgress {
+  return {
+    wordId: 'word-1',
+    correctCount: 3,
+    incorrectCount: 1,
+    streak: 2,
+    lastReviewed: 1_000_000,
+    nextReview: 2_000_000,
+    confidence: 0.6,
+    history: [],
+    ...overrides,
+  }
+}
+
+export function createMockSettings(overrides: Partial<UserSettings> = {}): UserSettings {
+  return {
+    activePairId: null,
+    quizMode: 'mixed',
+    dailyGoal: 20,
+    theme: 'dark',
+    typoTolerance: 1,
+    ...overrides,
+  }
+}
+
+export function createMockDailyStats(overrides: Partial<DailyStats> = {}): DailyStats {
+  return {
+    date: '2026-03-20',
+    wordsReviewed: 10,
+    correctCount: 8,
+    incorrectCount: 2,
+    streakDays: 3,
+    ...overrides,
+  }
+}
+
+export function createMockStarterPack(overrides: Partial<StarterPack> = {}): StarterPack {
+  return {
+    id: 'test-pack',
+    name: 'Test Pack',
+    description: 'A pack for testing',
+    sourceCode: 'en',
+    targetCode: 'lv',
+    level: 'B1',
+    words: [
+      { source: 'house', target: 'māja', tags: ['B1'] },
+      { source: 'cat', target: 'kaķis', tags: ['B1'] },
+    ],
+    ...overrides,
+  }
+}

--- a/src/test/mockStorage.ts
+++ b/src/test/mockStorage.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared mock StorageService factory.
+ *
+ * Returns a StorageService where every method is a vi.fn() with a sensible
+ * default return value (empty arrays, null, etc.).
+ *
+ * Individual tests can override specific methods:
+ *   const storage = createMockStorage({
+ *     getWords: vi.fn().mockResolvedValue([createMockWord()]),
+ *   })
+ */
+
+import { vi } from 'vitest'
+import type { StorageService } from '@/services/storage/StorageService'
+
+export function createMockStorage(overrides: Partial<StorageService> = {}): StorageService {
+  return {
+    getLanguagePairs: vi.fn().mockResolvedValue([]),
+    getLanguagePair: vi.fn().mockResolvedValue(null),
+    saveLanguagePair: vi.fn().mockResolvedValue(undefined),
+    deleteLanguagePair: vi.fn().mockResolvedValue(undefined),
+    getWords: vi.fn().mockResolvedValue([]),
+    getWord: vi.fn().mockResolvedValue(null),
+    saveWord: vi.fn().mockResolvedValue(undefined),
+    saveWords: vi.fn().mockResolvedValue(undefined),
+    deleteWord: vi.fn().mockResolvedValue(undefined),
+    getWordProgress: vi.fn().mockResolvedValue(null),
+    getAllProgress: vi.fn().mockResolvedValue([]),
+    saveWordProgress: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue(null),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+    getDailyStats: vi.fn().mockResolvedValue(null),
+    getDailyStatsRange: vi.fn().mockResolvedValue([]),
+    saveDailyStats: vi.fn().mockResolvedValue(undefined),
+    getRecentDailyStats: vi.fn().mockResolvedValue([]),
+    exportAll: vi.fn().mockResolvedValue('{}'),
+    importAll: vi.fn().mockResolvedValue(undefined),
+    clearAll: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}

--- a/src/test/renderWithStorage.tsx
+++ b/src/test/renderWithStorage.tsx
@@ -1,0 +1,36 @@
+/**
+ * Shared render helpers that wrap components and hooks in StorageContext.Provider.
+ *
+ * Usage:
+ *   const storage = createMockStorage({ getWords: vi.fn().mockResolvedValue([word]) })
+ *   renderWithStorage(<MyComponent />, storage)
+ *
+ *   const { result } = renderHookWithStorage(() => useMyHook(), storage)
+ */
+
+import { createElement, type ReactElement } from 'react'
+import type { ReactNode } from 'react'
+import { render, renderHook } from '@testing-library/react'
+import type { RenderResult, RenderHookResult } from '@testing-library/react'
+import { StorageContext } from '@/hooks/useStorage'
+import type { StorageService } from '@/services/storage/StorageService'
+import { createMockStorage } from './mockStorage'
+
+function makeWrapper(storage: StorageService) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(StorageContext.Provider, { value: storage }, children)
+}
+
+export function renderWithStorage(
+  ui: ReactElement,
+  storage: StorageService = createMockStorage(),
+): RenderResult {
+  return render(ui, { wrapper: makeWrapper(storage) })
+}
+
+export function renderHookWithStorage<T>(
+  hook: () => T,
+  storage: StorageService = createMockStorage(),
+): RenderHookResult<T, unknown> {
+  return renderHook(hook, { wrapper: makeWrapper(storage) })
+}


### PR DESCRIPTION
## Summary

- Extracts shared test utilities (`fixtures.ts`, `mockStorage.ts`, `renderWithStorage.tsx`) used across 8 test files, eliminating ~600 lines of duplicated boilerplate
- Extracts `QuizLayout` component shared by `ChoiceQuizContent` and `TypeQuizContent`, eliminating ~49 lines of duplicated quiz chrome (progress bar, direction chip, word card, end session button)

## Changes

- `src/test/fixtures.ts` — mock data factories for all 6 domain types with override support
- `src/test/mockStorage.ts` — `createMockStorage()` factory with all methods as `vi.fn()` returning sensible defaults
- `src/test/renderWithStorage.tsx` — `renderWithStorage` and `renderHookWithStorage` wrappers
- `src/features/quiz/components/QuizLayout.tsx` — new thin layout component
- `src/features/quiz/components/ChoiceQuizContent.tsx` — uses `QuizLayout`
- `src/features/quiz/components/TypeQuizContent.tsx` — uses `QuizLayout`
- 8 test files updated to use shared utilities

## Testing

- All 371 unit tests pass
- TypeScript strict: clean
- ESLint: clean (0 warnings)
- Prettier: clean
- Production build: success

## Review

- Code review passed — reviewer approved all changes

Closes #52