### PR TITLE
feat: add Sentry error tracking for production (#63)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Sentry DSN - get from https://sentry.io after creating a React project named "lexio"
+# The DSN is a write-only key — safe to embed in the client bundle (this is normal for Sentry).
+# Leave empty to disable Sentry (it will not initialise and the app works identically).
+VITE_SENTRY_DSN=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,11 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: mareks-reppo
+          SENTRY_PROJECT: lexio
 
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ dist-ssr
 e2e-results/
 playwright-report/
 test-results/
+
+# Local environment overrides (may contain secrets like VITE_SENTRY_DSN)
+.env.local
+.env.*.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,21 @@ Never commit a `package-lock.json` that fails `npm ci`. The CI pipeline enforces
 
 ---
 
+## Sentry Error Tracking
+
+Sentry is initialised in `src/main.tsx` before React renders. The initialisation module lives in `src/services/sentry.ts`.
+
+Key points for agents:
+
+- **Sentry is optional.** If `VITE_SENTRY_DSN` is not set, `initSentry()` returns immediately and the app works identically. No errors, no console warnings.
+- **Do not add Sentry imports directly.** Import from `@/services/sentry` (which re-exports the `Sentry` namespace), not directly from `@sentry/react`.
+- **Do not add explicit `Sentry.captureException()` calls** to new code. Sentry captures unhandled errors and unhandled promise rejections globally. You only need manual capture for errors you explicitly swallow with `catch`.
+- **No PII in errors.** Do not include localStorage contents, user input values, or personal data in error context.
+- **ErrorBoundary is in `App.tsx`.** React render crashes are caught there and shown as a user-friendly fallback. You do not need to add error boundaries in individual features.
+- **Source maps** are enabled in production builds (`build.sourcemap: true` in `vite.config.ts`). The Sentry Vite plugin uploads them when `SENTRY_AUTH_TOKEN` is set in CI — this only affects the CI build, not local dev.
+
+---
+
 ## Important Reminders
 
 - **Never hardcode language-specific content** - the app is language-agnostic

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,14 @@
         "@emotion/styled": "^11.13.5",
         "@mui/icons-material": "^6.4.7",
         "@mui/material": "^6.4.7",
+        "@sentry/react": "^10.45.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.58.2",
+        "@sentry/vite-plugin": "^5.1.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
@@ -1963,6 +1965,403 @@
         "win32"
       ]
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.45.0.tgz",
+      "integrity": "sha512-ZPZpeIarXKScvquGx2AfNKcYiVNDA4wegMmjyGVsTA2JPmP0TrJoO3UybJS6KGDeee8V3I3EfD/ruauMm7jOFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.45.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.45.0.tgz",
+      "integrity": "sha512-vCSurazFVq7RUeYiM5X326jA5gOVrWYD6lYX2fbjBOMcyCEhDnveNxMT62zKkZDyNT/jyD194nz/cjntBUkyWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.45.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.45.0.tgz",
+      "integrity": "sha512-vjosRoGA1bzhVAEO1oce+CsRdd70quzBeo7WvYqpcUnoLe/Rv8qpOMqWX3j26z7XfFHMExWQNQeLxmtYOArvlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.45.0",
+        "@sentry/core": "10.45.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.45.0.tgz",
+      "integrity": "sha512-nvq/AocdZTuD7y0KSiWi3gVaY0s5HOFy86mC/v1kDZmT/jsBAzN5LDkk/f1FvsWma1peqQmpUqxvhC+YIW294Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.45.0",
+        "@sentry/core": "10.45.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.1.1.tgz",
+      "integrity": "sha512-x2wEpBHwsTyTF2rWsLKJlzrRF1TTIGOfX+ngdE+Yd5DBkoS58HwQv824QOviPGQRla4/ypISqAXzjdDPL/zalg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.45.0.tgz",
+      "integrity": "sha512-e/a8UMiQhqqv706McSIcG6XK+AoQf9INthi2pD+giZfNRTzXTdqHzUT5OIO5hg8Am6eF63nDJc+vrYNPhzs51Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.45.0",
+        "@sentry-internal/feedback": "10.45.0",
+        "@sentry-internal/replay": "10.45.0",
+        "@sentry-internal/replay-canvas": "10.45.0",
+        "@sentry/core": "10.45.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-5.1.1.tgz",
+      "integrity": "sha512-F+itpwR9DyQR7gEkrXd2tigREPTvtF5lC8qu6e4anxXYRTui1+dVR0fXNwjpyAZMhIesLfXRN7WY7ggdj7hi0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/babel-plugin-component-annotate": "5.1.1",
+        "@sentry/cli": "^2.58.5",
+        "dotenv": "^16.3.1",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.5.tgz",
+      "integrity": "sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.5",
+        "@sentry/cli-linux-arm": "2.58.5",
+        "@sentry/cli-linux-arm64": "2.58.5",
+        "@sentry/cli-linux-i686": "2.58.5",
+        "@sentry/cli-linux-x64": "2.58.5",
+        "@sentry/cli-win32-arm64": "2.58.5",
+        "@sentry/cli-win32-i686": "2.58.5",
+        "@sentry/cli-win32-x64": "2.58.5"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.5.tgz",
+      "integrity": "sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.5.tgz",
+      "integrity": "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.5.tgz",
+      "integrity": "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.5.tgz",
+      "integrity": "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.5.tgz",
+      "integrity": "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.5.tgz",
+      "integrity": "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.5.tgz",
+      "integrity": "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.5.tgz",
+      "integrity": "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.45.0.tgz",
+      "integrity": "sha512-s69UXxvefeQxuZ5nY7/THtTrIEvJxNVCp3ns4kwoCw1qMpgpvn/296WCKVmM7MiwnaAdzEKnAvLAwaxZc2nM7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.45.0.tgz",
+      "integrity": "sha512-jLezuxi4BUIU3raKyAPR5xMbQG/nhwnWmKo5p11NCbLmWzkS+lxoyDTUB4B8TAKZLfdtdkKLOn1S0tFc8vbUHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.45.0",
+        "@sentry/core": "10.45.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/rollup-plugin": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/rollup-plugin/-/rollup-plugin-5.1.1.tgz",
+      "integrity": "sha512-1d5NkdRR6aKWBP7czkY8sFFWiKnfmfRpQOj+m9bJTsyTjbMiEQJst6315w5pCVlRItPhBqpAraqAhutZFgvyVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "5.1.1",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.1.1.tgz",
+      "integrity": "sha512-i6NWUDi2SDikfSUeMJvJTRdwEKYSfTd+mvBO2Ja51S1YK+hnickBuDfD+RvPerIXLuyRu3GamgNPbNqgCGUg/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "5.1.1",
+        "@sentry/rollup-plugin": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -3096,6 +3495,19 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -4442,6 +4854,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -4784,6 +5242,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4799,6 +5267,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@emotion/styled": "^11.13.5",
     "@mui/icons-material": "^6.4.7",
     "@mui/material": "^6.4.7",
