### PR TITLE
fix: move SonarCloud scan to end of pipeline and make non-blocking (#58)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,11 +45,6 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:run -- --coverage
 
-      - name: SonarCloud scan
-        uses: SonarSource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
       - name: Build
         run: npm run build
 
@@ -63,6 +58,14 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist
+
+      # SonarCloud runs last and never blocks deployment
+      - name: SonarCloud scan
+        continue-on-error: true
+        uses: SonarSource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary

- SonarCloud scan step repositioned to the very end of the build job, after build, E2E tests, and artifact upload
- Added `continue-on-error: true` so a Sonar failure never blocks deployment
- Added `GITHUB_TOKEN` env var required by the SonarCloud action for PR decoration

## Changes

- `.github/workflows/deploy.yml` - reordered steps and updated SonarCloud step config

## Testing

- All 371 tests pass
- TypeScript strict check passes
- This is a CI workflow-only change; no application code was modified

## Review

- All three acceptance criteria from the issue are met:
  - [x] SonarCloud scan moved to end of build job (after E2E tests)
  - [x] `continue-on-error: true` set on SonarCloud step
  - [x] `GITHUB_TOKEN` passed to SonarCloud step

Closes #58