### PR TITLE
feat: bulk word import - CSV/TSV paste and parse (#7)

### DIFF
--- a/src/features/words/components/ImportWordsDialog.test.tsx
+++ b/src/features/words/components/ImportWordsDialog.test.tsx
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ImportWordsDialog } from './ImportWordsDialog'
+import type { ImportSummary, ImportWordsDialogProps } from './ImportWordsDialog'
+import { createMockPair, createMockWord } from '@/test/fixtures'
+
+const DEFAULT_PAIR = createMockPair({ sourceLang: 'English', targetLang: 'Latvian' })
+const NO_EXISTING_WORDS = [] as const
+
+function renderDialog(
+  overrides: {
+    open?: boolean
+    existingWords?: Parameters<typeof createMockWord>[0][]
+    onImport?: ImportWordsDialogProps['onImport']
+    onClose?: () => void
+  } = {},
+) {
+  const onImport: ImportWordsDialogProps['onImport'] =
+    overrides.onImport ?? vi.fn().mockResolvedValue({ added: 0, skippedDuplicates: 0, errors: 0 })
+  const onClose = overrides.onClose ?? vi.fn()
+  const existingWords = (overrides.existingWords ?? []).map((o) => createMockWord(o))
+
+  return {
+    onImport,
+    onClose,
+    ...render(
+      <ImportWordsDialog
+        open={overrides.open ?? true}
+        activePair={DEFAULT_PAIR}
+        existingWords={existingWords}
+        onClose={onClose}
+        onImport={onImport}
+      />,
+    ),
+  }
+}
+
+describe('ImportWordsDialog', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('rendering', () => {
+    it('should render the dialog title when open', () => {
+      renderDialog()
+      expect(screen.getByText('Import words')).toBeInTheDocument()
+    })
+
+    it('should not render when closed', () => {
+      renderDialog({ open: false })
+      expect(screen.queryByText('Import words')).not.toBeInTheDocument()
+    })
+
+    it('should show language pair in the instruction text', () => {
+      renderDialog()
+      expect(screen.getByText(/English/)).toBeInTheDocument()
+      expect(screen.getByText(/Latvian/)).toBeInTheDocument()
+    })
+
+    it('should render the paste textarea', () => {
+      renderDialog()
+      expect(screen.getByLabelText('Paste words here')).toBeInTheDocument()
+    })
+  })
+
+  describe('step 1 - input', () => {
+    it('should show disabled Preview button when textarea is empty', () => {
+      renderDialog()
+      const btn = screen.getByRole('button', { name: /Preview/ })
+      expect(btn).toBeDisabled()
+    })
+
+    it('should enable Preview button when text is entered', async () => {
+      const user = userEvent.setup()
+      renderDialog()
+
+      await user.type(screen.getByLabelText('Paste words here'), 'hello,world')
+      expect(screen.getByRole('button', { name: /Preview \(1\)/ })).not.toBeDisabled()
+    })
+
+    it('should show detected word count after typing', async () => {
+      const user = userEvent.setup()
+      renderDialog()
+
+      await user.type(screen.getByLabelText('Paste words here'), 'a,b\nc,d\ne,f')
+      expect(screen.getByText(/3 words detected/)).toBeInTheDocument()
+    })
+
+    it('should show error count for unparseable lines', async () => {
+      const user = userEvent.setup()
+      renderDialog()
+
+      await user.type(screen.getByLabelText('Paste words here'), 'hello,world\nbadline')
+      expect(screen.getByText(/1 line could not be parsed/)).toBeInTheDocument()
+    })
+  })
+
+  describe('step 2 - preview', () => {
+    async function goToPreview(
+      text = 'hello,world\ncat,kaķis',
+      existingWordOverrides: Parameters<typeof createMockWord>[0][] = [],
+    ) {
+      const user = userEvent.setup()
+      renderDialog({ existingWords: existingWordOverrides })
+
+      await user.type(screen.getByLabelText('Paste words here'), text)
+      // Wait for the preview button to become enabled (shows row count > 0)
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /Preview \(\d+\)/ })
+        expect(btn).not.toBeDisabled()
+      })
+      await user.click(screen.getByRole('button', { name: /Preview \(\d+\)/ }))
+
+      return user
+    }
+
+    it('should show preview table with parsed rows', async () => {
+      await goToPreview('hello,world')
+      expect(screen.getByText('hello')).toBeInTheDocument()
+      expect(screen.getByText('world')).toBeInTheDocument()
+    })
+
+    it('should show Import button with correct count', async () => {
+      await goToPreview('hello,world\ncat,kaķis')
+      expect(screen.getByRole('button', { name: /Import 2 words/ })).toBeInTheDocument()
+    })
+
+    it('should show Back button', async () => {
+      await goToPreview()
+      expect(screen.getByRole('button', { name: /Back/ })).toBeInTheDocument()
+    })
+
+    it('should navigate back to input step when Back is clicked', async () => {
+      const user = await goToPreview()
+      await user.click(screen.getByRole('button', { name: /Back/ }))
+      expect(screen.getByLabelText('Paste words here')).toBeInTheDocument()
+    })
+
+    it('should highlight duplicate rows in the preview table', async () => {
+      await goToPreview('hello,world\nnew,word', [{ source: 'hello', target: 'world' }])
+      expect(screen.getByText('Duplicate')).toBeInTheDocument()
+    })
+
+    it('should pre-deselect duplicate rows', async () => {
+      await goToPreview('hello,world\nnew,word', [{ source: 'hello', target: 'world' }])
+      // 1 of 2 rows selected (the non-duplicate)
+      expect(screen.getByRole('button', { name: /Import 1 word/ })).toBeInTheDocument()
+    })
+
+    it('should allow user to deselect a row', async () => {
+      const user = await goToPreview('hello,world\ncat,kaķis')
+
+      // Deselect the first row via its checkbox
+      const checkboxes = screen.getAllByRole('checkbox')
+      await user.click(checkboxes[0])
+
+      expect(screen.getByRole('button', { name: /Import 1 word/ })).toBeInTheDocument()
+    })
+
+    it('should show parse errors section when there are unparseable lines', async () => {
+      await goToPreview('good,line\nbadline')
+
+      await waitFor(() => {
+        expect(screen.getByText(/could not be parsed and will be skipped/)).toBeInTheDocument()
+      })
+    })
+
+    it('should show notes column in preview table', async () => {
+      await goToPreview('hello,world,a greeting')
+      expect(screen.getByText('a greeting')).toBeInTheDocument()
+    })
+  })
+
+  describe('step 3 - done', () => {
+    async function importWords(
+      text = 'hello,world',
+      summary: ImportSummary = { added: 1, skippedDuplicates: 0, errors: 0 },
+    ) {
+      const user = userEvent.setup()
+      const onImport = vi.fn().mockResolvedValue(summary)
+      const onClose = vi.fn()
+
+      render(
+        <ImportWordsDialog
+          open={true}
+          activePair={DEFAULT_PAIR}
+          existingWords={NO_EXISTING_WORDS}
+          onClose={onClose}
+          onImport={onImport}
+        />,
+      )
+
+      await user.type(screen.getByLabelText('Paste words here'), text)
+      await waitFor(() => {
+        const btn = screen.getByRole('button', { name: /Preview \(\d+\)/ })
+        expect(btn).not.toBeDisabled()
+      })
+      await user.click(screen.getByRole('button', { name: /Preview \(\d+\)/ }))
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Import \d+ word/ })).not.toBeDisabled()
+      })
+      await user.click(screen.getByRole('button', { name: /Import \d+ word/ }))
+
+      return { user, onImport, onClose }
+    }
+
+    it('should show import summary after completion', async () => {
+      await importWords('hello,world', { added: 1, skippedDuplicates: 0, errors: 0 })
+
+      await waitFor(() => {
+        expect(screen.getByText(/Added/)).toBeInTheDocument()
+        expect(screen.getByText('1')).toBeInTheDocument()
+      })
+    })
+
+    it('should show skipped duplicates in summary', async () => {
+      await importWords('a,b', { added: 2, skippedDuplicates: 3, errors: 0 })
+
+      await waitFor(() => {
+        expect(screen.getByText(/Skipped/)).toBeInTheDocument()
+      })
+    })
+
+    it('should not show skipped section when there are none', async () => {
+      await importWords('a,b', { added: 1, skippedDuplicates: 0, errors: 0 })
+
+      await waitFor(() => {
+        expect(screen.queryByText(/Skipped/)).not.toBeInTheDocument()
+      })
+    })
+
+    it('should show Done button after import', async () => {
+      await importWords()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Done/ })).toBeInTheDocument()
+      })
+    })
+
+    it('should call onImport with selected rows', async () => {
+      const { onImport } = await importWords('cat,kaķis\ndog,suns')
+
+      await waitFor(() => {
+        expect(onImport).toHaveBeenCalledTimes(1)
+        const rows = onImport.mock.calls[0][0]
+        expect(rows).toHaveLength(2)
+        expect(rows[0]).toMatchObject({ source: 'cat', target: 'kaķis' })
+      })
+    })
+
+    it('should call onClose when Done is clicked', async () => {
+      const { user, onClose } = await importWords()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Done/ })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /Done/ }))
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Cancel button', () => {
+    it('should call onClose when Cancel is clicked on input step', async () => {
+      const user = userEvent.setup()
+      const { onClose } = renderDialog()
+
+      await user.click(screen.getByRole('button', { name: /Cancel/ }))
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/features/words/components/ImportWordsDialog.tsx
+++ b/src/features/words/components/ImportWordsDialog.tsx
@@ -1,0 +1,407 @@
+import { useState, useMemo, useCallback, useEffect } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Typography,
+  Box,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableContainer,
+  Checkbox,
+  Chip,
+  Alert,
+  Stack,
+  Divider,
+  CircularProgress,
+} from '@mui/material'
+import WarningAmberIcon from '@mui/icons-material/WarningAmber'
+import type { Word, LanguagePair } from '@/types'
+import { parseImportText, findDuplicateLineNumbers } from '@/utils/importParser'
+import type { ParsedWordRow, ParseErrorRow } from '@/utils/importParser'
+
+export interface ImportWordsDialogProps {
+  readonly open: boolean
+  readonly activePair: LanguagePair
+  readonly existingWords: readonly Word[]
+  readonly onClose: () => void
+  /** Called with the rows the user confirmed to import. Returns import summary counts. */
+  readonly onImport: (rows: readonly ParsedWordRow[]) => Promise<ImportSummary>
+}
+
+export interface ImportSummary {
+  readonly added: number
+  readonly skippedDuplicates: number
+  readonly errors: number
+}
+
+type Step = 'input' | 'preview' | 'done'
+
+/**
+ * Multi-step dialog for bulk importing words by pasting CSV/TSV/semicolon text.
+ *
+ * Step 1 (input):   Textarea for pasting raw text.
+ * Step 2 (preview): Table showing parsed rows with duplicate highlights; user can deselect rows.
+ * Step 3 (done):    Import summary.
+ */
+export function ImportWordsDialog({
+  open,
+  activePair,
+  existingWords,
+  onClose,
+  onImport,
+}: ImportWordsDialogProps) {
+  const [step, setStep] = useState<Step>('input')
+  const [rawText, setRawText] = useState('')
+  const [deselectedLineNumbers, setDeselectedLineNumbers] = useState<Set<number>>(new Set())
+  const [summary, setSummary] = useState<ImportSummary | null>(null)
+  const [importing, setImporting] = useState(false)
+
+  // Reset all state each time the dialog opens so re-opening starts fresh.
+  useEffect(() => {
+    if (open) {
+      setStep('input')
+      setRawText('')
+      setDeselectedLineNumbers(new Set())
+      setSummary(null)
+      setImporting(false)
+    }
+  }, [open])
+
+  const { rows, errors } = useMemo(() => parseImportText(rawText), [rawText])
+
+  const duplicateLineNumbers = useMemo(
+    () => findDuplicateLineNumbers(rows, existingWords),
+    [rows, existingWords],
+  )
+
+  // Rows the user has NOT deselected.
+  const selectedRows = useMemo(
+    () => rows.filter((r) => !deselectedLineNumbers.has(r.lineNumber)),
+    [rows, deselectedLineNumbers],
+  )
+
+  const handleToggleRow = useCallback((lineNumber: number) => {
+    setDeselectedLineNumbers((prev) => {
+      const next = new Set(prev)
+      if (next.has(lineNumber)) {
+        next.delete(lineNumber)
+      } else {
+        next.add(lineNumber)
+      }
+      return next
+    })
+  }, [])
+
+  const handleParseAndPreview = useCallback(() => {
+    // Pre-deselect all duplicate rows so the user doesn't accidentally re-import them.
+    setDeselectedLineNumbers(new Set(duplicateLineNumbers))
+    setStep('preview')
+  }, [duplicateLineNumbers])
+
+  const handleBack = useCallback(() => {
+    setStep('input')
+  }, [])
+
+  const handleConfirmImport = useCallback(async () => {
+    setImporting(true)
+    const result = await onImport(selectedRows)
+    setSummary(result)
+    setImporting(false)
+    setStep('done')
+  }, [onImport, selectedRows])
+
+  const handleClose = useCallback(() => {
+    onClose()
+  }, [onClose])
+
+  const canPreview = rows.length > 0
+
+  return (
+    <Dialog
+      open={open}
+      onClose={step === 'done' || step === 'input' ? handleClose : undefined}
+      fullWidth
+      maxWidth="md"
+      aria-labelledby="import-dialog-title"
+    >
+      <DialogTitle id="import-dialog-title">Import words</DialogTitle>
+
+      <DialogContent dividers>
+        {step === 'input' && (
+          <StepInput
+            rawText={rawText}
+            onRawTextChange={setRawText}
+            activePair={activePair}
+            previewRowCount={rows.length}
+            errorCount={errors.length}
+          />
+        )}
+
+        {step === 'preview' && (
+          <StepPreview
+            rows={rows}
+            errors={errors}
+            duplicateLineNumbers={duplicateLineNumbers}
+            deselectedLineNumbers={deselectedLineNumbers}
+            onToggleRow={handleToggleRow}
+          />
+        )}
+
+        {step === 'done' && summary !== null && <StepDone summary={summary} />}
+      </DialogContent>
+
+      <DialogActions>
+        {step === 'input' && (
+          <>
+            <Button onClick={handleClose}>Cancel</Button>
+            <Button variant="contained" onClick={handleParseAndPreview} disabled={!canPreview}>
+              Preview ({rows.length})
+            </Button>
+          </>
+        )}
+
+        {step === 'preview' && (
+          <>
+            <Button onClick={handleBack} disabled={importing}>
+              Back
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleConfirmImport}
+              disabled={importing || selectedRows.length === 0}
+              startIcon={importing ? <CircularProgress size={16} /> : undefined}
+            >
+              {importing
+                ? 'Importing…'
+                : `Import ${selectedRows.length} word${selectedRows.length !== 1 ? 's' : ''}`}
+            </Button>
+          </>
+        )}
+
+        {step === 'done' && (
+          <Button variant="contained" onClick={handleClose}>
+            Done
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components for each step
+// ---------------------------------------------------------------------------
+
+interface StepInputProps {
+  readonly rawText: string
+  readonly onRawTextChange: (text: string) => void
+  readonly activePair: LanguagePair
+  readonly previewRowCount: number
+  readonly errorCount: number
+}
+
+function StepInput({
+  rawText,
+  onRawTextChange,
+  activePair,
+  previewRowCount,
+  errorCount,
+}: StepInputProps) {
+  return (
+    <Stack spacing={2}>
+      <Typography variant="body2" color="text.secondary">
+        Paste words for{' '}
+        <strong>
+          {activePair.sourceLang} → {activePair.targetLang}
+        </strong>
+        . Supported formats: <code>source,target</code>, <code>source{'\t'}target</code>, or{' '}
+        <code>source;target</code>. An optional third column is treated as notes. The delimiter is
+        auto-detected.
+      </Typography>
+
+      <TextField
+        multiline
+        minRows={8}
+        maxRows={20}
+        fullWidth
+        value={rawText}
+        onChange={(e) => onRawTextChange(e.target.value)}
+        placeholder={`hello,world\ncat\tKatze\nbonjour;hello,a French greeting`}
+        inputProps={{ 'aria-label': 'Paste words here', lang: 'mul', spellCheck: false }}
+        sx={{ fontFamily: 'monospace' }}
+      />
+
+      {rawText.trim().length > 0 && (
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          {previewRowCount > 0 && (
+            <Chip
+              label={`${previewRowCount} word${previewRowCount !== 1 ? 's' : ''} detected`}
+              size="small"
+              color="success"
+              variant="outlined"
+            />
+          )}
+          {errorCount > 0 && (
+            <Chip
+              label={`${errorCount} line${errorCount !== 1 ? 's' : ''} could not be parsed`}
+              size="small"
+              color="warning"
+              variant="outlined"
+              icon={<WarningAmberIcon />}
+            />
+          )}
+        </Box>
+      )}
+    </Stack>
+  )
+}
+
+interface StepPreviewProps {
+  readonly rows: readonly ParsedWordRow[]
+  readonly errors: readonly ParseErrorRow[]
+  readonly duplicateLineNumbers: ReadonlySet<number>
+  readonly deselectedLineNumbers: ReadonlySet<number>
+  readonly onToggleRow: (lineNumber: number) => void
+}
+
+function StepPreview({
+  rows,
+  errors,
+  duplicateLineNumbers,
+  deselectedLineNumbers,
+  onToggleRow,
+}: StepPreviewProps) {
+  const selectedCount = rows.filter((r) => !deselectedLineNumbers.has(r.lineNumber)).length
+  const duplicateCount = rows.filter((r) => duplicateLineNumbers.has(r.lineNumber)).length
+
+  return (
+    <Stack spacing={2}>
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+        <Typography variant="body2">
+          {selectedCount} of {rows.length} row{rows.length !== 1 ? 's' : ''} selected for import.
+        </Typography>
+        {duplicateCount > 0 && (
+          <Chip
+            label={`${duplicateCount} duplicate${duplicateCount !== 1 ? 's' : ''} detected`}
+            size="small"
+            color="warning"
+            variant="outlined"
+          />
+        )}
+      </Box>
+
+      <TableContainer sx={{ maxHeight: 360, border: 1, borderColor: 'divider', borderRadius: 1 }}>
+        <Table size="small" stickyHeader aria-label="Import preview">
+          <TableHead>
+            <TableRow>
+              <TableCell padding="checkbox" />
+              <TableCell>Source</TableCell>
+              <TableCell>Target</TableCell>
+              <TableCell>Notes</TableCell>
+              <TableCell>Status</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => {
+              const isDuplicate = duplicateLineNumbers.has(row.lineNumber)
+              const isSelected = !deselectedLineNumbers.has(row.lineNumber)
+
+              return (
+                <TableRow
+                  key={row.lineNumber}
+                  selected={isSelected}
+                  sx={{ opacity: isSelected ? 1 : 0.4 }}
+                  hover
+                >
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      checked={isSelected}
+                      onChange={() => onToggleRow(row.lineNumber)}
+                      size="small"
+                      inputProps={{ 'aria-label': `Toggle row ${row.lineNumber}` }}
+                    />
+                  </TableCell>
+                  <TableCell>{row.source}</TableCell>
+                  <TableCell>{row.target}</TableCell>
+                  <TableCell
+                    sx={{ color: 'text.secondary', fontStyle: row.notes ? 'normal' : 'italic' }}
+                  >
+                    {row.notes ?? '—'}
+                  </TableCell>
+                  <TableCell>
+                    {isDuplicate && (
+                      <Chip label="Duplicate" size="small" color="warning" variant="outlined" />
+                    )}
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {errors.length > 0 && (
+        <>
+          <Divider />
+          <Alert severity="warning" icon={<WarningAmberIcon />}>
+            <Typography variant="body2" fontWeight={600} gutterBottom>
+              {errors.length} line{errors.length !== 1 ? 's' : ''} could not be parsed and will be
+              skipped:
+            </Typography>
+            <Box component="ul" sx={{ m: 0, pl: 2, maxHeight: 120, overflowY: 'auto' }}>
+              {errors.map((err) => (
+                <li key={err.lineNumber}>
+                  <Typography variant="caption">
+                    Line {err.lineNumber}: <code>{err.raw}</code> — {err.reason}
+                  </Typography>
+                </li>
+              ))}
+            </Box>
+          </Alert>
+        </>
+      )}
+    </Stack>
+  )
+}
+
+interface StepDoneProps {
+  readonly summary: ImportSummary
+}
+
+function StepDone({ summary }: StepDoneProps) {
+  return (
+    <Stack spacing={2}>
+      <Alert severity="success">Import complete.</Alert>
+      <Box component="ul" sx={{ m: 0, pl: 3 }}>
+        <li>
+          <Typography variant="body2">
+            Added <strong>{summary.added}</strong> word{summary.added !== 1 ? 's' : ''}
+          </Typography>
+        </li>
+        {summary.skippedDuplicates > 0 && (
+          <li>
+            <Typography variant="body2">
+              Skipped <strong>{summary.skippedDuplicates}</strong> duplicate
+              {summary.skippedDuplicates !== 1 ? 's' : ''}
+            </Typography>
+          </li>
+        )}
+        {summary.errors > 0 && (
+          <li>
+            <Typography variant="body2">
+              <strong>{summary.errors}</strong> error{summary.errors !== 1 ? 's' : ''} (unparseable
+              lines)
+            </Typography>
+          </li>
+        )}
+      </Box>
+    </Stack>
+  )
+}

--- a/src/features/words/components/WordListScreen.tsx
+++ b/src/features/words/components/WordListScreen.tsx
@@ -1,12 +1,16 @@
 import { useState, useCallback } from 'react'
 import { Box, Typography, Button, CircularProgress, Stack } from '@mui/material'
 import AddIcon from '@mui/icons-material/Add'
+import UploadFileIcon from '@mui/icons-material/UploadFile'
 import LibraryBooksIcon from '@mui/icons-material/LibraryBooks'
 import type { Word, LanguagePair } from '@/types'
 import { useWords } from '../useWords'
 import type { CreateWordInput } from '../useWords'
+import type { ParsedWordRow } from '@/utils/importParser'
 import { WordList } from './WordList'
 import { WordFormDialog } from './WordFormDialog'
+import { ImportWordsDialog } from './ImportWordsDialog'
+import type { ImportSummary } from './ImportWordsDialog'
 import { PackBrowserDialog } from '@/features/starter-packs'
 
 export interface WordListScreenProps {
@@ -25,6 +29,7 @@ export function WordListScreen({ activePair }: WordListScreenProps) {
   const [wordToEdit, setWordToEdit] = useState<Word | null>(null)
   const [quickAddMode, setQuickAddMode] = useState(false)
   const [packBrowserOpen, setPackBrowserOpen] = useState(false)
+  const [importOpen, setImportOpen] = useState(false)
 
   const handleOpenAdd = useCallback((quick = false) => {
     setWordToEdit(null)
@@ -56,6 +61,40 @@ export function WordListScreen({ activePair }: WordListScreenProps) {
       return result !== null
     },
     [activePair, wordToEdit, addWord, updateWord],
+  )
+
+  const handleOpenImport = useCallback(() => {
+    setImportOpen(true)
+  }, [])
+
+  const handleCloseImport = useCallback(() => {
+    setImportOpen(false)
+  }, [])
+
+  const handleImport = useCallback(
+    async (rows: readonly ParsedWordRow[]): Promise<ImportSummary> => {
+      if (!activePair) return { added: 0, skippedDuplicates: 0, errors: 0 }
+
+      let added = 0
+      let skippedDuplicates = 0
+
+      for (const row of rows) {
+        const result = await addWord(activePair.id, {
+          source: row.source,
+          target: row.target,
+          notes: row.notes,
+          tags: ['imported'],
+        })
+        if (result === null) {
+          skippedDuplicates++
+        } else {
+          added++
+        }
+      }
+
+      return { added, skippedDuplicates, errors: 0 }
+    },
+    [activePair, addWord],
   )
 
   const handleOpenPackBrowser = useCallback(() => {
@@ -120,6 +159,9 @@ export function WordListScreen({ activePair }: WordListScreenProps) {
             >
               Add your first word
             </Button>
+            <Button variant="outlined" startIcon={<UploadFileIcon />} onClick={handleOpenImport}>
+              Import
+            </Button>
             <Button
               variant="outlined"
               startIcon={<LibraryBooksIcon />}
@@ -145,6 +187,14 @@ export function WordListScreen({ activePair }: WordListScreenProps) {
                 onClick={handleOpenPackBrowser}
               >
                 Packs
+              </Button>
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<UploadFileIcon />}
+                onClick={handleOpenImport}
+              >
+                Import
               </Button>
               <Button variant="outlined" size="small" onClick={() => handleOpenAdd(true)}>
                 Quick add
@@ -188,6 +238,14 @@ export function WordListScreen({ activePair }: WordListScreenProps) {
         pairTargetCode={activePair.targetCode}
         onClose={handleClosePackBrowser}
         onInstalled={handlePackInstalled}
+      />
+
+      <ImportWordsDialog
+        open={importOpen}
+        activePair={activePair}
+        existingWords={words}
+        onClose={handleCloseImport}
+        onImport={handleImport}
       />
     </>
   )

--- a/src/features/words/components/index.ts
+++ b/src/features/words/components/index.ts
@@ -4,6 +4,9 @@ export type { WordFormDialogProps } from './WordFormDialog'
 export { DeleteWordDialog } from './DeleteWordDialog'
 export type { DeleteWordDialogProps } from './DeleteWordDialog'
 
+export { ImportWordsDialog } from './ImportWordsDialog'
+export type { ImportWordsDialogProps, ImportSummary } from './ImportWordsDialog'
+
 export { WordListItem } from './WordListItem'
 export type { WordListItemProps } from './WordListItem'
 

--- a/src/features/words/index.ts
+++ b/src/features/words/index.ts
@@ -15,6 +15,7 @@ export type { SortOption, WordFilter, ConfidenceFilter, SortOptionConfig } from 
 export {
   WordFormDialog,
   DeleteWordDialog,
+  ImportWordsDialog,
   WordListItem,
   WordList,
   WordListScreen,
@@ -22,6 +23,8 @@ export {
 export type {
   WordFormDialogProps,
   DeleteWordDialogProps,
+  ImportWordsDialogProps,
+  ImportSummary,
   WordListItemProps,
   WordListProps,
   WordListScreenProps,

--- a/src/utils/importParser.test.ts
+++ b/src/utils/importParser.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from 'vitest'
+import { parseImportText, findDuplicateLineNumbers } from './importParser'
+
+describe('parseImportText', () => {
+  describe('comma-separated', () => {
+    it('should parse simple source,target pairs', () => {
+      const result = parseImportText('hello,hallo\nworld,Welt')
+      expect(result.rows).toHaveLength(2)
+      expect(result.rows[0]).toMatchObject({
+        source: 'hello',
+        target: 'hallo',
+        notes: null,
+        lineNumber: 1,
+      })
+      expect(result.rows[1]).toMatchObject({
+        source: 'world',
+        target: 'Welt',
+        notes: null,
+        lineNumber: 2,
+      })
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('should parse source,target,notes triplets', () => {
+      const result = parseImportText('cat,Katze,a small animal')
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]).toMatchObject({
+        source: 'cat',
+        target: 'Katze',
+        notes: 'a small animal',
+      })
+    })
+
+    it('should trim whitespace from fields', () => {
+      const result = parseImportText('  hello  ,  world  ,  note  ')
+      expect(result.rows[0]).toMatchObject({ source: 'hello', target: 'world', notes: 'note' })
+    })
+
+    it('should ignore fields beyond the third', () => {
+      const result = parseImportText('a,b,c,d,e')
+      expect(result.rows[0]).toMatchObject({ source: 'a', target: 'b', notes: 'c' })
+    })
+  })
+
+  describe('tab-separated', () => {
+    it('should parse tab-separated pairs', () => {
+      const result = parseImportText('dog\tHund\ncat\tKatze')
+      expect(result.rows).toHaveLength(2)
+      expect(result.rows[0]).toMatchObject({ source: 'dog', target: 'Hund', notes: null })
+      expect(result.rows[1]).toMatchObject({ source: 'cat', target: 'Katze', notes: null })
+    })
+
+    it('should parse tab-separated triplets', () => {
+      const result = parseImportText('run\tlaufen\tto run fast')
+      expect(result.rows[0]).toMatchObject({
+        source: 'run',
+        target: 'laufen',
+        notes: 'to run fast',
+      })
+    })
+  })
+
+  describe('semicolon-separated', () => {
+    it('should parse semicolon-separated pairs', () => {
+      const result = parseImportText('maison;house\nchat;cat')
+      expect(result.rows).toHaveLength(2)
+      expect(result.rows[0]).toMatchObject({ source: 'maison', target: 'house' })
+      expect(result.rows[1]).toMatchObject({ source: 'chat', target: 'cat' })
+    })
+
+    it('should parse semicolon-separated triplets with notes', () => {
+      const result = parseImportText('bonjour;hello;a greeting')
+      expect(result.rows[0]).toMatchObject({
+        source: 'bonjour',
+        target: 'hello',
+        notes: 'a greeting',
+      })
+    })
+  })
+
+  describe('auto-detect delimiter', () => {
+    it('should prefer tab when tabs are dominant', () => {
+      const result = parseImportText('a\tb\nc\td')
+      expect(result.rows).toHaveLength(2)
+      expect(result.rows[0]).toMatchObject({ source: 'a', target: 'b' })
+    })
+
+    it('should prefer semicolon when semicolons are dominant', () => {
+      const result = parseImportText('a;b\nc;d\ne;f')
+      expect(result.rows).toHaveLength(3)
+      expect(result.rows[0]).toMatchObject({ source: 'a', target: 'b' })
+    })
+
+    it('should fall back to comma when no delimiter found', () => {
+      const result = parseImportText('hello,world')
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0]).toMatchObject({ source: 'hello', target: 'world' })
+    })
+  })
+
+  describe('empty lines and whitespace', () => {
+    it('should skip empty lines', () => {
+      const result = parseImportText('\nhello,world\n\nfoo,bar\n')
+      expect(result.rows).toHaveLength(2)
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('should skip lines with only whitespace', () => {
+      const result = parseImportText('a,b\n   \nc,d')
+      expect(result.rows).toHaveLength(2)
+      expect(result.errors).toHaveLength(0)
+    })
+  })
+
+  describe('mixed line endings', () => {
+    it('should handle Windows CRLF line endings', () => {
+      const result = parseImportText('hello,world\r\nfoo,bar\r\n')
+      expect(result.rows).toHaveLength(2)
+      expect(result.rows[0]).toMatchObject({ source: 'hello', target: 'world' })
+      expect(result.rows[1]).toMatchObject({ source: 'foo', target: 'bar' })
+    })
+
+    it('should handle Unix LF line endings', () => {
+      const result = parseImportText('hello,world\nfoo,bar\n')
+      expect(result.rows).toHaveLength(2)
+    })
+
+    it('should handle mixed CRLF and LF in same input', () => {
+      const result = parseImportText('hello,world\r\nfoo,bar\nbaz,qux')
+      expect(result.rows).toHaveLength(3)
+    })
+  })
+
+  describe('error handling', () => {
+    it('should flag lines with only one field', () => {
+      const result = parseImportText('hello\nfoo,bar')
+      expect(result.rows).toHaveLength(1)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].lineNumber).toBe(1)
+      expect(result.errors[0].raw).toBe('hello')
+    })
+
+    it('should flag lines where source is empty', () => {
+      const result = parseImportText(',target\ngood,line')
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].lineNumber).toBe(1)
+    })
+
+    it('should flag lines where target is empty', () => {
+      const result = parseImportText('source,\ngood,line')
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].lineNumber).toBe(1)
+    })
+
+    it('should include reason in error row', () => {
+      const result = parseImportText('bad-line')
+      expect(result.errors[0].reason).toMatch(/source and target/)
+    })
+
+    it('should continue parsing after an error', () => {
+      const result = parseImportText('bad\ngood,line\nalso bad\nanother,good')
+      expect(result.rows).toHaveLength(2)
+      expect(result.errors).toHaveLength(2)
+    })
+
+    it('should return empty result for empty input', () => {
+      const result = parseImportText('')
+      expect(result.rows).toHaveLength(0)
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('should return empty result for whitespace-only input', () => {
+      const result = parseImportText('   \n  \n  ')
+      expect(result.rows).toHaveLength(0)
+      expect(result.errors).toHaveLength(0)
+    })
+  })
+
+  describe('Latvian diacritics', () => {
+    it('should preserve Latvian diacritics in source and target', () => {
+      const result = parseImportText('ābols,apple\nčau,bye')
+      expect(result.rows[0]).toMatchObject({ source: 'ābols', target: 'apple' })
+      expect(result.rows[1]).toMatchObject({ source: 'čau', target: 'bye' })
+    })
+
+    it('should preserve full diacritic set: ā č ē ģ ī ķ ļ ņ š ū ž', () => {
+      const source = 'āčēģīķļņšūž'
+      const result = parseImportText(`${source},test`)
+      expect(result.rows[0].source).toBe(source)
+    })
+  })
+
+  describe('lineNumber tracking', () => {
+    it('should report correct 1-based line numbers', () => {
+      const result = parseImportText('a,b\nbad\nc,d')
+      expect(result.rows[0].lineNumber).toBe(1)
+      expect(result.errors[0].lineNumber).toBe(2)
+      expect(result.rows[1].lineNumber).toBe(3)
+    })
+
+    it('should track line numbers correctly when skipping blank lines', () => {
+      const result = parseImportText('\na,b\n\nbad\nc,d')
+      expect(result.rows[0].lineNumber).toBe(2)
+      expect(result.errors[0].lineNumber).toBe(4)
+      expect(result.rows[1].lineNumber).toBe(5)
+    })
+  })
+})
+
+describe('findDuplicateLineNumbers', () => {
+  const existingWords = [
+    { source: 'hello', target: 'world' },
+    { source: 'Cat', target: 'KATZE' },
+  ]
+
+  it('should detect exact duplicate', () => {
+    const rows = [{ source: 'hello', target: 'world', notes: null, lineNumber: 1 }]
+    const dupes = findDuplicateLineNumbers(rows, existingWords)
+    expect(dupes.has(1)).toBe(true)
+  })
+
+  it('should detect case-insensitive duplicates', () => {
+    const rows = [
+      { source: 'HELLO', target: 'WORLD', notes: null, lineNumber: 1 },
+      { source: 'cat', target: 'katze', notes: null, lineNumber: 2 },
+    ]
+    const dupes = findDuplicateLineNumbers(rows, existingWords)
+    expect(dupes.has(1)).toBe(true)
+    expect(dupes.has(2)).toBe(true)
+  })
+
+  it('should not flag non-duplicates', () => {
+    const rows = [{ source: 'dog', target: 'Hund', notes: null, lineNumber: 1 }]
+    const dupes = findDuplicateLineNumbers(rows, existingWords)
+    expect(dupes.has(1)).toBe(false)
+  })
+
+  it('should return empty set for empty rows', () => {
+    const dupes = findDuplicateLineNumbers([], existingWords)
+    expect(dupes.size).toBe(0)
+  })
+
+  it('should return empty set when no existing words', () => {
+    const rows = [{ source: 'hello', target: 'world', notes: null, lineNumber: 1 }]
+    const dupes = findDuplicateLineNumbers(rows, [])
+    expect(dupes.size).toBe(0)
+  })
+
+  it('should only mark a row as duplicate if both source and target match', () => {
+    const rows = [
+      { source: 'hello', target: 'different', notes: null, lineNumber: 1 },
+      { source: 'different', target: 'world', notes: null, lineNumber: 2 },
+    ]
+    const dupes = findDuplicateLineNumbers(rows, existingWords)
+    expect(dupes.size).toBe(0)
+  })
+})

--- a/src/utils/importParser.ts
+++ b/src/utils/importParser.ts
@@ -1,0 +1,127 @@
+/**
+ * Utilities for parsing bulk word import text in CSV, TSV, and semicolon-separated formats.
+ * Auto-detects the delimiter based on the content of the first non-empty line.
+ */
+
+export type ParsedWordRow = {
+  readonly source: string
+  readonly target: string
+  readonly notes: string | null
+  /** 1-based line number in the original input. */
+  readonly lineNumber: number
+}
+
+export type ParseErrorRow = {
+  readonly raw: string
+  readonly lineNumber: number
+  readonly reason: string
+}
+
+export type ParseResult = {
+  readonly rows: readonly ParsedWordRow[]
+  readonly errors: readonly ParseErrorRow[]
+}
+
+/** Supported delimiters in detection priority order. */
+const DELIMITERS = ['\t', ',', ';'] as const
+type Delimiter = (typeof DELIMITERS)[number]
+
+/**
+ * Detect the most likely delimiter by counting occurrences across the first
+ * few non-empty lines. The delimiter that appears most consistently wins.
+ */
+function detectDelimiter(lines: readonly string[]): Delimiter {
+  const sample = lines.filter((l) => l.trim().length > 0).slice(0, 10)
+
+  if (sample.length === 0) return ','
+
+  const counts = DELIMITERS.map((d) => {
+    const total = sample.reduce((sum, line) => {
+      // Count occurrences of delimiter in this line.
+      return sum + (line.split(d).length - 1)
+    }, 0)
+    return { delimiter: d, total }
+  })
+
+  // Pick the delimiter with the highest total count.
+  const best = counts.reduce((prev, curr) => (curr.total > prev.total ? curr : prev))
+
+  // Fall back to comma if nothing was detected.
+  return best.total > 0 ? best.delimiter : ','
+}
+
+/**
+ * Parse a raw multi-line string into word rows.
+ *
+ * Supported formats (auto-detected):
+ * - Tab-separated:       source<TAB>target[<TAB>notes]
+ * - Comma-separated:     source,target[,notes]
+ * - Semicolon-separated: source;target[;notes]
+ *
+ * Rules:
+ * - Empty lines are skipped.
+ * - Leading/trailing whitespace is trimmed from each field.
+ * - Lines with fewer than 2 non-empty fields are recorded as errors.
+ * - A third field (if present) is treated as notes.
+ * - Fields beyond the third are ignored.
+ */
+export function parseImportText(rawText: string): ParseResult {
+  const rawLines = rawText.split(/\r?\n/)
+  const nonEmptyLines = rawLines.filter((l) => l.trim().length > 0)
+
+  const delimiter = detectDelimiter(nonEmptyLines)
+
+  const rows: ParsedWordRow[] = []
+  const errors: ParseErrorRow[] = []
+
+  rawLines.forEach((line, index) => {
+    const lineNumber = index + 1
+
+    // Skip blank lines.
+    if (line.trim().length === 0) return
+
+    const parts = line.split(delimiter).map((p) => p.trim())
+    const source = parts[0] ?? ''
+    const target = parts[1] ?? ''
+
+    if (source.length === 0 || target.length === 0) {
+      errors.push({
+        raw: line,
+        lineNumber,
+        reason: 'Could not find both source and target values.',
+      })
+      return
+    }
+
+    const notes = parts[2] && parts[2].length > 0 ? parts[2] : null
+
+    rows.push({ source, target, notes, lineNumber })
+  })
+
+  return { rows, errors }
+}
+
+/**
+ * Given a list of parsed rows and a set of existing (source, target) pairs,
+ * return a Set of lineNumbers that are duplicates.
+ *
+ * Comparison is case-insensitive and whitespace-trimmed.
+ */
+export function findDuplicateLineNumbers(
+  rows: readonly ParsedWordRow[],
+  existingWords: ReadonlyArray<{ readonly source: string; readonly target: string }>,
+): ReadonlySet<number> {
+  const existingKeys = new Set(
+    existingWords.map((w) => `${w.source.trim().toLowerCase()}||${w.target.trim().toLowerCase()}`),
+  )
+
+  const duplicates = new Set<number>()
+  for (const row of rows) {
+    const key = `${row.source.toLowerCase()}||${row.target.toLowerCase()}`
+    if (existingKeys.has(key)) {
+      duplicates.add(row.lineNumber)
+    }
+  }
+
+  return duplicates
+}


### PR DESCRIPTION
## Summary

- Add `src/utils/importParser.ts` - parser utility that auto-detects delimiter (tab, comma, semicolon), trims whitespace, supports optional notes field, and detects case-insensitive duplicates
- Add `src/features/words/components/ImportWordsDialog.tsx` - 3-step dialog: paste input → preview table with duplicate highlights and row deselection → import summary
- Update `src/features/words/components/WordListScreen.tsx` - Import button added to both the empty state and the populated header; imported words saved with `"imported"` tag

## Changes

- `src/utils/importParser.ts` - `parseImportText()` and `findDuplicateLineNumbers()` utilities
- `src/utils/importParser.test.ts` - 33 unit tests covering all formats, edge cases, line endings, diacritics
- `src/features/words/components/ImportWordsDialog.tsx` - multi-step import dialog
- `src/features/words/components/ImportWordsDialog.test.tsx` - 24 component tests
- `src/features/words/components/WordListScreen.tsx` - Import button + dialog wiring
- `src/features/words/components/index.ts` - export `ImportWordsDialog`
- `src/features/words/index.ts` - re-export `ImportWordsDialog` and `ImportSummary`

## Testing

- 594 tests pass (57 new tests added)
- TypeScript strict: no errors
- ESLint: 0 warnings
- Prettier: all files formatted
- Production build: successful

## Review

- Code review passed (see issue #7 comments)

Closes #7