### PR TITLE
chore: bump version to 0.1.0 and set SonarCloud baseline (#54)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lexio",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=mreppo_lexio
 sonar.organization=mreppo
+sonar.projectVersion=0.1.0
 sonar.sources=src
 sonar.tests=src
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx


### PR DESCRIPTION
## Summary

- Sets `package.json` version to `0.1.0` (was `0.0.1`)
- Adds `sonar.projectVersion=0.1.0` to `sonar-project.properties`

## Why

SonarCloud quality gate is RED because "Previous version" was selected as the new code definition but no version tags exist. Sonar treats the entire codebase as "new code," inflating the duplication metric to 10.5% (overall is actually 4.5%).

Tagging `v0.1.0` gives Sonar a baseline — only future changes will count as "new code" going forward.

## Changes

- `package.json` — version `0.0.1` → `0.1.0`
- `sonar-project.properties` — added `sonar.projectVersion=0.1.0`

## Testing

- All 371 tests pass
- TypeScript strict check passes
- ESLint passes with 0 warnings
- Prettier formatting passes
- Production build succeeds

## Review

Straightforward config change, no logic modified.

Closes #54