### PR TITLE
feat: home/dashboard screen and app navigation (#18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ test-results/
 # Local environment overrides (may contain secrets like VITE_SENTRY_DSN)
 .env.local
 .env.*.local
+
+# Test coverage reports
+coverage/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,22 +8,20 @@ import {
   Typography,
   Container,
   Button,
-  Tab,
-  Tabs,
 } from '@mui/material'
 import { createAppTheme } from './theme'
 import { useThemeMode } from './hooks/useThemeMode'
 import { LocalStorageService } from './services/storage'
 import { StorageContext, useStorage } from './hooks/useStorage'
-import {
-  useLanguagePairs,
-  LanguagePairSelector,
-  CreatePairDialog,
-  LanguagePairList,
-} from './features/language-pairs'
+import { useLanguagePairs, LanguagePairSelector, CreatePairDialog } from './features/language-pairs'
 import type { CreatePairInput } from './features/language-pairs'
 import { WordListScreen } from './features/words'
 import { QuizHub } from './features/quiz'
+import { DashboardScreen, useDashboard } from './features/dashboard'
+import { StatsScreen } from './features/stats'
+import { SettingsScreen } from './features/settings'
+import { BottomNav } from './components'
+import type { AppTab } from './components'
 import type { UserSettings } from './types'
 import { Sentry } from './services/sentry'
 
@@ -38,16 +36,16 @@ const storageService = new LocalStorageService()
  * Split from the outer App so context is available for all hooks.
  */
 function AppContent() {
-  const { mode } = useThemeMode(storageService)
+  const { preference: themePreference, mode, setPreference } = useThemeMode(storageService)
   const appTheme = useMemo(() => createAppTheme(mode), [mode])
 
-  const { pairs, activePair, loading, createPair, switchPair, deletePair } = useLanguagePairs()
+  const { pairs, activePair, loading: pairsLoading, createPair, switchPair } = useLanguagePairs()
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   // Whether this is the first launch (no pairs yet, after loading completes).
   const [isFirstLaunch, setIsFirstLaunch] = useState(false)
-  // Active tab
-  const [activeTab, setActiveTab] = useState<'quiz' | 'words' | 'pairs'>('quiz')
+  // Active navigation tab.
+  const [activeTab, setActiveTab] = useState<AppTab>('home')
 
   const storage = useStorage()
   const [settings, setSettings] = useState<UserSettings>({
@@ -64,11 +62,13 @@ function AppContent() {
   }, [storage])
 
   useEffect(() => {
-    if (!loading && pairs.length === 0) {
+    if (!pairsLoading && pairs.length === 0) {
       setIsFirstLaunch(true)
       setCreateDialogOpen(true)
     }
-  }, [loading, pairs.length])
+  }, [pairsLoading, pairs.length])
+
+  const dashboardData = useDashboard(activePair?.id ?? null, settings.dailyGoal)
 
   const handleCreatePair = useCallback(
     async (input: CreatePairInput): Promise<void> => {
@@ -85,6 +85,37 @@ function AppContent() {
   const handleCloseCreateDialog = useCallback(() => {
     setCreateDialogOpen(false)
   }, [])
+
+  /** Navigate to quiz tab (called from Dashboard quick-start button). */
+  const handleStartQuizFromDashboard = useCallback(() => {
+    setActiveTab('quiz')
+  }, [])
+
+  /** Handle settings change from QuizHub (quiz mode changes) and persist. */
+  const handleSettingsChange = useCallback((updated: UserSettings): void => {
+    setSettings(updated)
+  }, [])
+
+  /** Handle theme change from SettingsScreen. */
+  const handleThemeChange = useCallback(
+    (preference: UserSettings['theme']): void => {
+      void setPreference(preference)
+    },
+    [setPreference],
+  )
+
+  // When returning to the home tab, refresh dashboard data.
+  const handleTabChange = useCallback(
+    (tab: AppTab): void => {
+      setActiveTab(tab)
+      if (tab === 'home') {
+        dashboardData.refresh()
+      }
+    },
+    [dashboardData],
+  )
+
+  const showNav = !pairsLoading && pairs.length > 0
 
   return (
     <ThemeProvider theme={appTheme}>
@@ -105,30 +136,16 @@ function AppContent() {
           <LanguagePairSelector
             pairs={pairs}
             activePair={activePair}
-            loading={loading}
+            loading={pairsLoading}
             onSwitch={switchPair}
             onAddPair={handleOpenCreateDialog}
           />
         </Toolbar>
       </AppBar>
 
-      {/* Navigation tabs — only show when there are pairs */}
-      {!loading && pairs.length > 0 && (
-        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-          <Tabs
-            value={activeTab}
-            onChange={(_e, v: 'quiz' | 'words' | 'pairs') => setActiveTab(v)}
-            centered
-          >
-            <Tab label="Quiz" value="quiz" />
-            <Tab label="Words" value="words" />
-            <Tab label="Language pairs" value="pairs" />
-          </Tabs>
-        </Box>
-      )}
-
-      <Container maxWidth="sm" sx={{ py: 4 }}>
-        {!loading && (
+      {/* Main content — bottom padding makes room for the fixed BottomNav */}
+      <Container maxWidth="sm" sx={{ py: 3, pb: showNav ? '72px' : 3 }}>
+        {!pairsLoading && (
           <>
             {pairs.length === 0 ? (
               <Box sx={{ textAlign: 'center', py: 8 }}>
@@ -144,42 +161,46 @@ function AppContent() {
               </Box>
             ) : (
               <>
+                {activeTab === 'home' && (
+                  <DashboardScreen
+                    activePair={activePair}
+                    settings={settings}
+                    todayStats={dashboardData.todayStats}
+                    wordProgressList={dashboardData.wordProgressList}
+                    totalWords={dashboardData.totalWords}
+                    streakDays={dashboardData.streakDays}
+                    recentStats={dashboardData.recentStats}
+                    loading={dashboardData.loading}
+                    onStartQuiz={handleStartQuizFromDashboard}
+                  />
+                )}
+
                 {activeTab === 'quiz' && (
-                  <QuizHub pair={activePair} settings={settings} onSettingsChange={setSettings} />
+                  <QuizHub
+                    pair={activePair}
+                    settings={settings}
+                    onSettingsChange={handleSettingsChange}
+                  />
                 )}
 
                 {activeTab === 'words' && <WordListScreen activePair={activePair} />}
 
-                {activeTab === 'pairs' && (
-                  <Box>
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'space-between',
-                        mb: 2,
-                      }}
-                    >
-                      <Typography variant="h6" fontWeight={700}>
-                        Language pairs
-                      </Typography>
-                      <Button variant="outlined" size="small" onClick={handleOpenCreateDialog}>
-                        Add pair
-                      </Button>
-                    </Box>
+                {activeTab === 'stats' && <StatsScreen />}
 
-                    <LanguagePairList
-                      pairs={pairs}
-                      activePairId={activePair?.id ?? null}
-                      onDelete={deletePair}
-                    />
-                  </Box>
+                {activeTab === 'settings' && (
+                  <SettingsScreen
+                    themePreference={themePreference}
+                    onThemeChange={handleThemeChange}
+                  />
                 )}
               </>
             )}
           </>
         )}
       </Container>
+
+      {/* Bottom navigation — only visible when there are language pairs */}
+      {showNav && <BottomNav activeTab={activeTab} onTabChange={handleTabChange} />}
 
       <CreatePairDialog
         open={createDialogOpen}

--- a/src/components/BottomNav.test.tsx
+++ b/src/components/BottomNav.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BottomNav } from './BottomNav'
+import type { AppTab } from './BottomNav'
+
+describe('BottomNav', () => {
+  it('should render all five navigation tabs', () => {
+    render(<BottomNav activeTab="home" onTabChange={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /Navigate to Home/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Navigate to Quiz/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Navigate to Words/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Navigate to Stats/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Navigate to Settings/i })).toBeInTheDocument()
+  })
+
+  it('should call onTabChange with correct tab when a tab is clicked', async () => {
+    const user = userEvent.setup()
+    const onTabChange = vi.fn()
+    render(<BottomNav activeTab="home" onTabChange={onTabChange} />)
+
+    await user.click(screen.getByRole('button', { name: /Navigate to Quiz/i }))
+    expect(onTabChange).toHaveBeenCalledWith('quiz')
+  })
+
+  it('should call onTabChange with "words" when Words tab is clicked', async () => {
+    const user = userEvent.setup()
+    const onTabChange = vi.fn()
+    render(<BottomNav activeTab="home" onTabChange={onTabChange} />)
+
+    await user.click(screen.getByRole('button', { name: /Navigate to Words/i }))
+    expect(onTabChange).toHaveBeenCalledWith('words')
+  })
+
+  it('should call onTabChange with "stats" when Stats tab is clicked', async () => {
+    const user = userEvent.setup()
+    const onTabChange = vi.fn()
+    render(<BottomNav activeTab="home" onTabChange={onTabChange} />)
+
+    await user.click(screen.getByRole('button', { name: /Navigate to Stats/i }))
+    expect(onTabChange).toHaveBeenCalledWith('stats')
+  })
+
+  it('should call onTabChange with "settings" when Settings tab is clicked', async () => {
+    const user = userEvent.setup()
+    const onTabChange = vi.fn()
+    render(<BottomNav activeTab="home" onTabChange={onTabChange} />)
+
+    await user.click(screen.getByRole('button', { name: /Navigate to Settings/i }))
+    expect(onTabChange).toHaveBeenCalledWith('settings')
+  })
+
+  it('should have aria-label for navigation', () => {
+    render(<BottomNav activeTab="home" onTabChange={vi.fn()} />)
+    expect(screen.getByRole('navigation', { name: 'App navigation' })).toBeInTheDocument()
+  })
+
+  it.each<AppTab>(['home', 'quiz', 'words', 'stats', 'settings'])(
+    'should render with "%s" as the active tab without crashing',
+    (tab) => {
+      render(<BottomNav activeTab={tab} onTabChange={vi.fn()} />)
+      expect(screen.getByRole('navigation', { name: 'App navigation' })).toBeInTheDocument()
+    },
+  )
+})

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,81 @@
+/**
+ * BottomNav - mobile-style bottom navigation bar.
+ *
+ * Renders five navigation tabs: Home, Quiz, Words, Stats, Settings.
+ * On desktop viewports the bar still renders at the bottom to keep
+ * the mobile-first experience consistent; it could be promoted to a
+ * sidebar variant in a future enhancement.
+ */
+
+import { Paper, BottomNavigation, BottomNavigationAction } from '@mui/material'
+import HomeIcon from '@mui/icons-material/Home'
+import QuizIcon from '@mui/icons-material/Quiz'
+import ListIcon from '@mui/icons-material/List'
+import BarChartIcon from '@mui/icons-material/BarChart'
+import SettingsIcon from '@mui/icons-material/Settings'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type AppTab = 'home' | 'quiz' | 'words' | 'stats' | 'settings'
+
+export interface BottomNavProps {
+  /** The currently active tab. */
+  readonly activeTab: AppTab
+  /** Called when the user selects a different tab. */
+  readonly onTabChange: (tab: AppTab) => void
+}
+
+// ─── Tab descriptors ──────────────────────────────────────────────────────────
+
+interface TabDescriptor {
+  readonly value: AppTab
+  readonly label: string
+  readonly icon: React.ReactNode
+}
+
+const TABS: readonly TabDescriptor[] = [
+  { value: 'home', label: 'Home', icon: <HomeIcon /> },
+  { value: 'quiz', label: 'Quiz', icon: <QuizIcon /> },
+  { value: 'words', label: 'Words', icon: <ListIcon /> },
+  { value: 'stats', label: 'Stats', icon: <BarChartIcon /> },
+  { value: 'settings', label: 'Settings', icon: <SettingsIcon /> },
+]
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function BottomNav({ activeTab, onTabChange }: BottomNavProps) {
+  return (
+    <Paper
+      elevation={3}
+      sx={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: (theme) => theme.zIndex.appBar,
+        // Ensure bottom nav does not overlap system home indicator on iOS.
+        paddingBottom: 'env(safe-area-inset-bottom)',
+      }}
+    >
+      <BottomNavigation
+        value={activeTab}
+        onChange={(_e, newValue: AppTab) => {
+          onTabChange(newValue)
+        }}
+        showLabels
+        component="nav"
+        aria-label="App navigation"
+      >
+        {TABS.map(({ value, label, icon }) => (
+          <BottomNavigationAction
+            key={value}
+            label={label}
+            value={value}
+            icon={icon}
+            aria-label={`Navigate to ${label}`}
+          />
+        ))}
+      </BottomNavigation>
+    </Paper>
+  )
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,2 @@
+export { BottomNav } from './BottomNav'
+export type { BottomNavProps, AppTab } from './BottomNav'

--- a/src/features/dashboard/components/DashboardScreen.test.tsx
+++ b/src/features/dashboard/components/DashboardScreen.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DashboardScreen } from './DashboardScreen'
+import type { DashboardScreenProps } from './DashboardScreen'
+import type { LanguagePair, UserSettings, DailyStats, WordProgress } from '@/types'
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const defaultSettings: UserSettings = {
+  activePairId: 'pair-1',
+  quizMode: 'type',
+  dailyGoal: 20,
+  theme: 'dark',
+  typoTolerance: 1,
+}
+
+const activePair: LanguagePair = {
+  id: 'pair-1',
+  sourceLang: 'Latvian',
+  targetLang: 'English',
+  sourceCode: 'lv',
+  targetCode: 'en',
+  createdAt: 1700000000000,
+}
+
+const todayStats: DailyStats = {
+  date: '2026-03-20',
+  wordsReviewed: 10,
+  correctCount: 8,
+  incorrectCount: 2,
+  streakDays: 3,
+}
+
+const wordProgress: WordProgress = {
+  wordId: 'word-1',
+  correctCount: 5,
+  incorrectCount: 1,
+  streak: 3,
+  lastReviewed: 1700000000000,
+  nextReview: 1700086400000,
+  confidence: 0.85,
+  history: [],
+}
+
+function buildProps(overrides: Partial<DashboardScreenProps> = {}): DashboardScreenProps {
+  return {
+    activePair,
+    settings: defaultSettings,
+    todayStats: null,
+    wordProgressList: [],
+    totalWords: 0,
+    streakDays: 0,
+    recentStats: [],
+    loading: false,
+    onStartQuiz: vi.fn(),
+    ...overrides,
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DashboardScreen', () => {
+  describe('empty state (new user)', () => {
+    it('should render without crashing with minimal props', () => {
+      render(<DashboardScreen {...buildProps()} />)
+      expect(screen.getByRole('main', { name: 'Dashboard' })).toBeInTheDocument()
+    })
+
+    it('should show "No sessions yet today" when todayStats is null', () => {
+      render(<DashboardScreen {...buildProps({ todayStats: null })} />)
+      expect(screen.getByText(/No sessions yet today/i)).toBeInTheDocument()
+    })
+
+    it('should show "No words added yet" when totalWords is 0', () => {
+      render(<DashboardScreen {...buildProps({ totalWords: 0 })} />)
+      expect(screen.getByText(/No words added yet/i)).toBeInTheDocument()
+    })
+
+    it('should show "No recent activity" when recentStats is empty', () => {
+      render(<DashboardScreen {...buildProps({ recentStats: [] })} />)
+      expect(screen.getByText(/No recent activity/i)).toBeInTheDocument()
+    })
+
+    it('should show "Quick start" section', () => {
+      render(<DashboardScreen {...buildProps()} />)
+      expect(screen.getByText('Quick start')).toBeInTheDocument()
+    })
+
+    it('should display the active language pair in quick start', () => {
+      render(<DashboardScreen {...buildProps()} />)
+      expect(screen.getByText(/Latvian.*English/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('populated state', () => {
+    it('should show today stats when provided', () => {
+      render(<DashboardScreen {...buildProps({ todayStats })} />)
+      // 10 words reviewed — may appear in multiple places (hero ring + today section)
+      const elements = screen.getAllByText('10')
+      expect(elements.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('should show accuracy percentage', () => {
+      render(<DashboardScreen {...buildProps({ todayStats })} />)
+      // 8/10 = 80%
+      expect(screen.getByText('80%')).toBeInTheDocument()
+    })
+
+    it('should show streak badge when streakDays >= 1', () => {
+      render(<DashboardScreen {...buildProps({ streakDays: 5 })} />)
+      expect(screen.getByRole('status', { name: /5 day streak/i })).toBeInTheDocument()
+    })
+
+    it('should not show streak badge when streakDays is 0', () => {
+      render(<DashboardScreen {...buildProps({ streakDays: 0 })} />)
+      expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    })
+
+    it('should show word buckets when totalWords > 0', () => {
+      render(
+        <DashboardScreen
+          {...buildProps({
+            totalWords: 3,
+            wordProgressList: [wordProgress],
+          })}
+        />,
+      )
+      expect(screen.getByLabelText(/mastered words/i)).toBeInTheDocument()
+    })
+
+    it('should show recent activity entries', () => {
+      const stats: DailyStats[] = [
+        {
+          date: '2026-03-19',
+          wordsReviewed: 15,
+          correctCount: 12,
+          incorrectCount: 3,
+          streakDays: 1,
+        },
+      ]
+      render(<DashboardScreen {...buildProps({ recentStats: stats })} />)
+      expect(screen.getByText('2026-03-19')).toBeInTheDocument()
+      expect(screen.getByText('15 words')).toBeInTheDocument()
+    })
+  })
+
+  describe('loading state', () => {
+    it('should render skeleton elements when loading', () => {
+      render(<DashboardScreen {...buildProps({ loading: true })} />)
+      // The Start Quiz button should be disabled while loading
+      const startButton = screen.getByRole('button', { name: /Start Quiz/i })
+      expect(startButton).toBeDisabled()
+    })
+  })
+
+  describe('interactions', () => {
+    it('should call onStartQuiz when Start Quiz button is clicked', async () => {
+      const user = userEvent.setup()
+      const onStartQuiz = vi.fn()
+      render(<DashboardScreen {...buildProps({ onStartQuiz })} />)
+
+      await user.click(screen.getByRole('button', { name: /Start Quiz/i }))
+      expect(onStartQuiz).toHaveBeenCalledTimes(1)
+    })
+
+    it('should disable Start Quiz button when activePair is null', () => {
+      render(<DashboardScreen {...buildProps({ activePair: null })} />)
+      expect(screen.getByRole('button', { name: /Start Quiz/i })).toBeDisabled()
+    })
+  })
+
+  describe('no active pair', () => {
+    it('should show "No language pair selected" in quick start', () => {
+      render(<DashboardScreen {...buildProps({ activePair: null })} />)
+      expect(screen.getByText('No language pair selected')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/features/dashboard/components/DashboardScreen.tsx
+++ b/src/features/dashboard/components/DashboardScreen.tsx
@@ -1,0 +1,511 @@
+/**
+ * DashboardScreen - the main home/landing screen shown after onboarding.
+ *
+ * Sections:
+ *   1. Hero    - greeting, current streak, daily goal progress ring
+ *   2. Quick start - "Start Quiz" button with active pair & mode info
+ *   3. Today's summary - words reviewed today, accuracy, new words
+ *   4. Word overview - Learning / Familiar / Mastered chip counts
+ *   5. Recent activity - last few sessions (daily stats)
+ */
+
+import { useMemo } from 'react'
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Skeleton,
+  Typography,
+} from '@mui/material'
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment'
+import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import type { LanguagePair, UserSettings, DailyStats, WordProgress } from '@/types'
+import { getCurrentGreeting } from '../utils/greeting'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const RING_SIZE = 96
+
+/** Confidence threshold for "Familiar" (between learning and mastered). */
+const FAMILIAR_THRESHOLD = 0.5
+
+/** Confidence threshold for "Mastered". */
+const MASTERED_THRESHOLD = 0.8
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface DashboardScreenProps {
+  /** The currently active language pair (null if none selected). */
+  readonly activePair: LanguagePair | null
+  /** The current user settings. */
+  readonly settings: UserSettings
+  /** Today's daily stats (null if no session today). */
+  readonly todayStats: DailyStats | null
+  /** Progress records for all words in the active pair. */
+  readonly wordProgressList: readonly WordProgress[]
+  /** Total words in the active pair. */
+  readonly totalWords: number
+  /** Current streak in days. */
+  readonly streakDays: number
+  /** Recent daily stats (last 7 days), newest first. */
+  readonly recentStats: readonly DailyStats[]
+  /** Whether data is still loading. */
+  readonly loading: boolean
+  /** Called when the user taps "Start Quiz". */
+  readonly onStartQuiz: () => void
+}
+
+// ─── Helper to bucket words by confidence ─────────────────────────────────────
+
+interface WordBuckets {
+  readonly learning: number
+  readonly familiar: number
+  readonly mastered: number
+}
+
+function bucketWords(progressList: readonly WordProgress[], totalWords: number): WordBuckets {
+  let familiar = 0
+  let mastered = 0
+  const withProgress = new Set(progressList.map((p) => p.wordId))
+
+  for (const p of progressList) {
+    if (p.confidence >= MASTERED_THRESHOLD) {
+      mastered++
+    } else if (p.confidence >= FAMILIAR_THRESHOLD) {
+      familiar++
+    }
+  }
+
+  // Words with no progress record are implicitly "learning".
+  const learning = totalWords - withProgress.size + (progressList.length - familiar - mastered)
+
+  return { learning, familiar, mastered }
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+interface HeroSectionProps {
+  readonly greeting: string
+  readonly streakDays: number
+  readonly wordsReviewedToday: number
+  readonly dailyGoal: number
+  readonly loading: boolean
+}
+
+function HeroSection({
+  greeting,
+  streakDays,
+  wordsReviewedToday,
+  dailyGoal,
+  loading,
+}: HeroSectionProps) {
+  const goalMet = wordsReviewedToday >= dailyGoal
+  const progressValue = dailyGoal > 0 ? Math.min(100, (wordsReviewedToday / dailyGoal) * 100) : 0
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 3,
+        p: 3,
+        borderRadius: 3,
+        bgcolor: goalMet ? 'success.main' : 'background.paper',
+        border: 1,
+        borderColor: goalMet ? 'success.main' : 'divider',
+        transition: 'background-color 0.3s, border-color 0.3s',
+      }}
+      role="region"
+      aria-label="Daily goal progress"
+    >
+      {/* Circular progress ring */}
+      <Box sx={{ position: 'relative', flexShrink: 0 }}>
+        <CircularProgress
+          variant="determinate"
+          value={100}
+          size={RING_SIZE}
+          thickness={4}
+          sx={{
+            color: goalMet ? 'rgba(255,255,255,0.3)' : 'action.hover',
+            position: 'absolute',
+          }}
+          aria-hidden="true"
+        />
+        <CircularProgress
+          variant="determinate"
+          value={progressValue}
+          size={RING_SIZE}
+          thickness={4}
+          sx={{ color: goalMet ? 'white' : 'primary.main' }}
+          aria-label={`Daily goal: ${wordsReviewedToday} of ${dailyGoal} words reviewed today`}
+        />
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          aria-hidden="true"
+        >
+          {goalMet ? (
+            <CheckCircleOutlineIcon sx={{ fontSize: 32, color: 'white' }} />
+          ) : (
+            <>
+              <Typography
+                variant="caption"
+                fontWeight={700}
+                lineHeight={1}
+                sx={{ color: 'text.primary', fontSize: '0.9rem' }}
+              >
+                {wordsReviewedToday}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{ color: 'text.disabled', fontSize: '0.65rem', lineHeight: 1 }}
+              >
+                / {dailyGoal}
+              </Typography>
+            </>
+          )}
+        </Box>
+      </Box>
+
+      {/* Right side */}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        {loading ? (
+          <>
+            <Skeleton width={120} height={20} />
+            <Skeleton width={80} height={16} sx={{ mt: 0.5 }} />
+          </>
+        ) : (
+          <>
+            <Typography
+              variant="h6"
+              fontWeight={700}
+              sx={{ color: goalMet ? 'white' : 'text.primary' }}
+            >
+              {greeting}
+            </Typography>
+
+            <Typography
+              variant="caption"
+              sx={{
+                color: goalMet ? 'rgba(255,255,255,0.85)' : 'text.secondary',
+                display: 'block',
+              }}
+            >
+              {goalMet
+                ? `${wordsReviewedToday} words today — goal met!`
+                : `${wordsReviewedToday} / ${dailyGoal} words today`}
+            </Typography>
+
+            {streakDays >= 1 && (
+              <Box
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 0.25,
+                  mt: 0.5,
+                  color: goalMet ? 'rgba(255,255,255,0.9)' : 'warning.main',
+                }}
+                role="status"
+                aria-label={`${streakDays} day streak`}
+              >
+                <LocalFireDepartmentIcon sx={{ fontSize: 14 }} aria-hidden="true" />
+                <Typography variant="caption" fontWeight={600} sx={{ lineHeight: 1 }}>
+                  {streakDays} day{streakDays !== 1 ? 's' : ''} streak
+                </Typography>
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+// ─── Quick Start section ──────────────────────────────────────────────────────
+
+interface QuickStartProps {
+  readonly activePair: LanguagePair | null
+  readonly quizMode: string
+  readonly onStartQuiz: () => void
+  readonly loading: boolean
+}
+
+function QuickStart({ activePair, quizMode, onStartQuiz, loading }: QuickStartProps) {
+  const modeLabel = quizMode.charAt(0).toUpperCase() + quizMode.slice(1)
+
+  return (
+    <Card variant="outlined">
+      <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, p: 2.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Box>
+            <Typography variant="subtitle1" fontWeight={700}>
+              Quick start
+            </Typography>
+            {loading ? (
+              <Skeleton width={100} height={16} />
+            ) : (
+              <Typography variant="caption" color="text.secondary">
+                {activePair
+                  ? `${activePair.sourceLang} → ${activePair.targetLang} · ${modeLabel} mode`
+                  : 'No language pair selected'}
+              </Typography>
+            )}
+          </Box>
+        </Box>
+
+        <Button
+          variant="contained"
+          size="large"
+          fullWidth
+          startIcon={<PlayArrowIcon />}
+          onClick={onStartQuiz}
+          disabled={activePair === null || loading}
+          aria-label="Start quiz"
+        >
+          Start Quiz
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── Today's summary ──────────────────────────────────────────────────────────
+
+interface TodaysSummaryProps {
+  readonly todayStats: DailyStats | null
+  readonly dailyGoal: number
+  readonly loading: boolean
+}
+
+function TodaysSummary({ todayStats, loading }: TodaysSummaryProps) {
+  const wordsReviewed = todayStats?.wordsReviewed ?? 0
+  const correctCount = todayStats?.correctCount ?? 0
+  const accuracy = wordsReviewed > 0 ? Math.round((correctCount / wordsReviewed) * 100) : null
+
+  const statItems = [
+    {
+      label: 'Reviewed',
+      value: wordsReviewed,
+      suffix: 'words',
+    },
+    {
+      label: 'Accuracy',
+      value: accuracy !== null ? `${accuracy}%` : '—',
+      suffix: '',
+    },
+  ]
+
+  return (
+    <Card variant="outlined">
+      <CardContent sx={{ p: 2.5 }}>
+        <Typography variant="subtitle1" fontWeight={700} gutterBottom>
+          Today
+        </Typography>
+
+        {loading ? (
+          <Box sx={{ display: 'flex', gap: 3 }}>
+            <Skeleton width={60} height={40} />
+            <Skeleton width={60} height={40} />
+          </Box>
+        ) : todayStats === null ? (
+          <Typography variant="body2" color="text.secondary">
+            No sessions yet today. Start a quiz to begin!
+          </Typography>
+        ) : (
+          <Box sx={{ display: 'flex', gap: 3 }}>
+            {statItems.map(({ label, value, suffix }) => (
+              <Box key={label}>
+                <Typography variant="h5" fontWeight={700} lineHeight={1}>
+                  {value}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {label}
+                  {suffix ? ` ${suffix}` : ''}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── Word overview ────────────────────────────────────────────────────────────
+
+interface WordOverviewProps {
+  readonly buckets: WordBuckets
+  readonly totalWords: number
+  readonly loading: boolean
+}
+
+function WordOverview({ buckets, totalWords, loading }: WordOverviewProps) {
+  return (
+    <Card variant="outlined">
+      <CardContent sx={{ p: 2.5 }}>
+        <Typography variant="subtitle1" fontWeight={700} gutterBottom>
+          Word overview
+        </Typography>
+
+        {loading ? (
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Skeleton width={80} height={32} sx={{ borderRadius: 4 }} />
+            <Skeleton width={80} height={32} sx={{ borderRadius: 4 }} />
+            <Skeleton width={80} height={32} sx={{ borderRadius: 4 }} />
+          </Box>
+        ) : totalWords === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No words added yet. Add words to get started!
+          </Typography>
+        ) : (
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            <Chip
+              label={`${buckets.learning} learning`}
+              size="small"
+              sx={{ bgcolor: 'warning.main', color: 'warning.contrastText' }}
+              aria-label={`${buckets.learning} words in learning stage`}
+            />
+            <Chip
+              label={`${buckets.familiar} familiar`}
+              size="small"
+              sx={{ bgcolor: 'info.main', color: 'info.contrastText' }}
+              aria-label={`${buckets.familiar} familiar words`}
+            />
+            <Chip
+              label={`${buckets.mastered} mastered`}
+              size="small"
+              sx={{ bgcolor: 'success.main', color: 'success.contrastText' }}
+              aria-label={`${buckets.mastered} mastered words`}
+            />
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── Recent activity ──────────────────────────────────────────────────────────
+
+interface RecentActivityProps {
+  readonly recentStats: readonly DailyStats[]
+  readonly loading: boolean
+}
+
+function RecentActivity({ recentStats, loading }: RecentActivityProps) {
+  // Show at most 5 recent days that have any activity.
+  const activeDays = recentStats.filter((s) => s.wordsReviewed > 0).slice(0, 5)
+
+  return (
+    <Card variant="outlined">
+      <CardContent sx={{ p: 2.5 }}>
+        <Typography variant="subtitle1" fontWeight={700} gutterBottom>
+          Recent activity
+        </Typography>
+
+        {loading ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Skeleton width="100%" height={24} />
+            <Skeleton width="80%" height={24} />
+          </Box>
+        ) : activeDays.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No recent activity. Complete a quiz to build your streak!
+          </Typography>
+        ) : (
+          <Box
+            sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
+            role="list"
+            aria-label="Recent activity"
+          >
+            {activeDays.map((day) => {
+              const accuracy =
+                day.wordsReviewed > 0 ? Math.round((day.correctCount / day.wordsReviewed) * 100) : 0
+              return (
+                <Box
+                  key={day.date}
+                  role="listitem"
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  }}
+                >
+                  <Typography variant="body2" color="text.secondary">
+                    {day.date}
+                  </Typography>
+                  <Box sx={{ display: 'flex', gap: 2 }}>
+                    <Typography variant="body2">{day.wordsReviewed} words</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {accuracy}% correct
+                    </Typography>
+                  </Box>
+                </Box>
+              )
+            })}
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function DashboardScreen({
+  activePair,
+  settings,
+  todayStats,
+  wordProgressList,
+  totalWords,
+  streakDays,
+  recentStats,
+  loading,
+  onStartQuiz,
+}: DashboardScreenProps) {
+  const greeting = useMemo(() => getCurrentGreeting(), [])
+  const buckets = useMemo(
+    () => bucketWords(wordProgressList, totalWords),
+    [wordProgressList, totalWords],
+  )
+
+  const wordsReviewedToday = todayStats?.wordsReviewed ?? 0
+
+  return (
+    <Box
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+      role="main"
+      aria-label="Dashboard"
+    >
+      <HeroSection
+        greeting={greeting}
+        streakDays={streakDays}
+        wordsReviewedToday={wordsReviewedToday}
+        dailyGoal={settings.dailyGoal}
+        loading={loading}
+      />
+
+      <QuickStart
+        activePair={activePair}
+        quizMode={settings.quizMode}
+        onStartQuiz={onStartQuiz}
+        loading={loading}
+      />
+
+      <TodaysSummary todayStats={todayStats} dailyGoal={settings.dailyGoal} loading={loading} />
+
+      <WordOverview buckets={buckets} totalWords={totalWords} loading={loading} />
+
+      <RecentActivity recentStats={recentStats} loading={loading} />
+    </Box>
+  )
+}

--- a/src/features/dashboard/hooks/useDashboard.ts
+++ b/src/features/dashboard/hooks/useDashboard.ts
@@ -1,0 +1,86 @@
+/**
+ * useDashboard - loads all data required by the DashboardScreen.
+ *
+ * Fetches from StorageService:
+ *   - today's DailyStats
+ *   - recent 7-day DailyStats
+ *   - current streak
+ *   - word progress for the active pair
+ *   - total word count for the active pair
+ *
+ * Refreshes whenever `activePairId` or `dailyGoal` changes.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import type { DailyStats, WordProgress } from '@/types'
+import { useStorage } from '@/hooks/useStorage'
+import { loadCurrentStreak, getTodayStats } from '@/services/streakService'
+
+/** Number of recent days to fetch for the activity feed. */
+const RECENT_DAYS = 7
+
+export interface UseDashboardResult {
+  readonly todayStats: DailyStats | null
+  readonly recentStats: readonly DailyStats[]
+  readonly streakDays: number
+  readonly wordProgressList: readonly WordProgress[]
+  readonly totalWords: number
+  readonly loading: boolean
+  /** Re-fetch all dashboard data. */
+  readonly refresh: () => void
+}
+
+export function useDashboard(activePairId: string | null, dailyGoal: number): UseDashboardResult {
+  const storage = useStorage()
+
+  const [todayStats, setTodayStats] = useState<DailyStats | null>(null)
+  const [recentStats, setRecentStats] = useState<readonly DailyStats[]>([])
+  const [streakDays, setStreakDays] = useState(0)
+  const [wordProgressList, setWordProgressList] = useState<readonly WordProgress[]>([])
+  const [totalWords, setTotalWords] = useState(0)
+  const [loading, setLoading] = useState(true)
+
+  const fetchData = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    try {
+      const [today, recent, streak] = await Promise.all([
+        getTodayStats(storage),
+        storage.getRecentDailyStats(RECENT_DAYS),
+        loadCurrentStreak(storage, dailyGoal),
+      ])
+
+      setTodayStats(today)
+      // Sort newest first.
+      setRecentStats([...recent].sort((a, b) => b.date.localeCompare(a.date)))
+      setStreakDays(streak)
+
+      if (activePairId !== null) {
+        const [words, progress] = await Promise.all([
+          storage.getWords(activePairId),
+          storage.getAllProgress(activePairId),
+        ])
+        setTotalWords(words.length)
+        setWordProgressList(progress)
+      } else {
+        setTotalWords(0)
+        setWordProgressList([])
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [storage, activePairId, dailyGoal])
+
+  useEffect(() => {
+    void fetchData()
+  }, [fetchData])
+
+  return {
+    todayStats,
+    recentStats,
+    streakDays,
+    wordProgressList,
+    totalWords,
+    loading,
+    refresh: () => void fetchData(),
+  }
+}

--- a/src/features/dashboard/index.ts
+++ b/src/features/dashboard/index.ts
@@ -1,0 +1,5 @@
+export { DashboardScreen } from './components/DashboardScreen'
+export type { DashboardScreenProps } from './components/DashboardScreen'
+export { useDashboard } from './hooks/useDashboard'
+export type { UseDashboardResult } from './hooks/useDashboard'
+export { getGreetingForHour, getCurrentGreeting } from './utils/greeting'

--- a/src/features/dashboard/utils/greeting.test.ts
+++ b/src/features/dashboard/utils/greeting.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { getGreetingForHour, getCurrentGreeting } from './greeting'
+
+describe('getGreetingForHour', () => {
+  it('should return "Good morning!" for midnight (hour 0)', () => {
+    expect(getGreetingForHour(0)).toBe('Good morning!')
+  })
+
+  it('should return "Good morning!" for hour 6', () => {
+    expect(getGreetingForHour(6)).toBe('Good morning!')
+  })
+
+  it('should return "Good morning!" for hour 11', () => {
+    expect(getGreetingForHour(11)).toBe('Good morning!')
+  })
+
+  it('should return "Good afternoon!" for noon (hour 12)', () => {
+    expect(getGreetingForHour(12)).toBe('Good afternoon!')
+  })
+
+  it('should return "Good afternoon!" for hour 15', () => {
+    expect(getGreetingForHour(15)).toBe('Good afternoon!')
+  })
+
+  it('should return "Good afternoon!" for hour 17', () => {
+    expect(getGreetingForHour(17)).toBe('Good afternoon!')
+  })
+
+  it('should return "Good evening!" for hour 18', () => {
+    expect(getGreetingForHour(18)).toBe('Good evening!')
+  })
+
+  it('should return "Good evening!" for hour 21', () => {
+    expect(getGreetingForHour(21)).toBe('Good evening!')
+  })
+
+  it('should return "Good evening!" for hour 23', () => {
+    expect(getGreetingForHour(23)).toBe('Good evening!')
+  })
+})
+
+describe('getCurrentGreeting', () => {
+  it('should return a non-empty string', () => {
+    expect(getCurrentGreeting()).toMatch(/^Good (morning|afternoon|evening)!$/)
+  })
+})

--- a/src/features/dashboard/utils/greeting.ts
+++ b/src/features/dashboard/utils/greeting.ts
@@ -1,0 +1,38 @@
+/**
+ * Greeting utilities - returns a time-of-day greeting string.
+ *
+ * Time buckets (local time):
+ *   00:00–11:59  → "Good morning!"
+ *   12:00–17:59  → "Good afternoon!"
+ *   18:00–23:59  → "Good evening!"
+ */
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Hour (0–23) at which the greeting switches from morning to afternoon. */
+const AFTERNOON_START_HOUR = 12
+
+/** Hour (0–23) at which the greeting switches from afternoon to evening. */
+const EVENING_START_HOUR = 18
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+/**
+ * Returns a greeting string based on the provided hour (0–23).
+ * Injectable for testing without real clock access.
+ *
+ * @param hour - The current hour in local time (0–23).
+ * @returns A greeting string.
+ */
+export function getGreetingForHour(hour: number): string {
+  if (hour < AFTERNOON_START_HOUR) return 'Good morning!'
+  if (hour < EVENING_START_HOUR) return 'Good afternoon!'
+  return 'Good evening!'
+}
+
+/**
+ * Returns a greeting string based on the current local time.
+ */
+export function getCurrentGreeting(): string {
+  return getGreetingForHour(new Date().getHours())
+}

--- a/src/features/settings/components/SettingsScreen.tsx
+++ b/src/features/settings/components/SettingsScreen.tsx
@@ -1,0 +1,76 @@
+/**
+ * SettingsScreen - placeholder for the settings/preferences feature.
+ *
+ * Theme mode toggle is accessible here. The full settings panel
+ * (daily goal, quiz mode, data export/import, reset) will be built
+ * in a future issue.
+ */
+
+import {
+  Box,
+  Card,
+  CardContent,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material'
+import SettingsIcon from '@mui/icons-material/Settings'
+import type { SelectChangeEvent } from '@mui/material'
+import type { ThemePreference } from '@/types'
+
+export interface SettingsScreenProps {
+  /** The user's current theme preference. */
+  readonly themePreference: ThemePreference
+  /** Called when the user changes the theme preference. */
+  readonly onThemeChange: (preference: ThemePreference) => void
+}
+
+export function SettingsScreen({ themePreference, onThemeChange }: SettingsScreenProps) {
+  const handleChange = (event: SelectChangeEvent) => {
+    onThemeChange(event.target.value as ThemePreference)
+  }
+
+  return (
+    <Box
+      sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+      role="main"
+      aria-label="Settings"
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, pt: 1 }}>
+        <SettingsIcon sx={{ color: 'text.secondary' }} aria-hidden="true" />
+        <Typography variant="h6" fontWeight={700}>
+          Settings
+        </Typography>
+      </Box>
+
+      <Card variant="outlined">
+        <CardContent sx={{ p: 2.5 }}>
+          <Typography variant="subtitle2" fontWeight={600} gutterBottom>
+            Appearance
+          </Typography>
+
+          <FormControl fullWidth size="small" sx={{ mt: 1 }}>
+            <InputLabel id="theme-select-label">Theme</InputLabel>
+            <Select
+              labelId="theme-select-label"
+              id="theme-select"
+              value={themePreference}
+              label="Theme"
+              onChange={handleChange}
+            >
+              <MenuItem value="system">System</MenuItem>
+              <MenuItem value="light">Light</MenuItem>
+              <MenuItem value="dark">Dark</MenuItem>
+            </Select>
+          </FormControl>
+        </CardContent>
+      </Card>
+
+      <Typography variant="body2" color="text.secondary" textAlign="center">
+        More settings coming soon.
+      </Typography>
+    </Box>
+  )
+}

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,0 +1,1 @@
+export { SettingsScreen } from './components/SettingsScreen'

--- a/src/features/stats/components/StatsScreen.tsx
+++ b/src/features/stats/components/StatsScreen.tsx
@@ -1,0 +1,35 @@
+/**
+ * StatsScreen - placeholder for the progress stats feature.
+ *
+ * The full stats implementation will be built in a future issue.
+ * This scaffold ensures navigation to this tab works correctly.
+ */
+
+import { Box, Typography } from '@mui/material'
+import BarChartIcon from '@mui/icons-material/BarChart'
+
+export function StatsScreen() {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        py: 8,
+        gap: 2,
+        textAlign: 'center',
+      }}
+      role="main"
+      aria-label="Stats"
+    >
+      <BarChartIcon sx={{ fontSize: 64, color: 'text.disabled' }} aria-hidden="true" />
+      <Typography variant="h6" fontWeight={700}>
+        Progress Stats
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Detailed stats and charts are coming soon.
+      </Typography>
+    </Box>
+  )
+}

--- a/src/features/stats/index.ts
+++ b/src/features/stats/index.ts
@@ -1,0 +1,1 @@
+export { StatsScreen } from './components/StatsScreen'


### PR DESCRIPTION
## Summary

- Implements the home/dashboard screen as the main landing page after onboarding
- Adds bottom navigation bar with Home, Quiz, Words, Stats, Settings tabs
- Adds placeholder screens for Stats and Settings (theme toggle in Settings)
- Wires up the full navigation in App.tsx

## Changes

- `src/features/dashboard/` - New feature module
  - `utils/greeting.ts` - Time-of-day greeting (morning/afternoon/evening)
  - `hooks/useDashboard.ts` - Loads all dashboard data from StorageService
  - `components/DashboardScreen.tsx` - Hero section (greeting + streak + daily ring), quick start, today summary, word overview chips, recent activity
  - `index.ts` - Feature exports
- `src/components/BottomNav.tsx` - Fixed-position bottom navigation bar (5 tabs)
- `src/components/index.ts` - Barrel export
- `src/features/stats/components/StatsScreen.tsx` - Placeholder screen
- `src/features/settings/components/SettingsScreen.tsx` - Settings with theme toggle
- `src/App.tsx` - Navigation wired up; dashboard is default home tab; removed old top-tab nav

## Testing

- 459 tests passing across 31 test files
- New: 37 tests (greeting utils, DashboardScreen component, BottomNav component)
- TypeScript strict: 0 errors
- ESLint: 0 warnings
- Prettier: all formatted
- Production build: success

## Review

- Code review passed — no issues found

Closes #18