### PR TITLE
feat: progress stats and charts screen (#14)

### DIFF
--- a/src/features/stats/components/ActivityChart.test.tsx
+++ b/src/features/stats/components/ActivityChart.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from '@mui/material'
+import { theme } from '@/theme'
+import { ActivityChart } from './ActivityChart'
+import type { ActivityDay } from '../utils/activityData'
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeDay(date: string, wordsReviewed: number, accuracy: number | null = null): ActivityDay {
+  const correctCount = accuracy !== null ? Math.round(wordsReviewed * accuracy) : 0
+  return {
+    date,
+    wordsReviewed,
+    correctCount,
+    incorrectCount: wordsReviewed - correctCount,
+    accuracy,
+  }
+}
+
+function emptyDays(count: number): ActivityDay[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeDay(`2024-01-${String(i + 1).padStart(2, '0')}`, 0),
+  )
+}
+
+function wrap(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ActivityChart', () => {
+  const days7 = emptyDays(7)
+  const days30 = emptyDays(30)
+
+  it('should render without crashing', () => {
+    wrap(<ActivityChart days7={days7} days30={days30} loading={false} />)
+    expect(screen.getByText('Activity')).toBeInTheDocument()
+  })
+
+  it('should show toggle buttons for 7d and 30d', () => {
+    wrap(<ActivityChart days7={days7} days30={days30} loading={false} />)
+    expect(screen.getByRole('button', { name: /last 7 days/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /last 30 days/i })).toBeInTheDocument()
+  })
+
+  it('should show empty state message when no activity', () => {
+    wrap(<ActivityChart days7={days7} days30={days30} loading={false} />)
+    expect(screen.getByText(/No activity in the last 7 days/i)).toBeInTheDocument()
+  })
+
+  it('should render SVG chart when there is activity', () => {
+    const activeDays7 = days7.map((d, i) => (i === 3 ? makeDay(d.date, 10, 0.8) : d))
+    const { container } = wrap(
+      <ActivityChart days7={activeDays7} days30={days30} loading={false} />,
+    )
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('should switch to 30-day view when toggle is clicked', async () => {
+    const user = userEvent.setup()
+    const activeDays30 = days30.map((d, i) => (i === 15 ? makeDay(d.date, 20, 0.9) : d))
+    wrap(<ActivityChart days7={days7} days30={activeDays30} loading={false} />)
+
+    // Initially showing 7-day view with no activity
+    expect(screen.getByText(/No activity in the last 7 days/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /last 30 days/i }))
+    // After toggle, 30-day has activity so no empty state message
+    expect(screen.queryByText(/No activity in the last 30 days/i)).not.toBeInTheDocument()
+  })
+
+  it('should show empty state for 30 days after toggling', async () => {
+    const user = userEvent.setup()
+    wrap(<ActivityChart days7={days7} days30={days30} loading={false} />)
+
+    await user.click(screen.getByRole('button', { name: /last 30 days/i }))
+    expect(screen.getByText(/No activity in the last 30 days/i)).toBeInTheDocument()
+  })
+
+  it('should show skeleton when loading', () => {
+    const { container } = wrap(<ActivityChart days7={days7} days30={days30} loading={true} />)
+    const skeletons = container.querySelectorAll('.MuiSkeleton-root')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('should show legend when chart has activity', () => {
+    const activeDays7 = [makeDay('2024-01-01', 10, 0.8), ...emptyDays(6)]
+    wrap(<ActivityChart days7={activeDays7} days30={days30} loading={false} />)
+    expect(screen.getByText(/≥70% accuracy/i)).toBeInTheDocument()
+  })
+})

--- a/src/features/stats/components/ActivityChart.tsx
+++ b/src/features/stats/components/ActivityChart.tsx
@@ -1,0 +1,194 @@
+/**
+ * ActivityChart - SVG bar chart showing words reviewed per day.
+ *
+ * Supports a 7-day and 30-day toggle. Each bar is colour-coded by the
+ * correct/incorrect ratio for that day. Uses pure SVG — no chart library.
+ */
+
+import { useState } from 'react'
+import {
+  Box,
+  Card,
+  CardContent,
+  Skeleton,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import type { ActivityDay, ActivityRange } from '../utils/activityData'
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface ActivityChartProps {
+  readonly days7: readonly ActivityDay[]
+  readonly days30: readonly ActivityDay[]
+  readonly loading: boolean
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CHART_HEIGHT = 80
+const BAR_GAP = 2
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Short label for a date (e.g. "Mon", "15"). For 7-day we show day name, for 30-day we show day-of-month. */
+function dayLabel(dateStr: string, range: ActivityRange): string {
+  const d = new Date(`${dateStr}T00:00:00`)
+  if (range === 7) {
+    return d.toLocaleDateString(undefined, { weekday: 'short' })
+  }
+  return String(d.getDate())
+}
+
+// ─── Sub-component: SVG bars ──────────────────────────────────────────────────
+
+interface SvgBarsProps {
+  readonly days: readonly ActivityDay[]
+  readonly range: ActivityRange
+  readonly correctColor: string
+  readonly incorrectColor: string
+  readonly emptyColor: string
+}
+
+function SvgBars({ days, range, correctColor, incorrectColor, emptyColor }: SvgBarsProps) {
+  const maxReviewed = Math.max(...days.map((d) => d.wordsReviewed), 1)
+
+  // For 30-day range only show every 5th x-axis label to avoid clutter.
+  const labelEvery = range === 30 ? 5 : 1
+
+  return (
+    <Box sx={{ width: '100%', overflowX: 'auto' }}>
+      <svg
+        width="100%"
+        viewBox={`0 0 ${days.length * (4 + BAR_GAP) * (range === 30 ? 1 : 2.5)} ${CHART_HEIGHT + 20}`}
+        preserveAspectRatio="none"
+        aria-label={`Activity bar chart showing last ${range} days`}
+        role="img"
+        style={{ display: 'block' }}
+      >
+        {days.map((day, idx) => {
+          const barHeight = (day.wordsReviewed / maxReviewed) * CHART_HEIGHT
+          const x = idx * (4 + BAR_GAP)
+          const y = CHART_HEIGHT - barHeight
+
+          // Colour by accuracy ratio
+          const barColor =
+            day.wordsReviewed === 0
+              ? emptyColor
+              : day.accuracy !== null && day.accuracy >= 0.7
+                ? correctColor
+                : incorrectColor
+
+          const label = dayLabel(day.date, range)
+          const showLabel = idx % labelEvery === 0
+
+          return (
+            <g key={day.date}>
+              <title>
+                {day.date}: {day.wordsReviewed} reviewed
+                {day.accuracy !== null ? `, ${Math.round(day.accuracy * 100)}% accuracy` : ''}
+              </title>
+              <rect
+                x={x}
+                y={day.wordsReviewed === 0 ? CHART_HEIGHT - 2 : y}
+                width={4}
+                height={day.wordsReviewed === 0 ? 2 : barHeight}
+                fill={barColor}
+                rx={1}
+              />
+              {showLabel && (
+                <text
+                  x={x + 2}
+                  y={CHART_HEIGHT + 14}
+                  fontSize={range === 30 ? 5 : 7}
+                  textAnchor="middle"
+                  fill={emptyColor}
+                >
+                  {label}
+                </text>
+              )}
+            </g>
+          )
+        })}
+      </svg>
+    </Box>
+  )
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function ActivityChart({ days7, days30, loading }: ActivityChartProps) {
+  const [range, setRange] = useState<ActivityRange>(7)
+  const theme = useTheme()
+
+  const days = range === 7 ? days7 : days30
+  const totalReviewed = days.reduce((s, d) => s + d.wordsReviewed, 0)
+
+  const handleRangeChange = (_: React.MouseEvent<HTMLElement>, value: ActivityRange | null) => {
+    if (value !== null) setRange(value)
+  }
+
+  return (
+    <Card variant="outlined">
+      <CardContent sx={{ p: 2.5 }}>
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1.5 }}
+        >
+          <Typography variant="subtitle1" fontWeight={700}>
+            Activity
+          </Typography>
+          <ToggleButtonGroup
+            value={range}
+            exclusive
+            onChange={handleRangeChange}
+            size="small"
+            aria-label="Activity range"
+          >
+            <ToggleButton value={7} aria-label="Last 7 days">
+              7d
+            </ToggleButton>
+            <ToggleButton value={30} aria-label="Last 30 days">
+              30d
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+
+        {loading ? (
+          <Skeleton width="100%" height={CHART_HEIGHT + 20} sx={{ borderRadius: 1 }} />
+        ) : totalReviewed === 0 ? (
+          <Box sx={{ py: 2, textAlign: 'center' }}>
+            <Typography variant="body2" color="text.secondary">
+              No activity in the last {range} days. Complete a quiz to see your chart!
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            <SvgBars
+              days={days}
+              range={range}
+              correctColor={theme.palette.success.main}
+              incorrectColor={theme.palette.warning.main}
+              emptyColor={theme.palette.action.disabled}
+            />
+            <Box sx={{ display: 'flex', gap: 2, mt: 1 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Box sx={{ width: 10, height: 10, borderRadius: 0.5, bgcolor: 'success.main' }} />
+                <Typography variant="caption" color="text.secondary">
+                  ≥70% accuracy
+                </Typography>
+              </Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Box sx={{ width: 10, height: 10, borderRadius: 0.5, bgcolor: 'warning.main' }} />
+                <Typography variant="caption" color="text.secondary">
+                  {'<70% accuracy'}
+                </Typography>
+              </Box>
+            </Box>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/features/stats/components/ConfidenceSummary.test.tsx
+++ b/src/features/stats/components/ConfidenceSummary.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ConfidenceSummary } from './ConfidenceSummary'
+import type { BucketCounts } from '../utils/confidenceBuckets'
+
+const emptyBuckets: BucketCounts = { learning: 0, familiar: 0, mastered: 0, total: 0 }
+
+const filledBuckets: BucketCounts = { learning: 5, familiar: 3, mastered: 2, total: 10 }
+
+describe('ConfidenceSummary', () => {
+  it('should render without crashing', () => {
+    render(<ConfidenceSummary buckets={emptyBuckets} loading={false} />)
+    expect(screen.getByText('Word confidence')).toBeInTheDocument()
+  })
+
+  it('should show empty state message when total is 0', () => {
+    render(<ConfidenceSummary buckets={emptyBuckets} loading={false} />)
+    expect(screen.getByText(/No words added yet/i)).toBeInTheDocument()
+  })
+
+  it('should render bucket counts when data is present', () => {
+    render(<ConfidenceSummary buckets={filledBuckets} loading={false} />)
+    expect(screen.getByText('5')).toBeInTheDocument() // learning count
+    expect(screen.getByText('3')).toBeInTheDocument() // familiar count
+    expect(screen.getByText('2')).toBeInTheDocument() // mastered count
+  })
+
+  it('should display the bucket labels', () => {
+    render(<ConfidenceSummary buckets={filledBuckets} loading={false} />)
+    expect(screen.getByText('Learning')).toBeInTheDocument()
+    expect(screen.getByText('Familiar')).toBeInTheDocument()
+    expect(screen.getByText('Mastered')).toBeInTheDocument()
+  })
+
+  it('should show total words count', () => {
+    render(<ConfidenceSummary buckets={filledBuckets} loading={false} />)
+    expect(screen.getByText('10 words total')).toBeInTheDocument()
+  })
+
+  it('should show the mastered percentage', () => {
+    render(<ConfidenceSummary buckets={filledBuckets} loading={false} />)
+    expect(screen.getByText(/20% mastered/i)).toBeInTheDocument()
+  })
+
+  it('should render skeleton loaders when loading', () => {
+    const { container } = render(<ConfidenceSummary buckets={emptyBuckets} loading={true} />)
+    // MUI Skeleton renders as a span with aria-busy
+    const skeletons = container.querySelectorAll('.MuiSkeleton-root')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('should have accessible list labels for bucket items', () => {
+    render(<ConfidenceSummary buckets={filledBuckets} loading={false} />)
+    expect(screen.getByRole('list', { name: 'Confidence bucket summary' })).toBeInTheDocument()
+  })
+
+  it('should show 100% mastered when all words are mastered', () => {
+    const allMastered: BucketCounts = { learning: 0, familiar: 0, mastered: 10, total: 10 }
+    render(<ConfidenceSummary buckets={allMastered} loading={false} />)
+    expect(screen.getByText(/100% mastered/i)).toBeInTheDocument()
+  })
+})

--- a/src/features/stats/components/ConfidenceSummary.tsx
+++ b/src/features/stats/components/ConfidenceSummary.tsx
@@ -1,0 +1,148 @@
+/**
+ * ConfidenceSummary - displays word confidence bucket counts as summary cards
+ * and a proportional progress bar.
+ */
+
+import { Box, Card, CardContent, LinearProgress, Skeleton, Typography } from '@mui/material'
+import type { BucketCounts } from '../utils/confidenceBuckets'
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface ConfidenceSummaryProps {
+  readonly buckets: BucketCounts
+  readonly loading: boolean
+}
+
+// ─── Bucket config ────────────────────────────────────────────────────────────
+
+interface BucketConfig {
+  readonly key: keyof Omit<BucketCounts, 'total'>
+  readonly label: string
+  readonly color: string
+  readonly bgColor: string
+}
+
+const BUCKET_CONFIG: readonly BucketConfig[] = [
+  { key: 'learning', label: 'Learning', color: 'error.main', bgColor: 'error.main' },
+  { key: 'familiar', label: 'Familiar', color: 'warning.main', bgColor: 'warning.main' },
+  { key: 'mastered', label: 'Mastered', color: 'success.main', bgColor: 'success.main' },
+]
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ConfidenceSummary({ buckets, loading }: ConfidenceSummaryProps) {
+  const { learning, familiar, mastered, total } = buckets
+
+  const learningPct = total > 0 ? (learning / total) * 100 : 0
+  const familiarPct = total > 0 ? (familiar / total) * 100 : 0
+  const masteredPct = total > 0 ? (mastered / total) * 100 : 0
+
+  return (
+    <Card variant="outlined">
+      <CardContent sx={{ p: 2.5 }}>
+        <Typography variant="subtitle1" fontWeight={700} gutterBottom>
+          Word confidence
+        </Typography>
+
+        {loading ? (
+          <Box>
+            <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+              <Skeleton width={90} height={72} sx={{ borderRadius: 2 }} />
+              <Skeleton width={90} height={72} sx={{ borderRadius: 2 }} />
+              <Skeleton width={90} height={72} sx={{ borderRadius: 2 }} />
+            </Box>
+            <Skeleton width="100%" height={12} sx={{ borderRadius: 1 }} />
+          </Box>
+        ) : total === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No words added yet. Add words and start quizzing to see your progress here.
+          </Typography>
+        ) : (
+          <>
+            {/* Summary cards */}
+            <Box
+              sx={{ display: 'flex', gap: 1, mb: 2, flexWrap: 'wrap' }}
+              role="list"
+              aria-label="Confidence bucket summary"
+            >
+              {BUCKET_CONFIG.map(({ key, label, bgColor }) => (
+                <Box
+                  key={key}
+                  role="listitem"
+                  aria-label={`${buckets[key]} ${label.toLowerCase()} words`}
+                  sx={{
+                    flex: '1 1 80px',
+                    p: 1.5,
+                    borderRadius: 2,
+                    border: '2px solid',
+                    borderColor: bgColor,
+                    textAlign: 'center',
+                  }}
+                >
+                  <Typography variant="h5" fontWeight={700} sx={{ color: bgColor, lineHeight: 1 }}>
+                    {buckets[key]}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+                    {label}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+
+            {/* Proportional stacked progress bar */}
+            <Box
+              sx={{ display: 'flex', height: 10, borderRadius: 5, overflow: 'hidden', gap: '2px' }}
+              role="progressbar"
+              aria-label={`${masteredPct.toFixed(0)}% mastered`}
+            >
+              {learningPct > 0 && (
+                <Box
+                  sx={{
+                    width: `${learningPct}%`,
+                    bgcolor: 'error.main',
+                    borderRadius: '5px 0 0 5px',
+                  }}
+                  aria-hidden="true"
+                />
+              )}
+              {familiarPct > 0 && (
+                <Box
+                  sx={{ width: `${familiarPct}%`, bgcolor: 'warning.main' }}
+                  aria-hidden="true"
+                />
+              )}
+              {masteredPct > 0 && (
+                <Box
+                  sx={{
+                    width: `${masteredPct}%`,
+                    bgcolor: 'success.main',
+                    borderRadius: '0 5px 5px 0',
+                  }}
+                  aria-hidden="true"
+                />
+              )}
+            </Box>
+
+            {/* Overall progress label */}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 1 }}>
+              <Typography variant="caption" color="text.secondary">
+                {total} words total
+              </Typography>
+              <Typography variant="caption" color="success.main" fontWeight={600}>
+                {masteredPct.toFixed(0)}% mastered
+              </Typography>
+            </Box>
+
+            {/* Hidden accessible progress for screen readers */}
+            <LinearProgress
+              variant="determinate"
+              value={masteredPct}
+              sx={{ display: 'none' }}
+              aria-hidden="true"
+            />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/features/stats/components/OverallSummary.tsx
+++ b/src/features/stats/components/OverallSummary.tsx
@@ -1,0 +1,139 @@
+/**
+ * OverallSummary - displays aggregate stats metrics for the active pair.
+ *
+ * Metrics shown:
+ *   - Total words in active pair
+ *   - Words learned (confidence > threshold)
+ *   - Total reviews all time
+ *   - Average accuracy
+ *   - Current streak / best streak
+ */
+
+import { Box, Card, CardContent, Divider, Skeleton, Typography } from '@mui/material'
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment'
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents'
+import type { BucketCounts } from '../utils/confidenceBuckets'
+import type { OverallMetrics } from '../utils/activityData'
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface OverallSummaryProps {
+  readonly buckets: BucketCounts
+  readonly metrics: OverallMetrics
+  readonly streakDays: number
+  readonly bestStreak: number
+  readonly loading: boolean
+}
+
+// ─── Sub-component: single stat cell ─────────────────────────────────────────
+
+interface StatCellProps {
+  readonly value: string | number
+  readonly label: string
+  readonly icon?: React.ReactNode
+  readonly color?: string
+}
+
+function StatCell({ value, label, icon, color }: StatCellProps) {
+  return (
+    <Box sx={{ textAlign: 'center', p: 1 }}>
+      {icon && <Box sx={{ display: 'flex', justifyContent: 'center', mb: 0.25 }}>{icon}</Box>}
+      <Typography
+        variant="h5"
+        fontWeight={700}
+        lineHeight={1}
+        sx={{ color: color ?? 'text.primary' }}
+      >
+        {value}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+    </Box>
+  )
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function OverallSummary({
+  buckets,
+  metrics,
+  streakDays,
+  bestStreak,
+  loading,
+}: OverallSummaryProps) {
+  const learnedCount = buckets.mastered
+  const accuracyLabel = metrics.averageAccuracy !== null ? `${metrics.averageAccuracy}%` : '—'
+
+  return (
+    <Card variant="outlined">
+      <CardContent sx={{ p: 2.5 }}>
+        <Typography variant="subtitle1" fontWeight={700} gutterBottom>
+          Overall summary
+        </Typography>
+
+        {loading ? (
+          <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} width={60} height={52} sx={{ borderRadius: 1 }} />
+            ))}
+          </Box>
+        ) : (
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(72px, 1fr))',
+              gap: 0.5,
+            }}
+            role="list"
+            aria-label="Overall statistics"
+          >
+            <Box role="listitem">
+              <StatCell value={buckets.total} label="Total words" />
+            </Box>
+            <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+            <Box role="listitem">
+              <StatCell value={learnedCount} label="Mastered" color="success.main" />
+            </Box>
+            <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+            <Box role="listitem">
+              <StatCell value={metrics.totalReviews} label="Reviews" />
+            </Box>
+            <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+            <Box role="listitem">
+              <StatCell value={accuracyLabel} label="Avg accuracy" />
+            </Box>
+            <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+            <Box role="listitem">
+              <StatCell
+                value={streakDays}
+                label="Streak"
+                color="warning.main"
+                icon={
+                  <LocalFireDepartmentIcon
+                    sx={{ fontSize: 16, color: 'warning.main' }}
+                    aria-hidden="true"
+                  />
+                }
+              />
+            </Box>
+            <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+            <Box role="listitem">
+              <StatCell
+                value={bestStreak}
+                label="Best streak"
+                color="primary.main"
+                icon={
+                  <EmojiEventsIcon
+                    sx={{ fontSize: 16, color: 'primary.main' }}
+                    aria-hidden="true"
+                  />
+                }
+              />
+            </Box>
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/features/stats/components/StatsScreen.tsx
+++ b/src/features/stats/components/StatsScreen.tsx
@@ -1,35 +1,91 @@
 /**
- * StatsScreen - placeholder for the progress stats feature.
+ * StatsScreen - the main statistics view.
  *
- * The full stats implementation will be built in a future issue.
- * This scaffold ensures navigation to this tab works correctly.
+ * Sections:
+ *   1. Overall summary - aggregate metrics (words, reviews, accuracy, streaks)
+ *   2. Word confidence - confidence bucket counts + proportional bar
+ *   3. Activity chart  - daily bar chart (last 7 / 30 days)
+ *   4. Streak calendar - GitHub-style heatmap (last ~3 months)
+ *   5. Word progress   - per-word sortable/filterable table
+ *
+ * Accepts an optional activePairId prop. When not provided, it loads the
+ * active pair from UserSettings (backward-compatible with the existing
+ * no-prop call in App.tsx).
  */
 
-import { Box, Typography } from '@mui/material'
-import BarChartIcon from '@mui/icons-material/BarChart'
+import { useState, useEffect, useMemo } from 'react'
+import { Box } from '@mui/material'
+import { useStorage } from '@/hooks/useStorage'
+import { useStats } from '../hooks/useStats'
+import { buildWordStatsList, computeBucketCounts } from '../utils/confidenceBuckets'
+import { buildActivityDays, buildCalendarDays, computeOverallMetrics } from '../utils/activityData'
+import { ConfidenceSummary } from './ConfidenceSummary'
+import { ActivityChart } from './ActivityChart'
+import { StreakCalendar } from './StreakCalendar'
+import { WordStatsTable } from './WordStatsTable'
+import { OverallSummary } from './OverallSummary'
 
-export function StatsScreen() {
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface StatsScreenProps {
+  /** The currently active language pair ID, or null if none. */
+  readonly activePairId?: string | null
+}
+
+// ─── Inner component ──────────────────────────────────────────────────────────
+
+interface StatsContentProps {
+  readonly activePairId: string | null
+}
+
+function StatsContent({ activePairId }: StatsContentProps) {
+  const { words, progress, dailyStats, streakDays, bestStreak, dailyGoal, loading } =
+    useStats(activePairId)
+
+  const wordStats = useMemo(() => buildWordStatsList(words, progress), [words, progress])
+  const buckets = useMemo(() => computeBucketCounts(wordStats), [wordStats])
+  const days7 = useMemo(() => buildActivityDays(dailyStats, 7), [dailyStats])
+  const days30 = useMemo(() => buildActivityDays(dailyStats, 30), [dailyStats])
+  const calendarDays = useMemo(
+    () => buildCalendarDays(dailyStats, dailyGoal),
+    [dailyStats, dailyGoal],
+  )
+  const metrics = useMemo(() => computeOverallMetrics(dailyStats), [dailyStats])
+
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        py: 8,
-        gap: 2,
-        textAlign: 'center',
-      }}
-      role="main"
-      aria-label="Stats"
-    >
-      <BarChartIcon sx={{ fontSize: 64, color: 'text.disabled' }} aria-hidden="true" />
-      <Typography variant="h6" fontWeight={700}>
-        Progress Stats
-      </Typography>
-      <Typography variant="body2" color="text.secondary">
-        Detailed stats and charts are coming soon.
-      </Typography>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }} role="main" aria-label="Stats">
+      <OverallSummary
+        buckets={buckets}
+        metrics={metrics}
+        streakDays={streakDays}
+        bestStreak={bestStreak}
+        loading={loading}
+      />
+
+      <ConfidenceSummary buckets={buckets} loading={loading} />
+
+      <ActivityChart days7={days7} days30={days30} loading={loading} />
+
+      <StreakCalendar days={calendarDays} loading={loading} />
+
+      <WordStatsTable wordStats={wordStats} loading={loading} />
     </Box>
   )
+}
+
+// ─── Public component ─────────────────────────────────────────────────────────
+
+export function StatsScreen({ activePairId: propPairId }: StatsScreenProps = {}) {
+  const storage = useStorage()
+  const [settingsPairId, setSettingsPairId] = useState<string | null>(null)
+
+  // When no activePairId prop is provided, fall back to loading it from settings.
+  useEffect(() => {
+    if (propPairId !== undefined) return
+    void storage.getSettings().then((s) => setSettingsPairId(s.activePairId))
+  }, [storage, propPairId])
+
+  const resolvedPairId = propPairId !== undefined ? propPairId : settingsPairId
+
+  return <StatsContent activePairId={resolvedPairId} />
 }

--- a/src/features/stats/components/StreakCalendar.test.tsx
+++ b/src/features/stats/components/StreakCalendar.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from '@mui/material'
+import { theme } from '@/theme'
+import { StreakCalendar } from './StreakCalendar'
+import { buildCalendarDays } from '../utils/activityData'
+import type { CalendarDay } from '../utils/activityData'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function wrap(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>)
+}
+
+function emptyCalendar(count = 91): CalendarDay[] {
+  return Array.from({ length: count }, (_, i) => ({
+    date: `2024-01-${String((i % 28) + 1).padStart(2, '0')}`,
+    level: 0 as const,
+    wordsReviewed: 0,
+    hasData: false,
+  }))
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('StreakCalendar', () => {
+  it('should render without crashing', () => {
+    wrap(<StreakCalendar days={emptyCalendar()} loading={false} />)
+    expect(screen.getByText('Activity calendar')).toBeInTheDocument()
+  })
+
+  it('should render a grid with calendar days', () => {
+    wrap(<StreakCalendar days={emptyCalendar()} loading={false} />)
+    expect(screen.getByRole('grid', { name: /Activity calendar heatmap/i })).toBeInTheDocument()
+  })
+
+  it('should render the correct number of grid cells', () => {
+    const days = emptyCalendar(91)
+    wrap(<StreakCalendar days={days} loading={false} />)
+    const cells = screen.getAllByRole('gridcell')
+    expect(cells.length).toBe(91)
+  })
+
+  it('should show skeleton when loading', () => {
+    const { container } = wrap(<StreakCalendar days={emptyCalendar()} loading={true} />)
+    const skeletons = container.querySelectorAll('.MuiSkeleton-root')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('should render a legend', () => {
+    wrap(<StreakCalendar days={emptyCalendar()} loading={false} />)
+    expect(screen.getByText('Less')).toBeInTheDocument()
+    expect(screen.getByText('More')).toBeInTheDocument()
+  })
+
+  it('should set aria-label on grid cells with date info', () => {
+    const today = '2024-03-15'
+    const days = buildCalendarDays([], 20, today)
+    wrap(<StreakCalendar days={days} loading={false} />)
+    // Check that at least one cell has an aria-label mentioning March
+    const cells = screen.getAllByRole('gridcell')
+    const hasMarch = cells.some((c) => c.getAttribute('aria-label')?.includes('Mar'))
+    expect(hasMarch).toBe(true)
+  })
+
+  it('should show "No activity" label for empty days', () => {
+    const today = '2024-03-15'
+    const days = buildCalendarDays([], 20, today)
+    wrap(<StreakCalendar days={days} loading={false} />)
+    const cells = screen.getAllByRole('gridcell')
+    // All cells should show "No activity" for empty calendar
+    const allNoActivity = cells.every((c) => c.getAttribute('aria-label')?.includes('No activity'))
+    expect(allNoActivity).toBe(true)
+  })
+})

--- a/src/features/stats/components/StreakCalendar.tsx
+++ b/src/features/stats/components/StreakCalendar.tsx
@@ -1,0 +1,157 @@
+/**
+ * StreakCalendar - GitHub-style contribution heatmap showing activity
+ * over the last ~3 months (91 days).
+ *
+ * Each cell is colour-coded by intensity:
+ *   Level 0 = no activity (background colour)
+ *   Level 1 = low       (10% of goal)
+ *   Level 2 = moderate  (25% of goal)
+ *   Level 3 = good      (50%+ of goal)
+ *   Level 4 = excellent (100%+ of goal / goal met)
+ */
+
+import { Box, Card, CardContent, Skeleton, Tooltip, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import type { CalendarDay } from '../utils/activityData'
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface StreakCalendarProps {
+  readonly days: readonly CalendarDay[]
+  readonly loading: boolean
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CELL_SIZE = 12
+const CELL_GAP = 2
+const DAYS_PER_WEEK = 7
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Maps an intensity level to a colour using the theme. */
+function levelToColor(level: 0 | 1 | 2 | 3 | 4, emptyColor: string, primaryColor: string): string {
+  if (level === 0) return emptyColor
+  // Use opacity to build the gradient from primary colour.
+  const opacities = [0, 0.25, 0.45, 0.7, 1] as const
+  // Decompose primary hex colour to apply alpha manually via MUI sx
+  return `${primaryColor}${Math.round(opacities[level] * 255)
+    .toString(16)
+    .padStart(2, '0')}`
+}
+
+/** Returns a human-readable tooltip label for a calendar day. */
+function calendarTooltip(day: CalendarDay): string {
+  const d = new Date(`${day.date}T00:00:00`)
+  const label = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+  if (!day.hasData || day.wordsReviewed === 0) return `${label}: No activity`
+  return `${label}: ${day.wordsReviewed} word${day.wordsReviewed !== 1 ? 's' : ''} reviewed`
+}
+
+/** Groups calendar days into week columns for rendering. */
+function groupIntoWeeks(days: readonly CalendarDay[]): CalendarDay[][] {
+  const weeks: CalendarDay[][] = []
+  let week: CalendarDay[] = []
+
+  for (const day of days) {
+    week.push(day)
+    if (week.length === DAYS_PER_WEEK) {
+      weeks.push(week)
+      week = []
+    }
+  }
+  if (week.length > 0) weeks.push(week)
+
+  return weeks
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function StreakCalendar({ days, loading }: StreakCalendarProps) {
+  const theme = useTheme()
+  const weeks = groupIntoWeeks(days)
+
+  const emptyColor = theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'
+  const primaryHex = theme.palette.primary.main // e.g. "#f59e0b"
+
+  return (
+    <Card variant="outlined">
+      <CardContent sx={{ p: 2.5 }}>
+        <Typography variant="subtitle1" fontWeight={700} gutterBottom>
+          Activity calendar
+        </Typography>
+
+        {loading ? (
+          <Skeleton
+            width="100%"
+            height={DAYS_PER_WEEK * (CELL_SIZE + CELL_GAP)}
+            sx={{ borderRadius: 1 }}
+          />
+        ) : (
+          <>
+            <Box
+              sx={{ display: 'flex', gap: `${CELL_GAP}px`, overflowX: 'auto', py: 0.5 }}
+              role="grid"
+              aria-label="Activity calendar heatmap"
+            >
+              {weeks.map((week, weekIdx) => (
+                <Box
+                  key={weekIdx}
+                  sx={{ display: 'flex', flexDirection: 'column', gap: `${CELL_GAP}px` }}
+                  role="row"
+                >
+                  {week.map((day) => {
+                    const bgColor =
+                      day.level === 0 ? emptyColor : levelToColor(day.level, emptyColor, primaryHex)
+
+                    return (
+                      <Tooltip key={day.date} title={calendarTooltip(day)} placement="top" arrow>
+                        <Box
+                          role="gridcell"
+                          aria-label={calendarTooltip(day)}
+                          sx={{
+                            width: CELL_SIZE,
+                            height: CELL_SIZE,
+                            borderRadius: '2px',
+                            backgroundColor: bgColor,
+                            cursor: 'default',
+                            transition: 'opacity 0.15s',
+                            '&:hover': { opacity: 0.8 },
+                            flexShrink: 0,
+                          }}
+                        />
+                      </Tooltip>
+                    )
+                  })}
+                </Box>
+              ))}
+            </Box>
+
+            {/* Legend */}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 1.5 }}>
+              <Typography variant="caption" color="text.secondary">
+                Less
+              </Typography>
+              {([0, 1, 2, 3, 4] as const).map((level) => (
+                <Box
+                  key={level}
+                  sx={{
+                    width: CELL_SIZE,
+                    height: CELL_SIZE,
+                    borderRadius: '2px',
+                    backgroundColor:
+                      level === 0 ? emptyColor : levelToColor(level, emptyColor, primaryHex),
+                  }}
+                  aria-hidden="true"
+                />
+              ))}
+              <Typography variant="caption" color="text.secondary">
+                More
+              </Typography>
+            </Box>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/features/stats/components/WordStatsTable.test.tsx
+++ b/src/features/stats/components/WordStatsTable.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from '@mui/material'
+import { theme } from '@/theme'
+import { WordStatsTable } from './WordStatsTable'
+import type { WordWithStats } from '../utils/confidenceBuckets'
+import type { Word } from '@/types'
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeWord(id: string, source: string, target: string): Word {
+  return {
+    id,
+    pairId: 'pair-1',
+    source,
+    target,
+    notes: null,
+    tags: [],
+    createdAt: 1000,
+    isFromPack: false,
+  }
+}
+
+function makeWordStat(
+  id: string,
+  source: string,
+  target: string,
+  bucket: WordWithStats['bucket'],
+  confidence: number,
+  timesReviewed = 5,
+): WordWithStats {
+  return {
+    word: makeWord(id, source, target),
+    progress: null,
+    bucket,
+    timesReviewed,
+    correctPct: timesReviewed > 0 ? 80 : null,
+    confidence,
+    lastReviewed: 1700000000000,
+  }
+}
+
+const sampleStats: WordWithStats[] = [
+  makeWordStat('w1', 'apple', 'ābols', 'mastered', 0.9),
+  makeWordStat('w2', 'cat', 'kaķis', 'learning', 0.1),
+  makeWordStat('w3', 'dog', 'suns', 'familiar', 0.55),
+  makeWordStat('w4', 'bird', 'putns', 'learning', 0.2),
+]
+
+function wrap(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('WordStatsTable', () => {
+  it('should render without crashing', () => {
+    wrap(<WordStatsTable wordStats={sampleStats} loading={false} />)
+    expect(screen.getByText('Word progress')).toBeInTheDocument()
+  })
+
+  it('should show empty state when wordStats is empty', () => {
+    wrap(<WordStatsTable wordStats={[]} loading={false} />)
+    expect(screen.getByText(/No words to display/i)).toBeInTheDocument()
+  })
+
+  it('should render a row for each word', () => {
+    wrap(<WordStatsTable wordStats={sampleStats} loading={false} />)
+    expect(screen.getByText('apple')).toBeInTheDocument()
+    expect(screen.getByText('cat')).toBeInTheDocument()
+    expect(screen.getByText('dog')).toBeInTheDocument()
+    expect(screen.getByText('bird')).toBeInTheDocument()
+  })
+
+  it('should show target word translations', () => {
+    wrap(<WordStatsTable wordStats={sampleStats} loading={false} />)
+    expect(screen.getByText('ābols')).toBeInTheDocument()
+    expect(screen.getByText('kaķis')).toBeInTheDocument()
+  })
+
+  it('should render a filter dropdown', () => {
+    wrap(<WordStatsTable wordStats={sampleStats} loading={false} />)
+    expect(screen.getByLabelText(/filter words by confidence level/i)).toBeInTheDocument()
+  })
+
+  it('should filter to show only learning words', async () => {
+    const user = userEvent.setup()
+    wrap(<WordStatsTable wordStats={sampleStats} loading={false} />)
+
+    // Open the MUI select by clicking the combobox
+    await user.click(screen.getByRole('combobox'))
+    await user.click(screen.getByRole('option', { name: 'Learning' }))
+
+    expect(screen.getByText('cat')).toBeInTheDocument()
+    expect(screen.getByText('bird')).toBeInTheDocument()
+    expect(screen.queryByText('apple')).not.toBeInTheDocument()
+    expect(screen.queryByText('dog')).not.toBeInTheDocument()
+  })
+
+  it('should filter to show only mastered words', async () => {
+    const user = userEvent.setup()
+    wrap(<WordStatsTable wordStats={sampleStats} loading={false} />)
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(screen.getByRole('option', { name: 'Mastered' }))
+
+    expect(screen.getByText('apple')).toBeInTheDocument()
+    expect(screen.queryByText('cat')).not.toBeInTheDocument()
+  })
+
+  it('should show message for empty bucket filter result', async () => {
+    const user = userEvent.setup()
+    // All words are learning - filter for familiar should show message
+    const learningOnly = sampleStats.filter((w) => w.bucket === 'learning')
+    wrap(<WordStatsTable wordStats={learningOnly} loading={false} />)
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(screen.getByRole('option', { name: 'Familiar' }))
+
+    expect(screen.getByText(/No words in the .* bucket/i)).toBeInTheDocument()
+  })
+
+  it('should render sortable column headers', () => {
+    wrap(<WordStatsTable wordStats={sampleStats} loading={false} />)
+    expect(screen.getByText('Word')).toBeInTheDocument()
+    expect(screen.getByText('Reviews')).toBeInTheDocument()
+    expect(screen.getByText('Accuracy')).toBeInTheDocument()
+    expect(screen.getByText('Confidence')).toBeInTheDocument()
+  })
+
+  it('should sort by word ascending when Word column is clicked', async () => {
+    const user = userEvent.setup()
+    wrap(<WordStatsTable wordStats={sampleStats} loading={false} />)
+
+    await user.click(screen.getByText('Word'))
+
+    const rows = screen.getAllByRole('row')
+    // First data row (after header) should be 'apple' (alphabetically first)
+    expect(rows[1]).toHaveTextContent('apple')
+  })
+
+  it('should show skeleton loaders when loading', () => {
+    const { container } = wrap(<WordStatsTable wordStats={[]} loading={true} />)
+    const skeletons = container.querySelectorAll('.MuiSkeleton-root')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('should render confidence chip with correct label', () => {
+    wrap(<WordStatsTable wordStats={[sampleStats[0]]} loading={false} />)
+    // mastered chip
+    expect(screen.getByText('mastered')).toBeInTheDocument()
+  })
+
+  it('should display dash for unreviewed words accuracy', () => {
+    const unreviewedStat: WordWithStats = makeWordStat('w5', 'tree', 'koks', 'learning', 0, 0)
+    wrap(<WordStatsTable wordStats={[unreviewedStat]} loading={false} />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+})

--- a/src/features/stats/components/WordStatsTable.tsx
+++ b/src/features/stats/components/WordStatsTable.tsx
@@ -1,0 +1,286 @@
+/**
+ * WordStatsTable - per-word stats with sorting and confidence-bucket filtering.
+ *
+ * Columns: Word (source → target), Times reviewed, Accuracy, Confidence, Last reviewed
+ * Sortable by any column. Filterable by confidence bucket.
+ */
+
+import { useMemo, useState } from 'react'
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  FormControl,
+  InputLabel,
+  LinearProgress,
+  MenuItem,
+  Select,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Typography,
+} from '@mui/material'
+import type { SelectChangeEvent } from '@mui/material'
+import type { ConfidenceBucket, WordWithStats } from '../utils/confidenceBuckets'
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface WordStatsTableProps {
+  readonly wordStats: readonly WordWithStats[]
+  readonly loading: boolean
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type SortColumn = 'word' | 'timesReviewed' | 'correctPct' | 'confidence' | 'lastReviewed'
+type SortDirection = 'asc' | 'desc'
+type BucketFilter = ConfidenceBucket | 'all'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const BUCKET_COLORS: Record<ConfidenceBucket, string> = {
+  learning: 'error',
+  familiar: 'warning',
+  mastered: 'success',
+}
+
+const ROWS_PER_PAGE = 50
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatLastReviewed(ts: number | null): string {
+  if (ts === null) return '—'
+  const d = new Date(ts)
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function sortWordStats(
+  stats: readonly WordWithStats[],
+  col: SortColumn,
+  dir: SortDirection,
+): WordWithStats[] {
+  const sign = dir === 'asc' ? 1 : -1
+  return [...stats].sort((a, b) => {
+    switch (col) {
+      case 'word':
+        return sign * a.word.source.localeCompare(b.word.source)
+      case 'timesReviewed':
+        return sign * (a.timesReviewed - b.timesReviewed)
+      case 'correctPct': {
+        const aPct = a.correctPct ?? -1
+        const bPct = b.correctPct ?? -1
+        return sign * (aPct - bPct)
+      }
+      case 'confidence':
+        return sign * (a.confidence - b.confidence)
+      case 'lastReviewed': {
+        const aTs = a.lastReviewed ?? -1
+        const bTs = b.lastReviewed ?? -1
+        return sign * (aTs - bTs)
+      }
+      default:
+        return 0
+    }
+  })
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function WordStatsTable({ wordStats, loading }: WordStatsTableProps) {
+  const [sortCol, setSortCol] = useState<SortColumn>('confidence')
+  const [sortDir, setSortDir] = useState<SortDirection>('asc')
+  const [bucketFilter, setBucketFilter] = useState<BucketFilter>('all')
+
+  const handleSort = (col: SortColumn) => {
+    if (col === sortCol) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortCol(col)
+      setSortDir('asc')
+    }
+  }
+
+  const handleFilterChange = (e: SelectChangeEvent<BucketFilter>) => {
+    setBucketFilter(e.target.value as BucketFilter)
+  }
+
+  const filtered = useMemo(
+    () =>
+      bucketFilter === 'all' ? wordStats : wordStats.filter((ws) => ws.bucket === bucketFilter),
+    [wordStats, bucketFilter],
+  )
+
+  const sorted = useMemo(
+    () => sortWordStats(filtered, sortCol, sortDir),
+    [filtered, sortCol, sortDir],
+  )
+
+  const displayed = sorted.slice(0, ROWS_PER_PAGE)
+
+  const SortLabel = ({ col, children }: { col: SortColumn; children: React.ReactNode }) => (
+    <TableSortLabel
+      active={sortCol === col}
+      direction={sortCol === col ? sortDir : 'asc'}
+      onClick={() => handleSort(col)}
+    >
+      {children}
+    </TableSortLabel>
+  )
+
+  return (
+    <Card variant="outlined">
+      <CardContent sx={{ p: 2.5 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            mb: 1.5,
+            flexWrap: 'wrap',
+            gap: 1,
+          }}
+        >
+          <Typography variant="subtitle1" fontWeight={700}>
+            Word progress
+          </Typography>
+
+          <FormControl size="small" sx={{ minWidth: 130 }}>
+            <InputLabel id="bucket-filter-label">Filter</InputLabel>
+            <Select
+              labelId="bucket-filter-label"
+              value={bucketFilter}
+              label="Filter"
+              onChange={handleFilterChange}
+              aria-label="Filter words by confidence level"
+            >
+              <MenuItem value="all">All words</MenuItem>
+              <MenuItem value="learning">Learning</MenuItem>
+              <MenuItem value="familiar">Familiar</MenuItem>
+              <MenuItem value="mastered">Mastered</MenuItem>
+            </Select>
+          </FormControl>
+        </Box>
+
+        {loading ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} width="100%" height={36} />
+            ))}
+          </Box>
+        ) : wordStats.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No words to display. Add words and complete quizzes to track your progress.
+          </Typography>
+        ) : (
+          <>
+            <TableContainer>
+              <Table size="small" aria-label="Word progress table">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>
+                      <SortLabel col="word">Word</SortLabel>
+                    </TableCell>
+                    <TableCell align="center">
+                      <SortLabel col="timesReviewed">Reviews</SortLabel>
+                    </TableCell>
+                    <TableCell align="center">
+                      <SortLabel col="correctPct">Accuracy</SortLabel>
+                    </TableCell>
+                    <TableCell align="center">
+                      <SortLabel col="confidence">Confidence</SortLabel>
+                    </TableCell>
+                    <TableCell align="right" sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
+                      <SortLabel col="lastReviewed">Last reviewed</SortLabel>
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {displayed.map(
+                    ({ word, bucket, timesReviewed, correctPct, confidence, lastReviewed }) => (
+                      <TableRow key={word.id} hover>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            fontWeight={500}
+                            noWrap
+                            sx={{ maxWidth: 140 }}
+                          >
+                            {word.source}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            noWrap
+                            sx={{ maxWidth: 140 }}
+                          >
+                            {word.target}
+                          </Typography>
+                        </TableCell>
+                        <TableCell align="center">
+                          <Typography variant="body2">{timesReviewed}</Typography>
+                        </TableCell>
+                        <TableCell align="center">
+                          <Typography variant="body2">
+                            {correctPct !== null ? `${correctPct}%` : '—'}
+                          </Typography>
+                        </TableCell>
+                        <TableCell align="center">
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              flexDirection: 'column',
+                              alignItems: 'center',
+                              gap: 0.5,
+                            }}
+                          >
+                            <Chip
+                              label={bucket}
+                              size="small"
+                              color={BUCKET_COLORS[bucket] as 'error' | 'warning' | 'success'}
+                              aria-label={`${word.source}: ${bucket} confidence`}
+                              sx={{ textTransform: 'capitalize', minWidth: 72 }}
+                            />
+                            <LinearProgress
+                              variant="determinate"
+                              value={confidence * 100}
+                              color={BUCKET_COLORS[bucket] as 'error' | 'warning' | 'success'}
+                              sx={{ width: 60, height: 4, borderRadius: 2 }}
+                              aria-hidden="true"
+                            />
+                          </Box>
+                        </TableCell>
+                        <TableCell align="right" sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
+                          <Typography variant="body2" color="text.secondary">
+                            {formatLastReviewed(lastReviewed)}
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    ),
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+
+            {sorted.length > ROWS_PER_PAGE && (
+              <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+                Showing {ROWS_PER_PAGE} of {sorted.length} words
+              </Typography>
+            )}
+
+            {filtered.length === 0 && bucketFilter !== 'all' && (
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                No words in the &ldquo;{bucketFilter}&rdquo; bucket.
+              </Typography>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/features/stats/hooks/useStats.ts
+++ b/src/features/stats/hooks/useStats.ts
@@ -1,0 +1,94 @@
+/**
+ * useStats - loads all data required by the StatsScreen.
+ *
+ * Fetches from StorageService:
+ *   - words and progress records for the active pair
+ *   - daily stats history (last 90+ days)
+ *   - user settings (daily goal)
+ *   - current streak and best streak
+ *
+ * Refreshes whenever activePairId changes.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import type { DailyStats, Word, WordProgress } from '@/types'
+import { useStorage } from '@/hooks/useStorage'
+import { loadCurrentStreak, loadBestStreak } from '@/services/streakService'
+import { CALENDAR_DAYS } from '../utils/activityData'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface UseStatsResult {
+  readonly words: readonly Word[]
+  readonly progress: readonly WordProgress[]
+  readonly dailyStats: readonly DailyStats[]
+  readonly streakDays: number
+  readonly bestStreak: number
+  readonly dailyGoal: number
+  readonly loading: boolean
+  readonly refresh: () => void
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useStats(activePairId: string | null): UseStatsResult {
+  const storage = useStorage()
+
+  const [words, setWords] = useState<readonly Word[]>([])
+  const [progress, setProgress] = useState<readonly WordProgress[]>([])
+  const [dailyStats, setDailyStats] = useState<readonly DailyStats[]>([])
+  const [streakDays, setStreakDays] = useState(0)
+  const [bestStreak, setBestStreak] = useState(0)
+  const [dailyGoal, setDailyGoal] = useState(20)
+  const [loading, setLoading] = useState(true)
+
+  const fetchData = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    try {
+      const [settings, stats] = await Promise.all([
+        storage.getSettings(),
+        storage.getRecentDailyStats(CALENDAR_DAYS + 10),
+      ])
+
+      // Compute streaks after settings are loaded so we have the dailyGoal.
+      const [currentStreak, best] = await Promise.all([
+        loadCurrentStreak(storage, settings.dailyGoal),
+        loadBestStreak(storage, settings.dailyGoal),
+      ])
+
+      setDailyGoal(settings.dailyGoal)
+      setDailyStats(stats)
+      setStreakDays(currentStreak)
+      setBestStreak(best)
+
+      if (activePairId !== null) {
+        const [ws, ps] = await Promise.all([
+          storage.getWords(activePairId),
+          storage.getAllProgress(activePairId),
+        ])
+        setWords(ws)
+        setProgress(ps)
+      } else {
+        setWords([])
+        setProgress([])
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [storage, activePairId])
+
+  useEffect(() => {
+    void fetchData()
+  }, [fetchData])
+
+  return {
+    words,
+    progress,
+    dailyStats,
+    streakDays,
+    bestStreak,
+    dailyGoal,
+    loading,
+    refresh: () => void fetchData(),
+  }
+}

--- a/src/features/stats/index.ts
+++ b/src/features/stats/index.ts
@@ -1,1 +1,21 @@
 export { StatsScreen } from './components/StatsScreen'
+export type { StatsScreenProps } from './components/StatsScreen'
+export { useStats } from './hooks/useStats'
+export type { UseStatsResult } from './hooks/useStats'
+export {
+  buildWordStatsList,
+  computeBucketCounts,
+  getConfidenceBucket,
+  LEARNING_THRESHOLD,
+  FAMILIAR_THRESHOLD,
+  MASTERED_THRESHOLD,
+} from './utils/confidenceBuckets'
+export type { ConfidenceBucket, BucketCounts, WordWithStats } from './utils/confidenceBuckets'
+export {
+  buildActivityDays,
+  buildCalendarDays,
+  computeOverallMetrics,
+  computeIntensityLevel,
+  CALENDAR_DAYS,
+} from './utils/activityData'
+export type { ActivityDay, ActivityRange, CalendarDay, OverallMetrics } from './utils/activityData'

--- a/src/features/stats/utils/activityData.test.ts
+++ b/src/features/stats/utils/activityData.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest'
+import type { DailyStats } from '@/types'
+import {
+  computeIntensityLevel,
+  buildActivityDays,
+  buildCalendarDays,
+  computeOverallMetrics,
+  CALENDAR_DAYS,
+} from './activityData'
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeStats(date: string, wordsReviewed: number, correctCount = 0): DailyStats {
+  return {
+    date,
+    wordsReviewed,
+    correctCount,
+    incorrectCount: wordsReviewed - correctCount,
+    streakDays: 1,
+  }
+}
+
+// ─── computeIntensityLevel ────────────────────────────────────────────────────
+
+describe('computeIntensityLevel', () => {
+  it('should return 0 for zero words reviewed', () => {
+    expect(computeIntensityLevel(0, 20)).toBe(0)
+  })
+
+  it('should return at least 1 for any non-zero review count', () => {
+    expect(computeIntensityLevel(1, 20)).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should return 4 for very high review counts', () => {
+    expect(computeIntensityLevel(100, 20)).toBe(4)
+  })
+
+  it('should scale thresholds proportionally with dailyGoal', () => {
+    // At goal=20, level thresholds are [1,5,15,30]
+    // At goal=40, thresholds double
+    const levelAt20 = computeIntensityLevel(10, 20)
+    const levelAt40 = computeIntensityLevel(10, 40)
+    // 10 reviews at goal=20 should be higher intensity than at goal=40
+    expect(levelAt20).toBeGreaterThanOrEqual(levelAt40)
+  })
+
+  it('should return values in range 0-4', () => {
+    for (let w = 0; w <= 50; w++) {
+      const level = computeIntensityLevel(w, 20)
+      expect(level).toBeGreaterThanOrEqual(0)
+      expect(level).toBeLessThanOrEqual(4)
+    }
+  })
+})
+
+// ─── buildActivityDays ────────────────────────────────────────────────────────
+
+describe('buildActivityDays', () => {
+  it('should return exactly the requested number of days', () => {
+    expect(buildActivityDays([], 7, '2024-01-15').length).toBe(7)
+    expect(buildActivityDays([], 30, '2024-01-15').length).toBe(30)
+  })
+
+  it('should have zeroed values for missing days', () => {
+    const days = buildActivityDays([], 7, '2024-01-15')
+    for (const day of days) {
+      expect(day.wordsReviewed).toBe(0)
+      expect(day.correctCount).toBe(0)
+      expect(day.incorrectCount).toBe(0)
+      expect(day.accuracy).toBeNull()
+    }
+  })
+
+  it('should place today as the last element', () => {
+    const today = '2024-03-01'
+    const days = buildActivityDays([], 7, today)
+    expect(days[days.length - 1].date).toBe(today)
+  })
+
+  it('should place 6 days ago as the first element for a 7-day range', () => {
+    const today = '2024-03-07'
+    const days = buildActivityDays([], 7, today)
+    expect(days[0].date).toBe('2024-03-01')
+  })
+
+  it('should populate stats from DailyStats records', () => {
+    const today = '2024-03-10'
+    const stats = [makeStats('2024-03-10', 15, 12), makeStats('2024-03-09', 8, 6)]
+    const days = buildActivityDays(stats, 7, today)
+
+    const todayEntry = days.find((d) => d.date === '2024-03-10')
+    expect(todayEntry?.wordsReviewed).toBe(15)
+    expect(todayEntry?.correctCount).toBe(12)
+    expect(todayEntry?.incorrectCount).toBe(3)
+    expect(todayEntry?.accuracy).toBeCloseTo(12 / 15)
+  })
+
+  it('should set accuracy to null for days with zero reviews', () => {
+    const today = '2024-03-10'
+    const days = buildActivityDays([], 7, today)
+    for (const day of days) {
+      expect(day.accuracy).toBeNull()
+    }
+  })
+})
+
+// ─── buildCalendarDays ────────────────────────────────────────────────────────
+
+describe('buildCalendarDays', () => {
+  it('should return exactly CALENDAR_DAYS entries', () => {
+    const days = buildCalendarDays([], 20, '2024-03-01')
+    expect(days.length).toBe(CALENDAR_DAYS)
+  })
+
+  it('should place today as the last element', () => {
+    const today = '2024-06-15'
+    const days = buildCalendarDays([], 20, today)
+    expect(days[days.length - 1].date).toBe(today)
+  })
+
+  it('should set level 0 for days with no activity', () => {
+    const days = buildCalendarDays([], 20, '2024-03-01')
+    for (const day of days) {
+      expect(day.level).toBe(0)
+    }
+  })
+
+  it('should set hasData=false for days with no record', () => {
+    const days = buildCalendarDays([], 20, '2024-03-01')
+    for (const day of days) {
+      expect(day.hasData).toBe(false)
+    }
+  })
+
+  it('should set hasData=true and level > 0 for active days', () => {
+    const today = '2024-03-01'
+    const stats = [makeStats(today, 20)]
+    const days = buildCalendarDays(stats, 20, today)
+    const todayEntry = days[days.length - 1]
+    expect(todayEntry.hasData).toBe(true)
+    expect(todayEntry.level).toBeGreaterThan(0)
+  })
+
+  it('should assign level 4 when daily goal is met', () => {
+    const today = '2024-03-01'
+    const stats = [makeStats(today, 30)] // above 30-threshold at goal=20
+    const days = buildCalendarDays(stats, 20, today)
+    const todayEntry = days[days.length - 1]
+    expect(todayEntry.level).toBe(4)
+  })
+})
+
+// ─── computeOverallMetrics ────────────────────────────────────────────────────
+
+describe('computeOverallMetrics', () => {
+  it('should return zeroes and null accuracy for empty stats', () => {
+    const metrics = computeOverallMetrics([])
+    expect(metrics.totalReviews).toBe(0)
+    expect(metrics.averageAccuracy).toBeNull()
+  })
+
+  it('should sum all wordsReviewed as totalReviews', () => {
+    const stats = [
+      makeStats('2024-01-01', 10, 8),
+      makeStats('2024-01-02', 20, 15),
+      makeStats('2024-01-03', 5, 5),
+    ]
+    const metrics = computeOverallMetrics(stats)
+    expect(metrics.totalReviews).toBe(35)
+  })
+
+  it('should compute weighted average accuracy across all days', () => {
+    // 10 reviewed, 8 correct + 20 reviewed, 15 correct = 30 reviewed, 23 correct = 76.67%
+    const stats = [makeStats('2024-01-01', 10, 8), makeStats('2024-01-02', 20, 15)]
+    const metrics = computeOverallMetrics(stats)
+    expect(metrics.averageAccuracy).toBe(77) // Math.round(23/30 * 100)
+  })
+
+  it('should return 100% accuracy when all reviews are correct', () => {
+    const stats = [makeStats('2024-01-01', 10, 10)]
+    const metrics = computeOverallMetrics(stats)
+    expect(metrics.averageAccuracy).toBe(100)
+  })
+
+  it('should return 0% accuracy when no reviews are correct', () => {
+    const stats = [makeStats('2024-01-01', 5, 0)]
+    const metrics = computeOverallMetrics(stats)
+    expect(metrics.averageAccuracy).toBe(0)
+  })
+})

--- a/src/features/stats/utils/activityData.ts
+++ b/src/features/stats/utils/activityData.ts
@@ -1,0 +1,153 @@
+/**
+ * Activity chart data utilities for the stats screen.
+ *
+ * Transforms raw DailyStats records into chart-ready structures for:
+ *   - Bar chart (last 7 or 30 days of words reviewed per day)
+ *   - Streak calendar heatmap (last ~90 days)
+ */
+
+import type { DailyStats } from '@/types'
+import { formatDate, offsetDate } from '@/services/streakService'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ActivityDay {
+  /** YYYY-MM-DD */
+  readonly date: string
+  /** Total words reviewed that day (0 if no session). */
+  readonly wordsReviewed: number
+  /** Correct answers that day. */
+  readonly correctCount: number
+  /** Incorrect answers that day. */
+  readonly incorrectCount: number
+  /** Accuracy ratio (0-1), or null if no reviews. */
+  readonly accuracy: number | null
+}
+
+export type ActivityRange = 7 | 30
+
+export interface CalendarDay {
+  /** YYYY-MM-DD */
+  readonly date: string
+  /** Intensity level: 0 = no activity, 1-4 = increasing activity. */
+  readonly level: 0 | 1 | 2 | 3 | 4
+  /** Actual words reviewed (for tooltip). */
+  readonly wordsReviewed: number
+  /** Whether this day has data at all (false = future or truly empty). */
+  readonly hasData: boolean
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Number of days shown in the streak calendar. */
+export const CALENDAR_DAYS = 91 // ~3 months
+
+/** Activity thresholds for calendar intensity levels. */
+const LEVEL_THRESHOLDS = [1, 5, 15, 30] as const
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Converts a wordsReviewed count to a calendar intensity level (0-4).
+ *
+ * @param wordsReviewed - Number of words reviewed on a given day.
+ * @param dailyGoal     - The user's daily goal (used to calibrate intensity).
+ */
+export function computeIntensityLevel(wordsReviewed: number, dailyGoal: number): 0 | 1 | 2 | 3 | 4 {
+  if (wordsReviewed === 0) return 0
+
+  // Scale thresholds relative to the daily goal so that hitting the goal = level 3.
+  const scale = Math.max(dailyGoal / 20, 1)
+  const scaled = LEVEL_THRESHOLDS.map((t) => Math.round(t * scale))
+
+  if (wordsReviewed >= scaled[3]) return 4
+  if (wordsReviewed >= scaled[2]) return 3
+  if (wordsReviewed >= scaled[1]) return 2
+  return 1
+}
+
+/**
+ * Builds an array of ActivityDay entries for the given range.
+ *
+ * Days with no DailyStats record appear with zero values.
+ * The array is ordered oldest-first (index 0 = range days ago, last = today).
+ *
+ * @param dailyStats - Raw DailyStats records (any order).
+ * @param range      - 7 or 30 days.
+ * @param today      - Today's date string (injectable for testing).
+ */
+export function buildActivityDays(
+  dailyStats: readonly DailyStats[],
+  range: ActivityRange,
+  today: string = formatDate(new Date()),
+): ActivityDay[] {
+  const statsMap = new Map(dailyStats.map((s) => [s.date, s]))
+  const days: ActivityDay[] = []
+
+  for (let i = range - 1; i >= 0; i--) {
+    const date = offsetDate(today, i)
+    const record = statsMap.get(date)
+    const wordsReviewed = record?.wordsReviewed ?? 0
+    const correctCount = record?.correctCount ?? 0
+    const incorrectCount = record?.incorrectCount ?? 0
+    const accuracy = wordsReviewed > 0 ? correctCount / wordsReviewed : null
+
+    days.push({ date, wordsReviewed, correctCount, incorrectCount, accuracy })
+  }
+
+  return days
+}
+
+/**
+ * Builds an array of CalendarDay entries for the streak calendar heatmap.
+ *
+ * Covers the last CALENDAR_DAYS days, oldest-first. Future days are excluded.
+ *
+ * @param dailyStats - Raw DailyStats records (any order).
+ * @param dailyGoal  - User's daily goal (used to calibrate intensity).
+ * @param today      - Today's date string (injectable for testing).
+ */
+export function buildCalendarDays(
+  dailyStats: readonly DailyStats[],
+  dailyGoal: number,
+  today: string = formatDate(new Date()),
+): CalendarDay[] {
+  const statsMap = new Map(dailyStats.map((s) => [s.date, s]))
+  const days: CalendarDay[] = []
+
+  for (let i = CALENDAR_DAYS - 1; i >= 0; i--) {
+    const date = offsetDate(today, i)
+    const record = statsMap.get(date)
+    const wordsReviewed = record?.wordsReviewed ?? 0
+    const hasData = record !== undefined
+    const level = computeIntensityLevel(wordsReviewed, dailyGoal)
+
+    days.push({ date, level, wordsReviewed, hasData })
+  }
+
+  return days
+}
+
+/**
+ * Computes overall summary metrics from DailyStats history.
+ *
+ * @param dailyStats - All available daily stats records.
+ */
+export interface OverallMetrics {
+  readonly totalReviews: number
+  readonly averageAccuracy: number | null
+}
+
+export function computeOverallMetrics(dailyStats: readonly DailyStats[]): OverallMetrics {
+  let totalReviews = 0
+  let totalCorrect = 0
+
+  for (const day of dailyStats) {
+    totalReviews += day.wordsReviewed
+    totalCorrect += day.correctCount
+  }
+
+  const averageAccuracy = totalReviews > 0 ? Math.round((totalCorrect / totalReviews) * 100) : null
+
+  return { totalReviews, averageAccuracy }
+}

--- a/src/features/stats/utils/confidenceBuckets.test.ts
+++ b/src/features/stats/utils/confidenceBuckets.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import type { Word, WordProgress } from '@/types'
+import {
+  getConfidenceBucket,
+  buildWordStatsList,
+  computeBucketCounts,
+  LEARNING_THRESHOLD,
+  FAMILIAR_THRESHOLD,
+  MASTERED_THRESHOLD,
+} from './confidenceBuckets'
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeWord(id: string, source = 'hello', target = 'sveiki'): Word {
+  return {
+    id,
+    pairId: 'pair-1',
+    source,
+    target,
+    notes: null,
+    tags: [],
+    createdAt: 1000,
+    isFromPack: false,
+  }
+}
+
+function makeProgress(
+  wordId: string,
+  confidence: number,
+  correct = 3,
+  incorrect = 1,
+): WordProgress {
+  return {
+    wordId,
+    correctCount: correct,
+    incorrectCount: incorrect,
+    streak: 2,
+    lastReviewed: 2000,
+    nextReview: 3000,
+    confidence,
+    history: [],
+  }
+}
+
+// ─── getConfidenceBucket ──────────────────────────────────────────────────────
+
+describe('getConfidenceBucket', () => {
+  it('should return "learning" for confidence 0', () => {
+    expect(getConfidenceBucket(0)).toBe('learning')
+  })
+
+  it('should return "learning" for confidence just below LEARNING_THRESHOLD', () => {
+    expect(getConfidenceBucket(LEARNING_THRESHOLD - 0.01)).toBe('learning')
+  })
+
+  it('should return "familiar" for confidence exactly at LEARNING_THRESHOLD', () => {
+    expect(getConfidenceBucket(LEARNING_THRESHOLD)).toBe('familiar')
+  })
+
+  it('should return "familiar" for confidence mid-range', () => {
+    expect(getConfidenceBucket(0.55)).toBe('familiar')
+  })
+
+  it('should return "familiar" for confidence just below FAMILIAR_THRESHOLD', () => {
+    expect(getConfidenceBucket(FAMILIAR_THRESHOLD - 0.01)).toBe('familiar')
+  })
+
+  it('should return "mastered" for confidence exactly at MASTERED_THRESHOLD', () => {
+    expect(getConfidenceBucket(MASTERED_THRESHOLD)).toBe('mastered')
+  })
+
+  it('should return "mastered" for confidence 1.0', () => {
+    expect(getConfidenceBucket(1.0)).toBe('mastered')
+  })
+
+  it('should return "mastered" for confidence 0.9', () => {
+    expect(getConfidenceBucket(0.9)).toBe('mastered')
+  })
+})
+
+// ─── buildWordStatsList ───────────────────────────────────────────────────────
+
+describe('buildWordStatsList', () => {
+  it('should return an entry per word', () => {
+    const words = [makeWord('w1'), makeWord('w2'), makeWord('w3')]
+    const progress = [makeProgress('w1', 0.8)]
+    const result = buildWordStatsList(words, progress)
+    expect(result).toHaveLength(3)
+  })
+
+  it('should assign null progress and bucket "learning" for words with no progress record', () => {
+    const words = [makeWord('w1')]
+    const result = buildWordStatsList(words, [])
+    expect(result[0].progress).toBeNull()
+    expect(result[0].bucket).toBe('learning')
+    expect(result[0].confidence).toBe(0)
+    expect(result[0].timesReviewed).toBe(0)
+    expect(result[0].correctPct).toBeNull()
+    expect(result[0].lastReviewed).toBeNull()
+  })
+
+  it('should compute timesReviewed as correct + incorrect', () => {
+    const words = [makeWord('w1')]
+    const progress = [makeProgress('w1', 0.5, 7, 3)]
+    const result = buildWordStatsList(words, progress)
+    expect(result[0].timesReviewed).toBe(10)
+  })
+
+  it('should compute correctPct as percentage (0-100)', () => {
+    const words = [makeWord('w1')]
+    const progress = [makeProgress('w1', 0.5, 3, 1)]
+    const result = buildWordStatsList(words, progress)
+    expect(result[0].correctPct).toBe(75)
+  })
+
+  it('should set correctPct to null when timesReviewed is 0', () => {
+    const words = [makeWord('w1')]
+    const progress = [makeProgress('w1', 0, 0, 0)]
+    const result = buildWordStatsList(words, progress)
+    expect(result[0].correctPct).toBeNull()
+  })
+
+  it('should carry through the lastReviewed timestamp', () => {
+    const words = [makeWord('w1')]
+    const progress = [makeProgress('w1', 0.6)]
+    const result = buildWordStatsList(words, progress)
+    expect(result[0].lastReviewed).toBe(2000)
+  })
+
+  it('should correctly assign bucket for familiar confidence', () => {
+    const words = [makeWord('w1')]
+    const progress = [makeProgress('w1', 0.55)]
+    const result = buildWordStatsList(words, progress)
+    expect(result[0].bucket).toBe('familiar')
+  })
+
+  it('should correctly assign bucket for mastered confidence', () => {
+    const words = [makeWord('w1')]
+    const progress = [makeProgress('w1', 0.85)]
+    const result = buildWordStatsList(words, progress)
+    expect(result[0].bucket).toBe('mastered')
+  })
+})
+
+// ─── computeBucketCounts ─────────────────────────────────────────────────────
+
+describe('computeBucketCounts', () => {
+  it('should return all zeroes for an empty list', () => {
+    const counts = computeBucketCounts([])
+    expect(counts).toEqual({ learning: 0, familiar: 0, mastered: 0, total: 0 })
+  })
+
+  it('should correctly count words per bucket', () => {
+    const words = [makeWord('w1'), makeWord('w2'), makeWord('w3'), makeWord('w4'), makeWord('w5')]
+    const progress = [
+      makeProgress('w1', 0.1), // learning
+      makeProgress('w2', 0.3), // learning
+      makeProgress('w3', 0.5), // familiar
+      makeProgress('w4', 0.65), // familiar
+      makeProgress('w5', 0.9), // mastered
+    ]
+    const wordStats = buildWordStatsList(words, progress)
+    const counts = computeBucketCounts(wordStats)
+
+    expect(counts.learning).toBe(2)
+    expect(counts.familiar).toBe(2)
+    expect(counts.mastered).toBe(1)
+    expect(counts.total).toBe(5)
+  })
+
+  it('should count words with no progress as "learning"', () => {
+    const words = [makeWord('w1'), makeWord('w2')]
+    const wordStats = buildWordStatsList(words, [])
+    const counts = computeBucketCounts(wordStats)
+
+    expect(counts.learning).toBe(2)
+    expect(counts.familiar).toBe(0)
+    expect(counts.mastered).toBe(0)
+    expect(counts.total).toBe(2)
+  })
+})

--- a/src/features/stats/utils/confidenceBuckets.ts
+++ b/src/features/stats/utils/confidenceBuckets.ts
@@ -1,0 +1,108 @@
+/**
+ * Confidence bucket utilities for the stats screen.
+ *
+ * Categorises words into three learning stages based on their confidence score:
+ *   - Learning  (0.0 – 0.4): just started or struggling
+ *   - Familiar  (0.4 – 0.7): making progress
+ *   - Mastered  (0.7 – 1.0): solidly known
+ *
+ * These thresholds are intentionally different from the dashboard's MASTERED_THRESHOLD (0.8)
+ * because the stats screen is meant to show a more granular view of progress.
+ */
+
+import type { Word, WordProgress } from '@/types'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Upper bound (exclusive) of the "Learning" confidence bucket. */
+export const LEARNING_THRESHOLD = 0.4
+
+/** Upper bound (exclusive) of the "Familiar" confidence bucket. */
+export const FAMILIAR_THRESHOLD = 0.7
+
+/** Minimum confidence to be considered "Mastered". */
+export const MASTERED_THRESHOLD = 0.7
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ConfidenceBucket = 'learning' | 'familiar' | 'mastered'
+
+export interface BucketCounts {
+  readonly learning: number
+  readonly familiar: number
+  readonly mastered: number
+  readonly total: number
+}
+
+export interface WordWithStats {
+  readonly word: Word
+  readonly progress: WordProgress | null
+  readonly bucket: ConfidenceBucket
+  readonly timesReviewed: number
+  readonly correctPct: number | null
+  readonly confidence: number
+  readonly lastReviewed: number | null
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Returns the confidence bucket for a given confidence score (0-1). */
+export function getConfidenceBucket(confidence: number): ConfidenceBucket {
+  if (confidence >= MASTERED_THRESHOLD) return 'mastered'
+  if (confidence >= LEARNING_THRESHOLD) return 'familiar'
+  return 'learning'
+}
+
+/**
+ * Builds a per-word stats list combining word metadata with progress data.
+ *
+ * Words with no progress record have confidence=0 and are in the "learning" bucket.
+ *
+ * @param words    - All words for the active pair.
+ * @param progress - All progress records for the active pair.
+ * @returns Combined per-word stats, one entry per word.
+ */
+export function buildWordStatsList(
+  words: readonly Word[],
+  progress: readonly WordProgress[],
+): WordWithStats[] {
+  const progressMap = new Map(progress.map((p) => [p.wordId, p]))
+
+  return words.map((word) => {
+    const p = progressMap.get(word.id) ?? null
+    const timesReviewed = p !== null ? p.correctCount + p.incorrectCount : 0
+    const confidence = p?.confidence ?? 0
+    const correctPct =
+      timesReviewed > 0 ? Math.round((p!.correctCount / timesReviewed) * 100) : null
+
+    return {
+      word,
+      progress: p,
+      bucket: getConfidenceBucket(confidence),
+      timesReviewed,
+      correctPct,
+      confidence,
+      lastReviewed: p?.lastReviewed ?? null,
+    }
+  })
+}
+
+/**
+ * Aggregates per-word stats into bucket counts.
+ *
+ * @param wordStats - Output of buildWordStatsList.
+ * @returns Count per bucket plus total.
+ */
+export function computeBucketCounts(wordStats: readonly WordWithStats[]): BucketCounts {
+  let learning = 0
+  let familiar = 0
+  let mastered = 0
+
+  for (const ws of wordStats) {
+    if (ws.bucket === 'mastered') mastered++
+    else if (ws.bucket === 'familiar') familiar++
+    else learning++
+  }
+
+  return { learning, familiar, mastered, total: wordStats.length }
+}


### PR DESCRIPTION
## Summary

Replaces the stats placeholder with a fully functional stats screen featuring per-word progress tracking, confidence buckets, activity charts, and a streak calendar heatmap.

## Changes

- `src/features/stats/components/StatsScreen.tsx` - Main screen component, wires all sections together, reads activePairId from settings for backward compatibility
- `src/features/stats/components/OverallSummary.tsx` - Aggregate metrics: total words, mastered count, all-time reviews, avg accuracy, current/best streak
- `src/features/stats/components/ConfidenceSummary.tsx` - Confidence bucket cards (Learning/Familiar/Mastered) + stacked proportional progress bar
- `src/features/stats/components/ActivityChart.tsx` - Pure SVG bar chart with 7d/30d toggle, colour-coded by accuracy ratio (no chart library)
- `src/features/stats/components/StreakCalendar.tsx` - GitHub-style 91-day heatmap with 5 intensity levels, MUI Tooltip for each day
- `src/features/stats/components/WordStatsTable.tsx` - Sortable by any column, filterable by confidence bucket, confidence chip + LinearProgress per word
- `src/features/stats/hooks/useStats.ts` - Data loading hook (words, progress, daily stats, streaks, settings) from StorageService
- `src/features/stats/utils/confidenceBuckets.ts` - Bucket thresholds, per-word stats builder, bucket count aggregation
- `src/features/stats/utils/activityData.ts` - Activity data builders for bar chart and calendar heatmap, overall metrics
- `src/features/stats/index.ts` - Updated barrel exports
- 6 new test files with 78 new tests

## Testing

- All 537 tests pass (37 test files)
- `npx tsc --noEmit` clean
- `npm run build` succeeds
- `npx eslint . --max-warnings 0` clean
- `npx prettier --check .` clean

## Review

- Code review passed - no direct localStorage calls, MUI theme throughout, TypeScript strict compliant, accessibility roles/labels on all interactive elements, useMemo for all computed values

Closes #14