+    "@sentry/react": "^10.45.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.58.2",
+    "@sentry/vite-plugin": "^5.1.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import type { CreatePairInput } from './features/language-pairs'
 import { WordListScreen } from './features/words'
 import { QuizHub } from './features/quiz'
 import type { UserSettings } from './types'
+import { Sentry } from './services/sentry'
 
 /**
  * A single shared storage instance for the application.
@@ -190,10 +191,39 @@ function AppContent() {
   )
 }
 
+/**
+ * Fallback UI rendered when a React render crash is caught by the ErrorBoundary.
+ * Shows a user-friendly message and a button to retry.
+ */
+function ErrorFallback({
+  resetError,
+}: {
+  error: unknown
+  resetError: () => void
+  componentStack: string
+  eventId: string
+}): React.JSX.Element {
+  return (
+    <Box sx={{ textAlign: 'center', py: 8, px: 2 }}>
+      <Typography variant="h5" gutterBottom>
+        Something went wrong
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        The error has been reported. Please try refreshing the page.
+      </Typography>
+      <Button variant="contained" onClick={resetError}>
+        Try again
+      </Button>
+    </Box>
+  )
+}
+
 export default function App() {
   return (
     <StorageContext.Provider value={storageService}>
-      <AppContent />
+      <Sentry.ErrorBoundary fallback={ErrorFallback}>
+        <AppContent />
+      </Sentry.ErrorBoundary>
     </StorageContext.Provider>
   )
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,8 @@
+// Sentry must be initialised before React so that initialisation errors are
+// also captured. The call is a no-op when VITE_SENTRY_DSN is not set.
+import { initSentry } from './services/sentry'
+initSentry()
+
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'

--- a/src/services/sentry.test.ts
+++ b/src/services/sentry.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// We mock @sentry/react before importing the module under test so that
+// Sentry.init is never called against a real DSN in the test environment.
+const mockInit = vi.fn()
+const mockErrorBoundary = vi.fn()
+
+vi.mock('@sentry/react', () => ({
+  init: mockInit,
+  ErrorBoundary: mockErrorBoundary,
+}))
+
+describe('initSentry', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockInit.mockClear()
+    mockErrorBoundary.mockClear()
+  })
+
+  afterEach(() => {
+    // Clean up any DSN set during test.
+    delete import.meta.env.VITE_SENTRY_DSN
+  })
+
+  it('should not call Sentry.init when VITE_SENTRY_DSN is not set', async () => {
+    delete import.meta.env.VITE_SENTRY_DSN
+
+    const { initSentry } = await import('./sentry')
+    initSentry()
+
+    expect(mockInit).not.toHaveBeenCalled()
+  })
+
+  it('should not call Sentry.init when VITE_SENTRY_DSN is an empty string', async () => {
+    import.meta.env.VITE_SENTRY_DSN = ''
+
+    const { initSentry } = await import('./sentry')
+    initSentry()
+
+    expect(mockInit).not.toHaveBeenCalled()
+  })
+
+  it('should call Sentry.init when VITE_SENTRY_DSN is provided', async () => {
+    const testDsn = 'https://test@o123.ingest.sentry.io/456'
+    import.meta.env.VITE_SENTRY_DSN = testDsn
+
+    const { initSentry } = await import('./sentry')
+    initSentry()
+
+    expect(mockInit).toHaveBeenCalledOnce()
+    expect(mockInit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dsn: testDsn,
+        sampleRate: 1.0,
+        tracesSampleRate: 0.1,
+      }),
+    )
+  })
+
+  it('should pass enabled: false in non-production environments', async () => {
+    const testDsn = 'https://test@o123.ingest.sentry.io/456'
+    import.meta.env.VITE_SENTRY_DSN = testDsn
+    // PROD is false in the Vitest jsdom environment.
+    import.meta.env.PROD = false
+
+    const { initSentry } = await import('./sentry')
+    initSentry()
+
+    expect(mockInit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+      }),
+    )
+  })
+
+  it('should include ignoreErrors patterns to suppress noisy browser errors', async () => {
+    const testDsn = 'https://test@o123.ingest.sentry.io/456'
+    import.meta.env.VITE_SENTRY_DSN = testDsn
+
+    const { initSentry } = await import('./sentry')
+    initSentry()
+
+    const callArgs = mockInit.mock.calls[0][0] as {
+      ignoreErrors: Array<string | RegExp>
+    }
+    expect(callArgs.ignoreErrors).toContain('Failed to fetch')
+    expect(callArgs.ignoreErrors).toContain('Network request failed')
+    expect(callArgs.ignoreErrors.some((e) => e instanceof RegExp)).toBe(true)
+  })
+
+  it('should re-export the Sentry namespace', async () => {
+    const { Sentry } = await import('./sentry')
+    expect(Sentry).toBeDefined()
+    // Confirm it re-exports the mocked init function.
+    expect(Sentry.init).toBe(mockInit)
+  })
+})

