### PR TITLE
feat: score and streak tracking (#13)

### DIFF
--- a/src/features/quiz/components/ActiveQuizView.tsx
+++ b/src/features/quiz/components/ActiveQuizView.tsx
@@ -18,14 +18,18 @@ interface ActiveQuizViewProps {
   readonly settings: UserSettings
   /**
    * Called once when the session transitions to 'finished'.
-   * Receives the final wordsReviewed and correctCount.
+   * Receives the final wordsReviewed, correctCount, and bestSessionStreak.
    */
-  readonly onSessionFinished: (wordsReviewed: number, correctCount: number) => void
+  readonly onSessionFinished: (
+    wordsReviewed: number,
+    correctCount: number,
+    bestSessionStreak: number,
+  ) => void
 }
 
 export function ActiveQuizView({ mode, pair, settings, onSessionFinished }: ActiveQuizViewProps) {
   const session = useQuizSession(pair, settings, mode)
-  const { phase, wordsCompleted, correctCount, currentMode } = session.state
+  const { phase, wordsCompleted, correctCount, bestSessionStreak, currentMode } = session.state
 
   // Store onSessionFinished in a ref so the effect dep array only contains the
   // stable phase value — the callback itself is always current.
@@ -34,11 +38,11 @@ export function ActiveQuizView({ mode, pair, settings, onSessionFinished }: Acti
 
   useEffect(() => {
     if (phase === 'finished') {
-      onFinishedRef.current(wordsCompleted, correctCount)
+      onFinishedRef.current(wordsCompleted, correctCount, bestSessionStreak)
     }
-    // wordsCompleted and correctCount are stable at the moment phase becomes
-    // 'finished', so including them is correct and avoids stale reads.
-  }, [phase, wordsCompleted, correctCount])
+    // wordsCompleted, correctCount, and bestSessionStreak are stable at the moment
+    // phase becomes 'finished', so including them is correct and avoids stale reads.
+  }, [phase, wordsCompleted, correctCount, bestSessionStreak])
 
   if (currentMode === 'type') {
     return <TypeQuizContent session={session} pair={pair} settings={settings} />

--- a/src/features/quiz/components/ChoiceQuizContent.tsx
+++ b/src/features/quiz/components/ChoiceQuizContent.tsx
@@ -91,6 +91,7 @@ export function ChoiceQuizContent({ session, pair }: ChoiceQuizContentProps) {
     wordsCompleted,
     sessionGoal,
     correctCount,
+    sessionStreak,
     error,
   } = state
 
@@ -165,6 +166,7 @@ export function ChoiceQuizContent({ session, pair }: ChoiceQuizContentProps) {
       wordsCompleted={wordsCompleted}
       sessionGoal={sessionGoal}
       correctCount={correctCount}
+      sessionStreak={sessionStreak}
       onEndSession={endSession}
     >
       <Box

--- a/src/features/quiz/components/QuizHub.tsx
+++ b/src/features/quiz/components/QuizHub.tsx
@@ -2,8 +2,8 @@
  * QuizHub - the entry point for the quiz feature.
  *
  * Manages the pre-quiz mode selection screen, active quiz routing, and
- * the post-session summary. It persists the user's mode preference and
- * pulls the current streak from daily stats for the summary screen.
+ * the post-session summary. It persists the user's mode preference, updates
+ * DailyStats after each session, and shows streak + words-learned data.
  *
  * Hub state machine:
  *   'select'  → user picks Type / Choice / Mixed
@@ -15,6 +15,8 @@ import { useState, useCallback, useEffect } from 'react'
 import { Box } from '@mui/material'
 import type { LanguagePair, UserSettings, QuizMode } from '@/types'
 import { useStorage } from '@/hooks/useStorage'
+import { updateDailyStatsAfterSession, loadCurrentStreak } from '@/services/streakService'
+import { getWordsLearnedForPair } from '@/services/wordsLearnedService'
 import { QuizModeSelector } from './QuizModeSelector'
 import { SessionSummary } from './SessionSummary'
 import { ActiveQuizView } from './ActiveQuizView'
@@ -31,6 +33,7 @@ type HubPhase = 'select' | 'active' | 'summary'
 interface SessionResult {
   readonly wordsReviewed: number
   readonly correctCount: number
+  readonly bestSessionStreak: number
 }
 
 export function QuizHub({ pair, settings, onSettingsChange }: QuizHubProps) {
@@ -40,23 +43,34 @@ export function QuizHub({ pair, settings, onSettingsChange }: QuizHubProps) {
   const [sessionResult, setSessionResult] = useState<SessionResult>({
     wordsReviewed: 0,
     correctCount: 0,
+    bestSessionStreak: 0,
   })
   const [streakDays, setStreakDays] = useState(0)
+  const [wordsLearned, setWordsLearned] = useState(0)
+  const [totalWords, setTotalWords] = useState(0)
 
   // Keep local selectedMode in sync when settings.quizMode changes externally.
   useEffect(() => {
     setSelectedMode(settings.quizMode)
   }, [settings.quizMode])
 
-  // Load streak days from recent daily stats.
+  // Reload streak from storage whenever the hub phase changes (e.g. after session).
   useEffect(() => {
-    void storage.getRecentDailyStats(7).then((stats) => {
-      const latest = stats[stats.length - 1]
-      if (latest !== undefined) {
-        setStreakDays(latest.streakDays)
-      }
+    void loadCurrentStreak(storage, settings.dailyGoal).then(setStreakDays)
+  }, [storage, hubPhase, settings.dailyGoal])
+
+  // Reload words learned whenever the hub phase changes or the pair changes.
+  useEffect(() => {
+    if (pair === null) {
+      setWordsLearned(0)
+      setTotalWords(0)
+      return
+    }
+    void getWordsLearnedForPair(storage, pair.id).then((result) => {
+      setWordsLearned(result.learned)
+      setTotalWords(result.total)
     })
-  }, [storage, hubPhase])
+  }, [storage, pair, hubPhase])
 
   const handleModeChange = useCallback(
     (mode: QuizMode): void => {
@@ -72,10 +86,22 @@ export function QuizHub({ pair, settings, onSettingsChange }: QuizHubProps) {
     setHubPhase('active')
   }, [])
 
-  const handleSessionFinished = useCallback((wordsReviewed: number, correctCount: number): void => {
-    setSessionResult({ wordsReviewed, correctCount })
-    setHubPhase('summary')
-  }, [])
+  const handleSessionFinished = useCallback(
+    (wordsReviewed: number, correctCount: number, bestSessionStreak: number): void => {
+      setSessionResult({ wordsReviewed, correctCount, bestSessionStreak })
+
+      // Persist daily stats in the background - do not block UI transition.
+      void updateDailyStatsAfterSession(
+        storage,
+        wordsReviewed,
+        correctCount,
+        settings.dailyGoal,
+      ).then(setStreakDays)
+
+      setHubPhase('summary')
+    },
+    [storage, settings.dailyGoal],
+  )
 
   const handleContinue = useCallback((): void => {
     setHubPhase('select')
@@ -102,6 +128,9 @@ export function QuizHub({ pair, settings, onSettingsChange }: QuizHubProps) {
         wordsReviewed={sessionResult.wordsReviewed}
         correctCount={sessionResult.correctCount}
         streakDays={streakDays}
+        bestSessionStreak={sessionResult.bestSessionStreak}
+        wordsLearned={wordsLearned}
+        totalWords={totalWords}
         onContinue={handleContinue}
         onGoHome={handleGoHome}
       />

--- a/src/features/quiz/components/QuizLayout.tsx
+++ b/src/features/quiz/components/QuizLayout.tsx
@@ -23,6 +23,7 @@ interface QuizLayoutProps {
   readonly wordsCompleted: number
   readonly sessionGoal: number
   readonly correctCount: number
+  readonly sessionStreak?: number
   readonly onEndSession: () => void
   readonly children: ReactNode
 }
@@ -35,12 +36,18 @@ export function QuizLayout({
   wordsCompleted,
   sessionGoal,
   correctCount,
+  sessionStreak,
   onEndSession,
   children,
 }: QuizLayoutProps) {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-      <SessionProgress completed={wordsCompleted} total={sessionGoal} correct={correctCount} />
+      <SessionProgress
+        completed={wordsCompleted}
+        total={sessionGoal}
+        correct={correctCount}
+        sessionStreak={sessionStreak}
+      />
 
       <Box sx={{ display: 'flex', justifyContent: 'center' }}>
         <Chip

--- a/src/features/quiz/components/SessionProgress.tsx
+++ b/src/features/quiz/components/SessionProgress.tsx
@@ -1,8 +1,10 @@
 /**
- * SessionProgress - displays a progress bar and score for the current quiz session.
+ * SessionProgress - displays a progress bar, score, and current session streak
+ * for the active quiz session.
  */
 
 import { Box, LinearProgress, Typography } from '@mui/material'
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment'
 
 interface SessionProgressProps {
   /** Number of words completed so far. */
@@ -11,21 +13,51 @@ interface SessionProgressProps {
   readonly total: number
   /** Number of correct answers. */
   readonly correct: number
+  /** Current streak of consecutive correct answers in this session. */
+  readonly sessionStreak?: number
 }
 
-export function SessionProgress({ completed, total, correct }: SessionProgressProps) {
+export function SessionProgress({
+  completed,
+  total,
+  correct,
+  sessionStreak = 0,
+}: SessionProgressProps) {
   const progress = total > 0 ? Math.min(100, (completed / total) * 100) : 0
+  const percentage = completed > 0 ? Math.round((correct / completed) * 100) : 0
 
   return (
     <Box sx={{ width: '100%', mb: 2 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5 }}>
         <Typography variant="caption" color="text.secondary">
           {completed} / {total}
         </Typography>
-        <Typography variant="caption" color="text.secondary">
-          {correct} correct
-        </Typography>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          {sessionStreak >= 2 && (
+            <Box
+              sx={{ display: 'flex', alignItems: 'center', gap: 0.25, color: 'warning.main' }}
+              role="status"
+              aria-label={`Session streak: ${sessionStreak} consecutive correct answers`}
+            >
+              <LocalFireDepartmentIcon sx={{ fontSize: 14 }} aria-hidden="true" />
+              <Typography variant="caption" fontWeight={600} color="warning.main">
+                {sessionStreak}
+              </Typography>
+            </Box>
+          )}
+
+          <Typography variant="caption" color="text.secondary">
+            {correct} correct
+            {completed > 0 && (
+              <Typography component="span" variant="caption" color="text.disabled" sx={{ ml: 0.5 }}>
+                ({percentage}%)
+              </Typography>
+            )}
+          </Typography>
+        </Box>
       </Box>
+
       <LinearProgress
         variant="determinate"
         value={progress}

--- a/src/features/quiz/components/SessionSummary.test.tsx
+++ b/src/features/quiz/components/SessionSummary.test.tsx
@@ -7,6 +7,10 @@
  * - Calculates and displays accuracy percentage
  * - Shows streak info when streakDays > 0
  * - Does not show streak info when streakDays === 0
+ * - Shows best session streak when bestSessionStreak >= 2
+ * - Does not show best session streak when bestSessionStreak < 2
+ * - Shows words learned metric when totalWords > 0
+ * - Does not show words learned when totalWords === 0
  * - Calls onContinue when "Start new session" is clicked
  * - Calls onGoHome when "Back to dashboard" is clicked
  * - Shows an encouraging message appropriate to accuracy
@@ -18,19 +22,36 @@ import userEvent from '@testing-library/user-event'
 import { ThemeProvider, createTheme } from '@mui/material'
 import { SessionSummary } from './SessionSummary'
 
-function renderSummary(
+interface RenderOptions {
+  wordsReviewed?: number
+  correctCount?: number
+  streakDays?: number
+  bestSessionStreak?: number
+  wordsLearned?: number
+  totalWords?: number
+  onContinue?: () => void
+  onGoHome?: () => void
+}
+
+function renderSummary({
   wordsReviewed = 10,
   correctCount = 8,
   streakDays = 0,
+  bestSessionStreak = 0,
+  wordsLearned = 0,
+  totalWords = 0,
   onContinue = vi.fn(),
   onGoHome = vi.fn(),
-) {
+}: RenderOptions = {}) {
   return render(
     <ThemeProvider theme={createTheme()}>
       <SessionSummary
         wordsReviewed={wordsReviewed}
         correctCount={correctCount}
         streakDays={streakDays}
+        bestSessionStreak={bestSessionStreak}
+        wordsLearned={wordsLearned}
+        totalWords={totalWords}
         onContinue={onContinue}
         onGoHome={onGoHome}
       />
@@ -45,45 +66,72 @@ describe('SessionSummary', () => {
   })
 
   it('should display words reviewed count', () => {
-    renderSummary(15, 12)
+    renderSummary({ wordsReviewed: 15, correctCount: 12 })
     expect(screen.getByLabelText('15 words reviewed')).toBeInTheDocument()
   })
 
   it('should display accuracy percentage', () => {
     // 8/10 = 80%
-    renderSummary(10, 8)
+    renderSummary({ wordsReviewed: 10, correctCount: 8 })
     expect(screen.getByLabelText('80% accuracy')).toBeInTheDocument()
   })
 
   it('should display correct count', () => {
-    renderSummary(10, 8)
+    renderSummary({ wordsReviewed: 10, correctCount: 8 })
     expect(screen.getByLabelText('8 correct')).toBeInTheDocument()
   })
 
   it('should display incorrect count', () => {
     // 10 - 8 = 2 incorrect
-    renderSummary(10, 8)
+    renderSummary({ wordsReviewed: 10, correctCount: 8 })
     expect(screen.getByLabelText('2 incorrect')).toBeInTheDocument()
   })
 
   it('should show 0% accuracy when wordsReviewed is 0', () => {
-    renderSummary(0, 0)
+    renderSummary({ wordsReviewed: 0, correctCount: 0 })
     expect(screen.getByLabelText('0% accuracy')).toBeInTheDocument()
   })
 
   it('should show streak info when streakDays > 0', () => {
-    renderSummary(10, 8, 5)
+    renderSummary({ streakDays: 5 })
     expect(screen.getByText(/5 day streak/i)).toBeInTheDocument()
   })
 
   it('should not show streak info when streakDays === 0', () => {
-    renderSummary(10, 8, 0)
+    renderSummary({ streakDays: 0 })
     expect(screen.queryByText(/day streak/i)).not.toBeInTheDocument()
+  })
+
+  it('should show best session streak when bestSessionStreak >= 2', () => {
+    renderSummary({ bestSessionStreak: 5 })
+    expect(screen.getByLabelText('Best in-session streak: 5 correct in a row')).toBeInTheDocument()
+    expect(screen.getByText(/best streak this session/i)).toBeInTheDocument()
+  })
+
+  it('should not show best session streak row when bestSessionStreak < 2', () => {
+    renderSummary({ bestSessionStreak: 1 })
+    expect(screen.queryByText(/best streak this session/i)).not.toBeInTheDocument()
+  })
+
+  it('should not show best session streak row when bestSessionStreak is 0', () => {
+    renderSummary({ bestSessionStreak: 0 })
+    expect(screen.queryByText(/best streak this session/i)).not.toBeInTheDocument()
+  })
+
+  it('should show words learned metric when totalWords > 0', () => {
+    renderSummary({ wordsLearned: 12, totalWords: 50 })
+    expect(screen.getByLabelText('12 of 50 words learned')).toBeInTheDocument()
+    expect(screen.getByText(/words learned/i)).toBeInTheDocument()
+  })
+
+  it('should not show words learned metric when totalWords === 0', () => {
+    renderSummary({ wordsLearned: 0, totalWords: 0 })
+    expect(screen.queryByText(/words learned/i)).not.toBeInTheDocument()
   })
 
   it('should call onContinue when "Start new session" is clicked', async () => {
     const onContinue = vi.fn()
-    renderSummary(10, 8, 0, onContinue)
+    renderSummary({ onContinue })
     const user = userEvent.setup()
     await user.click(screen.getByRole('button', { name: /start new session/i }))
     expect(onContinue).toHaveBeenCalledOnce()
@@ -91,29 +139,29 @@ describe('SessionSummary', () => {
 
   it('should call onGoHome when "Back to dashboard" is clicked', async () => {
     const onGoHome = vi.fn()
-    renderSummary(10, 8, 0, vi.fn(), onGoHome)
+    renderSummary({ onGoHome })
     const user = userEvent.setup()
     await user.click(screen.getByRole('button', { name: /back to dashboard/i }))
     expect(onGoHome).toHaveBeenCalledOnce()
   })
 
   it('should show outstanding message for >= 90% accuracy', () => {
-    renderSummary(10, 9) // 90%
+    renderSummary({ wordsReviewed: 10, correctCount: 9 }) // 90%
     expect(screen.getByText(/outstanding/i)).toBeInTheDocument()
   })
 
   it('should show great job message for >= 75% accuracy', () => {
-    renderSummary(10, 8) // 80%
+    renderSummary({ wordsReviewed: 10, correctCount: 8 }) // 80%
     expect(screen.getByText(/great job/i)).toBeInTheDocument()
   })
 
   it('should show good effort message for >= 50% accuracy', () => {
-    renderSummary(10, 6) // 60%
+    renderSummary({ wordsReviewed: 10, correctCount: 6 }) // 60%
     expect(screen.getByText(/good effort/i)).toBeInTheDocument()
   })
 
   it('should show keep going message for < 50% accuracy', () => {
-    renderSummary(10, 4) // 40%
+    renderSummary({ wordsReviewed: 10, correctCount: 4 }) // 40%
     expect(screen.getByText(/keep going/i)).toBeInTheDocument()
   })
 })

--- a/src/features/quiz/components/SessionSummary.tsx
+++ b/src/features/quiz/components/SessionSummary.tsx
@@ -1,12 +1,14 @@
 /**
  * SessionSummary - displayed when a quiz session ends.
  *
- * Shows words reviewed, accuracy, streak info, and an encouraging message.
- * Provides options to start a new session or return to the dashboard (home).
+ * Shows words reviewed, accuracy, streak info, words learned, and an
+ * encouraging message. Provides options to start a new session or return
+ * to the mode selector.
  */
 
 import { Box, Button, Paper, Typography, Divider } from '@mui/material'
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment'
 import EmojiEventsOutlinedIcon from '@mui/icons-material/EmojiEventsOutlined'
 
 interface SessionSummaryProps {
@@ -14,11 +16,17 @@ interface SessionSummaryProps {
   readonly wordsReviewed: number
   /** Total correct answers. */
   readonly correctCount: number
-  /** Current streak in days (consecutive days meeting the daily goal). */
+  /** Current daily streak in days (consecutive days meeting the daily goal). */
   readonly streakDays: number
+  /** Best consecutive-correct streak achieved within this session. */
+  readonly bestSessionStreak: number
+  /** Number of words learned (confidence >= threshold) in the active pair. */
+  readonly wordsLearned: number
+  /** Total words in the active pair. */
+  readonly totalWords: number
   /** Called when user wants to start another session. */
   readonly onContinue: () => void
-  /** Called when user wants to go back to the dashboard / home view. */
+  /** Called when user wants to go back to the mode selector. */
   readonly onGoHome: () => void
 }
 
@@ -38,6 +46,9 @@ export function SessionSummary({
   wordsReviewed,
   correctCount,
   streakDays,
+  bestSessionStreak,
+  wordsLearned,
+  totalWords,
   onContinue,
   onGoHome,
 }: SessionSummaryProps) {
@@ -158,9 +169,57 @@ export function SessionSummary({
             </Typography>
           </Box>
         </Box>
+
+        {/* Best in-session streak row */}
+        {bestSessionStreak >= 2 && (
+          <>
+            <Divider />
+            <Box sx={{ p: 2, textAlign: 'center' }}>
+              <Box
+                sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}
+              >
+                <LocalFireDepartmentIcon
+                  sx={{ color: 'warning.main', fontSize: 20 }}
+                  aria-hidden="true"
+                />
+                <Typography
+                  variant="h5"
+                  fontWeight={600}
+                  color="warning.main"
+                  aria-label={`Best in-session streak: ${bestSessionStreak} correct in a row`}
+                >
+                  {bestSessionStreak}
+                </Typography>
+              </Box>
+              <Typography variant="caption" color="text.secondary">
+                Best streak this session
+              </Typography>
+            </Box>
+          </>
+        )}
+
+        {/* Words learned row */}
+        {totalWords > 0 && (
+          <>
+            <Divider />
+            <Box sx={{ p: 2, textAlign: 'center' }}>
+              <Typography
+                variant="h5"
+                fontWeight={600}
+                color="primary.main"
+                aria-label={`${wordsLearned} of ${totalWords} words learned`}
+              >
+                {wordsLearned} / {totalWords}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                Words learned
+              </Typography>
+            </Box>
+          </>
+        )}
       </Paper>
 
-      {/* Streak info */}
+      {/* Daily streak info */}
       {streakDays > 0 && (
         <Box
           sx={{

--- a/src/features/quiz/components/TypeQuizContent.tsx
+++ b/src/features/quiz/components/TypeQuizContent.tsx
@@ -32,6 +32,7 @@ export function TypeQuizContent({ session, pair, settings }: TypeQuizContentProp
     wordsCompleted,
     sessionGoal,
     correctCount,
+    sessionStreak,
     error,
   } = state
 
@@ -113,6 +114,7 @@ export function TypeQuizContent({ session, pair, settings }: TypeQuizContentProp
       wordsCompleted={wordsCompleted}
       sessionGoal={sessionGoal}
       correctCount={correctCount}
+      sessionStreak={sessionStreak}
       onEndSession={endSession}
     >
       {phase === 'question' && (

--- a/src/features/quiz/useQuizSession.ts
+++ b/src/features/quiz/useQuizSession.ts
@@ -50,6 +50,10 @@ export interface QuizSessionState {
   readonly sessionGoal: number
   /** Number of correct answers this session. */
   readonly correctCount: number
+  /** Current streak of consecutive correct answers within this session. */
+  readonly sessionStreak: number
+  /** Best streak of consecutive correct answers achieved in this session. */
+  readonly bestSessionStreak: number
   /** Error message if something went wrong. */
   readonly error: string | null
   // Type-mode state
@@ -165,6 +169,8 @@ export function useQuizSession(
   const [lastChoiceCorrect, setLastChoiceCorrect] = useState<boolean | null>(null)
   const [wordsCompleted, setWordsCompleted] = useState(0)
   const [correctCount, setCorrectCount] = useState(0)
+  const [sessionStreak, setSessionStreak] = useState(0)
+  const [bestSessionStreak, setBestSessionStreak] = useState(0)
   const [error, setError] = useState<string | null>(null)
 
   // Recent mode history for consecutive-mode enforcement in mixed mode.
@@ -319,7 +325,16 @@ export function useQuizSession(
 
       setLastResult(matchResult)
       setWordsCompleted((n) => n + 1)
-      if (isCorrect) setCorrectCount((n) => n + 1)
+      if (isCorrect) {
+        setCorrectCount((n) => n + 1)
+        setSessionStreak((s) => {
+          const next = s + 1
+          setBestSessionStreak((b) => Math.max(b, next))
+          return next
+        })
+      } else {
+        setSessionStreak(0)
+      }
       setPhase('feedback')
     },
     [phase, currentWord, direction, currentMode, settings.typoTolerance, storage],
@@ -347,7 +362,16 @@ export function useQuizSession(
       setSelectedIndex(index)
       setLastChoiceCorrect(isCorrect)
       setWordsCompleted((n) => n + 1)
-      if (isCorrect) setCorrectCount((n) => n + 1)
+      if (isCorrect) {
+        setCorrectCount((n) => n + 1)
+        setSessionStreak((s) => {
+          const next = s + 1
+          setBestSessionStreak((b) => Math.max(b, next))
+          return next
+        })
+      } else {
+        setSessionStreak(0)
+      }
       setPhase('feedback')
     },
     [phase, currentWord, direction, currentMode, selectedIndex, correctIndex, storage],
@@ -383,6 +407,8 @@ export function useQuizSession(
   const restart = useCallback((): void => {
     setWordsCompleted(0)
     setCorrectCount(0)
+    setSessionStreak(0)
+    setBestSessionStreak(0)
     setSelectedIndex(-1)
     setLastResult(null)
     setLastChoiceCorrect(null)
@@ -404,6 +430,8 @@ export function useQuizSession(
     wordsCompleted,
     sessionGoal,
     correctCount,
+    sessionStreak,
+    bestSessionStreak,
     error,
     lastResult,
     options,

--- a/src/services/streakService.test.ts
+++ b/src/services/streakService.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for streakService - daily streak calculation logic.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { DailyStats } from '@/types'
+import {
+  calculateCurrentStreak,
+  calculateBestStreak,
+  formatDate,
+  offsetDate,
+  todayDateString,
+  yesterdayDateString,
+  LEARNED_CONFIDENCE_THRESHOLD,
+} from './streakService'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeStats(date: string, wordsReviewed: number): DailyStats {
+  return {
+    date,
+    wordsReviewed,
+    correctCount: wordsReviewed,
+    incorrectCount: 0,
+    streakDays: 0,
+  }
+}
+
+function makeMap(entries: DailyStats[]): Map<string, DailyStats> {
+  return new Map(entries.map((s) => [s.date, s]))
+}
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+describe('formatDate', () => {
+  it('formats a date object as YYYY-MM-DD', () => {
+    expect(formatDate(new Date(2024, 0, 5))).toBe('2024-01-05') // January 5
+    expect(formatDate(new Date(2024, 11, 31))).toBe('2024-12-31') // December 31
+    expect(formatDate(new Date(2024, 1, 29))).toBe('2024-02-29') // Leap day
+  })
+})
+
+describe('offsetDate', () => {
+  it('returns a date string offset by the given number of days (past)', () => {
+    expect(offsetDate('2024-03-10', 1)).toBe('2024-03-09')
+    expect(offsetDate('2024-03-10', 5)).toBe('2024-03-05')
+    expect(offsetDate('2024-03-01', 1)).toBe('2024-02-29') // leap year boundary
+  })
+
+  it('returns a date string offset into the future with negative offset', () => {
+    expect(offsetDate('2024-03-10', -1)).toBe('2024-03-11')
+    expect(offsetDate('2024-02-29', -1)).toBe('2024-03-01')
+  })
+})
+
+describe('todayDateString', () => {
+  it('returns a string in YYYY-MM-DD format', () => {
+    expect(todayDateString()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})
+
+describe('yesterdayDateString', () => {
+  it('returns a string in YYYY-MM-DD format', () => {
+    expect(yesterdayDateString()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('is one day before today', () => {
+    const today = todayDateString()
+    expect(offsetDate(today, 1)).toBe(yesterdayDateString())
+  })
+})
+
+// ─── calculateCurrentStreak ───────────────────────────────────────────────────
+
+describe('calculateCurrentStreak', () => {
+  const GOAL = 5
+
+  it('returns 0 for an empty map', () => {
+    expect(calculateCurrentStreak(new Map(), GOAL, '2024-03-10')).toBe(0)
+  })
+
+  it('returns 0 when today has no entry yet (grace: starts checking yesterday)', () => {
+    // No entry for yesterday either.
+    const stats = makeMap([makeStats('2024-03-08', GOAL)])
+    // Yesterday = 2024-03-09, not in map → streak is 0.
+    expect(calculateCurrentStreak(stats, GOAL, '2024-03-10')).toBe(0)
+  })
+
+  it('counts a single completed day (yesterday)', () => {
+    const stats = makeMap([makeStats('2024-03-09', GOAL)])
+    expect(calculateCurrentStreak(stats, GOAL, '2024-03-10')).toBe(1)
+  })
+
+  it('counts consecutive completed days ending yesterday', () => {
+    const stats = makeMap([
+      makeStats('2024-03-07', GOAL),
+      makeStats('2024-03-08', GOAL),
+      makeStats('2024-03-09', GOAL),
+    ])
+    expect(calculateCurrentStreak(stats, GOAL, '2024-03-10')).toBe(3)
+  })
+
+  it('counts today when today is already complete', () => {
+    const stats = makeMap([makeStats('2024-03-09', GOAL), makeStats('2024-03-10', GOAL)])
+    expect(calculateCurrentStreak(stats, GOAL, '2024-03-10')).toBe(2)
+  })
+
+  it('breaks streak when a day is missed', () => {
+    // 2024-03-08 is missing (gap between 07 and 09).
+    const stats = makeMap([makeStats('2024-03-07', GOAL), makeStats('2024-03-09', GOAL)])
+    // Yesterday is 2024-03-09 (completed), but 2024-03-08 is missing → streak = 1.
+    expect(calculateCurrentStreak(stats, GOAL, '2024-03-10')).toBe(1)
+  })
+
+  it('breaks streak when a day has fewer words than dailyGoal', () => {
+    const stats = makeMap([
+      makeStats('2024-03-08', GOAL),
+      makeStats('2024-03-09', GOAL - 1), // not enough
+    ])
+    expect(calculateCurrentStreak(stats, GOAL, '2024-03-10')).toBe(0)
+  })
+
+  it('applies grace period: today not yet started does not break streak', () => {
+    // User reviewed yesterday and the day before, but nothing today yet.
+    const stats = makeMap([makeStats('2024-03-08', GOAL), makeStats('2024-03-09', GOAL)])
+    // Today (2024-03-10) has no entry — grace period applies.
+    expect(calculateCurrentStreak(stats, GOAL, '2024-03-10')).toBe(2)
+  })
+
+  it('only counts today if goal is already met today', () => {
+    // Today partially done (below goal) - should not count.
+    const stats = makeMap([makeStats('2024-03-09', GOAL), makeStats('2024-03-10', GOAL - 1)])
+    expect(calculateCurrentStreak(stats, GOAL, '2024-03-10')).toBe(1)
+  })
+})
+
+// ─── calculateBestStreak ─────────────────────────────────────────────────────
+
+describe('calculateBestStreak', () => {
+  const GOAL = 5
+
+  it('returns 0 for an empty map', () => {
+    expect(calculateBestStreak(new Map(), GOAL)).toBe(0)
+  })
+
+  it('returns 1 for a single completed day', () => {
+    const stats = makeMap([makeStats('2024-03-09', GOAL)])
+    expect(calculateBestStreak(stats, GOAL)).toBe(1)
+  })
+
+  it('calculates a multi-day streak', () => {
+    const stats = makeMap([
+      makeStats('2024-03-07', GOAL),
+      makeStats('2024-03-08', GOAL),
+      makeStats('2024-03-09', GOAL),
+    ])
+    expect(calculateBestStreak(stats, GOAL)).toBe(3)
+  })
+
+  it('returns the longest run when there are multiple runs', () => {
+    const stats = makeMap([
+      makeStats('2024-03-01', GOAL),
+      makeStats('2024-03-02', GOAL),
+      // gap on 2024-03-03
+      makeStats('2024-03-04', GOAL),
+      makeStats('2024-03-05', GOAL),
+      makeStats('2024-03-06', GOAL),
+      makeStats('2024-03-07', GOAL),
+    ])
+    expect(calculateBestStreak(stats, GOAL)).toBe(4)
+  })
+
+  it('ignores days with fewer words than dailyGoal', () => {
+    const stats = makeMap([
+      makeStats('2024-03-08', GOAL),
+      makeStats('2024-03-09', GOAL - 1), // not enough
+      makeStats('2024-03-10', GOAL),
+    ])
+    expect(calculateBestStreak(stats, GOAL)).toBe(1)
+  })
+
+  it('handles a single long unbroken streak', () => {
+    const entries: DailyStats[] = []
+    for (let i = 1; i <= 30; i++) {
+      entries.push(makeStats(`2024-01-${String(i).padStart(2, '0')}`, GOAL))
+    }
+    expect(calculateBestStreak(makeMap(entries), GOAL)).toBe(30)
+  })
+})
+
+// ─── LEARNED_CONFIDENCE_THRESHOLD ────────────────────────────────────────────
+
+describe('LEARNED_CONFIDENCE_THRESHOLD', () => {
+  it('is 0.8', () => {
+    expect(LEARNED_CONFIDENCE_THRESHOLD).toBe(0.8)
+  })
+})

--- a/src/services/streakService.ts
+++ b/src/services/streakService.ts
@@ -1,0 +1,233 @@
+/**
+ * Streak service - calculates and persists daily streak data.
+ *
+ * Rules:
+ * - A day is "complete" when the user reviews >= dailyGoal words.
+ * - Streak = consecutive days of completing the daily goal.
+ * - Streak resets to 0 if a day is missed (a day with no entry, or
+ *   an entry where wordsReviewed < dailyGoal).
+ * - Grace period: the streak check only considers dates up to and
+ *   including yesterday, so a user reviewing late on day N still
+ *   counts for day N even if the app is opened the following morning.
+ */
+
+import type { DailyStats } from '@/types'
+import type { StorageService } from './storage/StorageService'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Number of past days to scan when calculating the current streak. */
+const STREAK_SCAN_DAYS = 366
+
+/** Confidence threshold above which a word is considered "learned". */
+export const LEARNED_CONFIDENCE_THRESHOLD = 0.8
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+/** Returns today's date string in YYYY-MM-DD format (local time). */
+export function todayDateString(): string {
+  const d = new Date()
+  return formatDate(d)
+}
+
+/** Returns yesterday's date string in YYYY-MM-DD format (local time). */
+export function yesterdayDateString(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - 1)
+  return formatDate(d)
+}
+
+/** Formats a Date object as YYYY-MM-DD using local time. */
+export function formatDate(d: Date): string {
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/**
+ * Returns a date string that is `offset` days before `baseDate`.
+ * Positive offset = further in the past.
+ */
+export function offsetDate(baseDate: string, offset: number): string {
+  const d = new Date(`${baseDate}T00:00:00`)
+  d.setDate(d.getDate() - offset)
+  return formatDate(d)
+}
+
+// ─── Streak calculation ───────────────────────────────────────────────────────
+
+/**
+ * Calculates the current streak in days given an array of daily stats records
+ * and the daily goal.
+ *
+ * The algorithm walks backward day by day, starting from today.
+ * Grace period: if today has no completed entry yet, we skip it and start
+ * counting from yesterday. If today IS already complete, it counts too.
+ *
+ * @param statsMap  - Map from date string (YYYY-MM-DD) to DailyStats.
+ * @param dailyGoal - Minimum words reviewed per day to count as complete.
+ * @param today     - Today's date string (injectable for testing).
+ * @returns Current streak count (days).
+ */
+export function calculateCurrentStreak(
+  statsMap: ReadonlyMap<string, DailyStats>,
+  dailyGoal: number,
+  today: string = todayDateString(),
+): number {
+  // Determine the start date for counting.
+  // If today is already complete, start from today.
+  // Otherwise apply the grace period and start from yesterday.
+  const todayEntry = statsMap.get(today)
+  const todayComplete = todayEntry !== undefined && todayEntry.wordsReviewed >= dailyGoal
+
+  // daysBack: how many days before today we start checking (0 = today, 1 = yesterday, ...)
+  let daysBack = todayComplete ? 0 : 1
+  let streak = 0
+
+  while (daysBack < STREAK_SCAN_DAYS) {
+    const checkDate = offsetDate(today, daysBack)
+    const entry = statsMap.get(checkDate)
+    const completed = entry !== undefined && entry.wordsReviewed >= dailyGoal
+
+    if (!completed) break
+
+    streak++
+    daysBack++
+  }
+
+  return streak
+}
+
+/**
+ * Calculates the all-time best streak from a map of daily stats.
+ *
+ * Scans all dates present in the map and finds the longest consecutive run
+ * of days where wordsReviewed >= dailyGoal.
+ *
+ * @param statsMap  - Map from date string (YYYY-MM-DD) to DailyStats.
+ * @param dailyGoal - Minimum words reviewed per day to count as complete.
+ * @returns Best streak count (days).
+ */
+export function calculateBestStreak(
+  statsMap: ReadonlyMap<string, DailyStats>,
+  dailyGoal: number,
+): number {
+  if (statsMap.size === 0) return 0
+
+  const sortedDates = Array.from(statsMap.keys()).sort()
+  let bestStreak = 0
+  let currentRun = 0
+  let prevDate: string | null = null
+
+  for (const date of sortedDates) {
+    const entry = statsMap.get(date)
+    const completed = entry !== undefined && entry.wordsReviewed >= dailyGoal
+
+    if (!completed) {
+      currentRun = 0
+      prevDate = null
+      continue
+    }
+
+    if (prevDate !== null) {
+      // Check if this date is exactly one day after the previous.
+      // offsetDate(prevDate, -1) returns the day after prevDate.
+      const dayAfterPrev = offsetDate(prevDate, -1)
+      if (dayAfterPrev === date) {
+        currentRun++
+      } else {
+        // Gap: restart the run.
+        currentRun = 1
+      }
+    } else {
+      currentRun = 1
+    }
+
+    if (currentRun > bestStreak) bestStreak = currentRun
+    prevDate = date
+  }
+
+  return bestStreak
+}
+
+// ─── Persistence ──────────────────────────────────────────────────────────────
+
+/**
+ * Updates (or creates) the DailyStats entry for today after a quiz session.
+ * Recalculates the streak and persists it.
+ *
+ * @param storage       - The storage service.
+ * @param wordsReviewed - Words reviewed in the completed session.
+ * @param correctCount  - Correct answers in the completed session.
+ * @param dailyGoal     - Minimum words per day for the goal to be met.
+ * @returns The updated streak count for today.
+ */
+export async function updateDailyStatsAfterSession(
+  storage: StorageService,
+  wordsReviewed: number,
+  correctCount: number,
+  dailyGoal: number,
+): Promise<number> {
+  const today = todayDateString()
+
+  // Load the existing entry for today (if any) and merge.
+  const existing = await storage.getDailyStats(today)
+
+  const updatedWordsReviewed = (existing?.wordsReviewed ?? 0) + wordsReviewed
+  const updatedCorrect = (existing?.correctCount ?? 0) + correctCount
+  const updatedIncorrect = (existing?.incorrectCount ?? 0) + (wordsReviewed - correctCount)
+
+  // Fetch enough history to compute current streak.
+  const recentStats = await storage.getRecentDailyStats(STREAK_SCAN_DAYS)
+  const statsMap = new Map<string, DailyStats>(recentStats.map((s) => [s.date, s]))
+
+  // Apply today's updated totals into the map before calculating streak.
+  const todayEntry: DailyStats = {
+    date: today,
+    wordsReviewed: updatedWordsReviewed,
+    correctCount: updatedCorrect,
+    incorrectCount: updatedIncorrect,
+    streakDays: 0, // placeholder - filled below
+  }
+  statsMap.set(today, todayEntry)
+
+  const currentStreak = calculateCurrentStreak(statsMap, dailyGoal, today)
+
+  const finalEntry: DailyStats = { ...todayEntry, streakDays: currentStreak }
+  await storage.saveDailyStats(finalEntry)
+
+  return currentStreak
+}
+
+/**
+ * Loads the current streak from storage.
+ *
+ * Reads DailyStats history, computes the current streak using the canonical
+ * algorithm, and returns it.
+ *
+ * @param storage   - The storage service.
+ * @param dailyGoal - Minimum words per day for the goal to be met.
+ * @returns Current streak count.
+ */
+export async function loadCurrentStreak(
+  storage: StorageService,
+  dailyGoal: number,
+): Promise<number> {
+  const recentStats = await storage.getRecentDailyStats(STREAK_SCAN_DAYS)
+  const statsMap = new Map<string, DailyStats>(recentStats.map((s) => [s.date, s]))
+  return calculateCurrentStreak(statsMap, dailyGoal)
+}
+
+/**
+ * Loads the all-time best streak from storage.
+ *
+ * @param storage   - The storage service.
+ * @param dailyGoal - Minimum words per day for the goal to be met.
+ * @returns Best streak count.
+ */
+export async function loadBestStreak(storage: StorageService, dailyGoal: number): Promise<number> {
+  const recentStats = await storage.getRecentDailyStats(STREAK_SCAN_DAYS)
+  const statsMap = new Map<string, DailyStats>(recentStats.map((s) => [s.date, s]))
+  return calculateBestStreak(statsMap, dailyGoal)
+}

--- a/src/services/wordsLearnedService.test.ts
+++ b/src/services/wordsLearnedService.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for wordsLearnedService - words learned metric.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Word, WordProgress, LanguagePair } from '@/types'
+import type { StorageService } from './storage/StorageService'
+import { getWordsLearnedForPair, getTotalWordsLearned } from './wordsLearnedService'
+import { LEARNED_CONFIDENCE_THRESHOLD } from './streakService'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeWord(id: string, pairId: string = 'pair1'): Word {
+  return {
+    id,
+    pairId,
+    source: `source-${id}`,
+    target: `target-${id}`,
+    notes: null,
+    tags: [],
+    createdAt: Date.now(),
+    isFromPack: false,
+  }
+}
+
+function makeProgress(wordId: string, confidence: number): WordProgress {
+  return {
+    wordId,
+    correctCount: 5,
+    incorrectCount: 1,
+    streak: 3,
+    lastReviewed: Date.now(),
+    nextReview: Date.now() + 86400000,
+    confidence,
+    history: [],
+  }
+}
+
+function makePair(id: string): LanguagePair {
+  return {
+    id,
+    sourceLang: 'English',
+    targetLang: 'Latvian',
+    sourceCode: 'en',
+    targetCode: 'lv',
+    createdAt: Date.now(),
+  }
+}
+
+function createMockStorage(overrides: Partial<StorageService> = {}): StorageService {
+  return {
+    getLanguagePairs: vi.fn().mockResolvedValue([]),
+    getLanguagePair: vi.fn().mockResolvedValue(null),
+    saveLanguagePair: vi.fn().mockResolvedValue(undefined),
+    deleteLanguagePair: vi.fn().mockResolvedValue(undefined),
+    getWords: vi.fn().mockResolvedValue([]),
+    getWord: vi.fn().mockResolvedValue(null),
+    saveWord: vi.fn().mockResolvedValue(undefined),
+    saveWords: vi.fn().mockResolvedValue(undefined),
+    deleteWord: vi.fn().mockResolvedValue(undefined),
+    getWordProgress: vi.fn().mockResolvedValue(null),
+    getAllProgress: vi.fn().mockResolvedValue([]),
+    saveWordProgress: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({
+      activePairId: null,
+      quizMode: 'mixed',
+      dailyGoal: 20,
+      theme: 'dark',
+      typoTolerance: 1,
+    }),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+    getDailyStats: vi.fn().mockResolvedValue(null),
+    getDailyStatsRange: vi.fn().mockResolvedValue([]),
+    saveDailyStats: vi.fn().mockResolvedValue(undefined),
+    getRecentDailyStats: vi.fn().mockResolvedValue([]),
+    exportAll: vi.fn().mockResolvedValue('{}'),
+    importAll: vi.fn().mockResolvedValue(undefined),
+    clearAll: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as StorageService
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('getWordsLearnedForPair', () => {
+  let storage: StorageService
+
+  beforeEach(() => {
+    storage = createMockStorage()
+  })
+
+  it('returns 0/0 when the pair has no words', async () => {
+    vi.mocked(storage.getWords).mockResolvedValue([])
+    vi.mocked(storage.getAllProgress).mockResolvedValue([])
+
+    const result = await getWordsLearnedForPair(storage, 'pair1')
+    expect(result).toEqual({ learned: 0, total: 0 })
+  })
+
+  it('counts words with confidence >= threshold as learned', async () => {
+    const words = [makeWord('w1'), makeWord('w2'), makeWord('w3')]
+    const progress = [
+      makeProgress('w1', LEARNED_CONFIDENCE_THRESHOLD), // exactly at threshold = learned
+      makeProgress('w2', LEARNED_CONFIDENCE_THRESHOLD + 0.1), // above = learned
+      makeProgress('w3', LEARNED_CONFIDENCE_THRESHOLD - 0.01), // below = not learned
+    ]
+
+    vi.mocked(storage.getWords).mockResolvedValue(words)
+    vi.mocked(storage.getAllProgress).mockResolvedValue(progress)
+
+    const result = await getWordsLearnedForPair(storage, 'pair1')
+    expect(result).toEqual({ learned: 2, total: 3 })
+  })
+
+  it('does not count words with no progress record as learned', async () => {
+    const words = [makeWord('w1'), makeWord('w2')]
+    // w2 has no progress record
+    const progress = [makeProgress('w1', 0.9)]
+
+    vi.mocked(storage.getWords).mockResolvedValue(words)
+    vi.mocked(storage.getAllProgress).mockResolvedValue(progress)
+
+    const result = await getWordsLearnedForPair(storage, 'pair1')
+    expect(result).toEqual({ learned: 1, total: 2 })
+  })
+
+  it('returns 0 learned when all words have low confidence', async () => {
+    const words = [makeWord('w1'), makeWord('w2')]
+    const progress = [makeProgress('w1', 0.1), makeProgress('w2', 0.5)]
+
+    vi.mocked(storage.getWords).mockResolvedValue(words)
+    vi.mocked(storage.getAllProgress).mockResolvedValue(progress)
+
+    const result = await getWordsLearnedForPair(storage, 'pair1')
+    expect(result).toEqual({ learned: 0, total: 2 })
+  })
+
+  it('returns total learned when all words exceed threshold', async () => {
+    const words = [makeWord('w1'), makeWord('w2'), makeWord('w3')]
+    const progress = [makeProgress('w1', 0.9), makeProgress('w2', 0.85), makeProgress('w3', 1.0)]
+
+    vi.mocked(storage.getWords).mockResolvedValue(words)
+    vi.mocked(storage.getAllProgress).mockResolvedValue(progress)
+
+    const result = await getWordsLearnedForPair(storage, 'pair1')
+    expect(result).toEqual({ learned: 3, total: 3 })
+  })
+})
+
+describe('getTotalWordsLearned', () => {
+  it('returns 0/0 when there are no language pairs', async () => {
+    const storage = createMockStorage({
+      getLanguagePairs: vi.fn().mockResolvedValue([]),
+    })
+
+    const result = await getTotalWordsLearned(storage)
+    expect(result).toEqual({ learned: 0, total: 0 })
+  })
+
+  it('aggregates learned/total across multiple pairs', async () => {
+    const pair1 = makePair('pair1')
+    const pair2 = makePair('pair2')
+
+    const storage = createMockStorage({
+      getLanguagePairs: vi.fn().mockResolvedValue([pair1, pair2]),
+      getWords: vi
+        .fn()
+        .mockResolvedValueOnce([makeWord('w1', 'pair1'), makeWord('w2', 'pair1')])
+        .mockResolvedValueOnce([makeWord('w3', 'pair2')]),
+      getAllProgress: vi
+        .fn()
+        .mockResolvedValueOnce([makeProgress('w1', 0.9), makeProgress('w2', 0.3)])
+        .mockResolvedValueOnce([makeProgress('w3', 0.95)]),
+    })
+
+    const result = await getTotalWordsLearned(storage)
+    // pair1: 1 learned out of 2; pair2: 1 learned out of 1 → total: 2/3
+    expect(result).toEqual({ learned: 2, total: 3 })
+  })
+})

--- a/src/services/wordsLearnedService.ts
+++ b/src/services/wordsLearnedService.ts
@@ -1,0 +1,73 @@
+/**
+ * Words learned service - computes the "words learned" metric.
+ *
+ * A word is considered "learned" when its confidence score exceeds
+ * LEARNED_CONFIDENCE_THRESHOLD (0.8).  Words with no progress record
+ * have an implicit confidence of 0 and are not yet learned.
+ */
+
+import type { StorageService } from './storage/StorageService'
+import { LEARNED_CONFIDENCE_THRESHOLD } from './streakService'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface WordsLearnedResult {
+  /** Number of words whose confidence >= LEARNED_CONFIDENCE_THRESHOLD. */
+  readonly learned: number
+  /** Total words in the pair (including those with no progress record). */
+  readonly total: number
+}
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+/**
+ * Counts how many words in a language pair have been learned
+ * (confidence >= LEARNED_CONFIDENCE_THRESHOLD).
+ *
+ * @param storage - The storage service.
+ * @param pairId  - The language pair to evaluate.
+ * @returns learned / total counts for the pair.
+ */
+export async function getWordsLearnedForPair(
+  storage: StorageService,
+  pairId: string,
+): Promise<WordsLearnedResult> {
+  const words = await storage.getWords(pairId)
+  const total = words.length
+
+  if (total === 0) return { learned: 0, total: 0 }
+
+  const progressList = await storage.getAllProgress(pairId)
+  const progressMap = new Map(progressList.map((p) => [p.wordId, p]))
+
+  let learned = 0
+  for (const word of words) {
+    const progress = progressMap.get(word.id)
+    if (progress !== undefined && progress.confidence >= LEARNED_CONFIDENCE_THRESHOLD) {
+      learned++
+    }
+  }
+
+  return { learned, total }
+}
+
+/**
+ * Counts total learned and total words across all language pairs.
+ *
+ * @param storage - The storage service.
+ * @returns Aggregated learned / total counts.
+ */
+export async function getTotalWordsLearned(storage: StorageService): Promise<WordsLearnedResult> {
+  const pairs = await storage.getLanguagePairs()
+
+  let totalLearned = 0
+  let totalWords = 0
+
+  for (const pair of pairs) {
+    const result = await getWordsLearnedForPair(storage, pair.id)
+    totalLearned += result.learned
+    totalWords += result.total
+  }
+
+  return { learned: totalLearned, total: totalWords }
+}


### PR DESCRIPTION
## Summary

- Implements `streakService.ts` with daily streak calculation (current streak, best streak, grace period logic)
- Implements `wordsLearnedService.ts` to count words above the confidence threshold (0.8)
- Adds `sessionStreak` and `bestSessionStreak` to `useQuizSession` state — consecutive correct answers within a session
- Updates `SessionProgress` header to show a flame icon indicator when session streak is >= 2
- Updates `SessionSummary` to display: best in-session streak, words learned (X / Y), and daily streak
- Updates `QuizHub` to persist `DailyStats` after each session and load streak + words-learned data from storage

## Changes

- `src/services/streakService.ts` — pure streak calculation functions + async persistence helpers
- `src/services/streakService.test.ts` — 22 tests covering streak edge cases, grace period, best streak
- `src/services/wordsLearnedService.ts` — words learned metric per pair and across all pairs
- `src/services/wordsLearnedService.test.ts` — 7 tests covering threshold logic and multi-pair aggregation
- `src/features/quiz/useQuizSession.ts` — added `sessionStreak` / `bestSessionStreak` state
- `src/features/quiz/components/SessionProgress.tsx` — flame icon for active session streak
- `src/features/quiz/components/QuizLayout.tsx` — pass `sessionStreak` prop through
- `src/features/quiz/components/TypeQuizContent.tsx` — pass `sessionStreak` to layout
- `src/features/quiz/components/ChoiceQuizContent.tsx` — pass `sessionStreak` to layout
- `src/features/quiz/components/ActiveQuizView.tsx` — pass `bestSessionStreak` to finished callback
- `src/features/quiz/components/SessionSummary.tsx` — show best streak + words learned rows
- `src/features/quiz/components/SessionSummary.test.tsx` — updated tests for new props
- `src/features/quiz/components/QuizHub.tsx` — wire streak/words-learned persistence and display

## Testing

- All 405 tests pass (`npm test -- --run`)
- TypeScript strict: `npx tsc --noEmit` clean
- Production build: `npm run build` succeeds
- ESLint: `npx eslint . --max-warnings 0` clean
- Prettier: `npx prettier --check .` clean

## Review

- No direct `localStorage` calls — all storage via `StorageService`
- No hardcoded colours — MUI theme tokens used throughout
- No language-specific content
- All new functions have explicit return types
- Pure streak functions are fully unit tested with injectable `today` parameter

Closes #13