### PR TITLE
fix: update GitHub Actions to Node 22 versions (#60)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,13 +16,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full history needed for SonarCloud blame analysis
           fetch-depth: 0
+          # checkout@v6 defaults persist-credentials to false; set true for SonarCloud git blame
+          persist-credentials: true
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -55,7 +57,7 @@ jobs:
         run: npx playwright test
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: dist
 


### PR DESCRIPTION
## Summary

Updates GitHub Actions to their latest major versions that use Node 22 internally, removing the Node 20 deprecation warnings from CI.

## Changes

- `.github/workflows/deploy.yml` - Updated three actions:
  - `actions/checkout`: `v4` -> `v6`
  - `actions/setup-node`: `v4` -> `v6`
  - `actions/upload-pages-artifact`: `v3` -> `v4`
  - Added `persist-credentials: true` to `checkout@v6` (the new default is `false`, which would break SonarCloud git blame analysis that relies on `fetch-depth: 0`)

## Testing

- All 371 unit tests pass
- TypeScript type check passes
- ESLint passes with zero warnings
- Production build succeeds

Closes #60