--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -1,0 +1,59 @@
+import * as Sentry from '@sentry/react'
+import type { Breadcrumb } from '@sentry/core'
+
+/**
+ * Initialises Sentry error tracking.
+ *
+ * Sentry is optional — if VITE_SENTRY_DSN is not set (local dev, forks without
+ * the secret), this function returns early and the app works identically.
+ *
+ * Call this before React renders so that initialisation errors are also captured.
+ */
+export function initSentry(): void {
+  const dsn = import.meta.env.VITE_SENTRY_DSN as string | undefined
+
+  // Skip initialisation if no DSN provided (local dev or secret not configured).
+  if (!dsn) return
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.MODE as string,
+    // Only send errors in production builds — keeps staging/preview clean.
+    enabled: import.meta.env.PROD as boolean,
+    // Capture 100% of errors, 10% of performance transactions.
+    sampleRate: 1.0,
+    tracesSampleRate: 0.1,
+    // Suppress noisy errors caused by browser extensions or transient network issues.
+    ignoreErrors: [
+      /extensions\//,
+      /^chrome-extension:\/\//,
+      'Network request failed',
+      'Failed to fetch',
+      'Load failed',
+    ],
+    beforeSend(event) {
+      // The app has no user accounts, but strip breadcrumb data that could
+      // accidentally include form values or localStorage contents.
+      if (event.breadcrumbs) {
+        event.breadcrumbs = event.breadcrumbs.map(
+          (crumb: Breadcrumb): Breadcrumb => ({
+            ...crumb,
+            // Retain only url and method from XHR/fetch breadcrumb payloads —
+            // strip any response bodies or other potentially sensitive fields.
+            data: crumb.data
+              ? {
+                  url: crumb.data.url as string | undefined,
+                  method: crumb.data.method as string | undefined,
+                }
+              : undefined,
+          }),
+        )
+      }
+      return event
+    },
+  })
+}
+
+// Re-export the Sentry namespace so callers do not need a direct dependency on
+// @sentry/react — they import from here and get the ErrorBoundary etc.
+export { Sentry }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,31 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    // Only upload source maps when the Sentry auth token is available (CI builds).
+    // Local builds and forks without the secret continue to work without this step.
+    ...(process.env.SENTRY_AUTH_TOKEN
+      ? [
+          sentryVitePlugin({
+            org: 'mareks-reppo',
+            project: 'lexio',
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+          }),
+        ]
+      : []),
+  ],
   base: '/lexio/',
+  build: {
+    // Source maps are required for Sentry to show readable stack traces.
+    // They are uploaded to Sentry and not served publicly, so this does not
+    // expose source code to end users.
+    sourcemap: true,
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary

Adds optional Sentry error tracking to catch React render crashes, unhandled promise rejections, and failed network requests in production.

- Sentry is fully optional: if `VITE_SENTRY_DSN` is not set, `initSentry()` is a no-op and the app works identically
- React `ErrorBoundary` wraps the entire app with a user-friendly fallback UI
- Source maps enabled for readable stack traces; uploaded to Sentry in CI when `SENTRY_AUTH_TOKEN` is configured
- `beforeSend` strips breadcrumb payloads to prevent accidental PII capture

## Changes

- `src/services/sentry.ts` — new: `initSentry()` and `Sentry` namespace re-export
- `src/services/sentry.test.ts` — new: 6 unit tests for init logic
- `src/main.tsx` — call `initSentry()` before React renders
- `src/App.tsx` — wrap `AppContent` in `Sentry.ErrorBoundary` with `ErrorFallback`
- `vite.config.ts` — `build.sourcemap: true`; conditional `sentryVitePlugin`
- `.env.example` — new: documents `VITE_SENTRY_DSN`
- `.gitignore` — ignore `.env.local` and `.env.*.local`
- `.github/workflows/deploy.yml` — pass DSN and auth token env vars to build step
- `CLAUDE.md` — Sentry section for future agents

## Testing

- 411 unit tests pass (27 test files, 6 new for sentry.ts)
- `npx tsc --noEmit` clean
- `npx eslint . --max-warnings 0` clean
- `npx prettier --check .` clean
- `npm run build` succeeds

## Review

- Code review passed — no issues found

Closes #63