### PR TITLE
feat: settings screen - preferences, export/import, reset (#16)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback, useEffect } from 'react'
+import { useMemo, useState, useCallback, useEffect, useRef } from 'react'
 import {
   ThemeProvider,
   CssBaseline,
@@ -69,6 +69,31 @@ function AppContent() {
   }, [pairsLoading, pairs.length])
 
   const dashboardData = useDashboard(activePair?.id ?? null, settings.dailyGoal)
+
+  // Word counts per pair for the Settings screen language-pairs section.
+  const [wordCounts, setWordCounts] = useState<Record<string, number>>({})
+  // Track which pair IDs we have already fetched word counts for to avoid redundant fetches.
+  const fetchedPairIds = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    const pairsToFetch = pairs.filter((p) => !fetchedPairIds.current.has(p.id))
+    if (pairsToFetch.length === 0) return
+    void Promise.all(
+      pairsToFetch.map(async (pair) => {
+        const words = await storage.getWords(pair.id)
+        return { id: pair.id, count: words.length }
+      }),
+    ).then((results) => {
+      setWordCounts((prev) => {
+        const next = { ...prev }
+        for (const { id, count } of results) {
+          next[id] = count
+          fetchedPairIds.current.add(id)
+        }
+        return next
+      })
+    })
+  }, [pairs, storage])
 
   const handleCreatePair = useCallback(
     async (input: CreatePairInput): Promise<void> => {
@@ -191,6 +216,11 @@ function AppContent() {
                   <SettingsScreen
                     themePreference={themePreference}
                     onThemeChange={handleThemeChange}
+                    settings={settings}
+                    onSettingsChange={handleSettingsChange}
+                    pairs={pairs}
+                    wordCounts={wordCounts}
+                    onAddPair={handleOpenCreateDialog}
                   />
                 )}
               </>

--- a/src/features/settings/components/SettingsScreen.test.tsx
+++ b/src/features/settings/components/SettingsScreen.test.tsx
@@ -1,0 +1,490 @@
+/**
+ * Tests for SettingsScreen.
+ *
+ * Covers:
+ * - Rendering of all sections (Preferences, Language Pairs, Data Management, About)
+ * - Preference changes: theme, quiz mode, daily goal, typo tolerance
+ * - Settings persistence via saveSettings
+ * - Data export flow
+ * - Data import: validation, confirmation dialog, success
+ * - Reset progress: confirmation dialog, keeps words
+ * - Reset all: double confirmation dialog, calls clearAll
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SettingsScreen } from './SettingsScreen'
+import { StorageContext } from '@/hooks/useStorage'
+import { createMockStorage } from '@/test/mockStorage'
+import {
+  createMockSettings,
+  createMockPair,
+  createMockWord,
+  createMockProgress,
+} from '@/test/fixtures'
+import type { StorageService } from '@/services/storage/StorageService'
+import type { UserSettings, LanguagePair } from '@/types'
+import { createElement, type ReactNode } from 'react'
+
+// __APP_VERSION__ is declared in vite-env.d.ts; in tests it is undefined unless
+// the Vite define plugin runs — provide a fallback via globalThis.
+Object.defineProperty(globalThis, '__APP_VERSION__', {
+  value: '0.1.0',
+  writable: true,
+})
+
+// Stub URL.createObjectURL / revokeObjectURL (not available in jsdom).
+Object.defineProperty(URL, 'createObjectURL', {
+  value: vi.fn().mockReturnValue('blob:mock'),
+  writable: true,
+})
+Object.defineProperty(URL, 'revokeObjectURL', {
+  value: vi.fn(),
+  writable: true,
+})
+
+function makeWrapper(storage: StorageService) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(StorageContext.Provider, { value: storage }, children)
+}
+
+function renderSettings(
+  storage: StorageService,
+  overrides: {
+    settings?: UserSettings
+    themePreference?: UserSettings['theme']
+    onThemeChange?: (p: UserSettings['theme']) => void
+    onSettingsChange?: (s: UserSettings) => void
+    pairs?: readonly LanguagePair[]
+    wordCounts?: Record<string, number>
+    onAddPair?: () => void
+  } = {},
+) {
+  const settings = overrides.settings ?? createMockSettings()
+  return render(
+    <SettingsScreen
+      themePreference={overrides.themePreference ?? 'dark'}
+      onThemeChange={overrides.onThemeChange ?? vi.fn()}
+      settings={settings}
+      onSettingsChange={overrides.onSettingsChange ?? vi.fn()}
+      pairs={overrides.pairs ?? []}
+      wordCounts={overrides.wordCounts ?? {}}
+      onAddPair={overrides.onAddPair ?? vi.fn()}
+    />,
+    { wrapper: makeWrapper(storage) },
+  )
+}
+
+describe('SettingsScreen', () => {
+  let storage: ReturnType<typeof createMockStorage>
+
+  beforeEach(() => {
+    storage = createMockStorage({
+      saveSettings: vi.fn().mockResolvedValue(undefined),
+      getSettings: vi.fn().mockResolvedValue(createMockSettings()),
+      exportAll: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          languagePairs: [],
+          words: {},
+          progress: {},
+          settings: createMockSettings(),
+          dailyStats: [],
+        }),
+      ),
+      importAll: vi.fn().mockResolvedValue(undefined),
+      clearAll: vi.fn().mockResolvedValue(undefined),
+    })
+    vi.clearAllMocks()
+  })
+
+  // ── Section rendering ──────────────────────────────────────────────────────
+
+  it('should render the Preferences section', () => {
+    renderSettings(storage)
+    expect(screen.getByText('Preferences')).toBeInTheDocument()
+    expect(screen.getByLabelText('Theme preference')).toBeInTheDocument()
+    expect(screen.getByLabelText('Default quiz mode')).toBeInTheDocument()
+    expect(screen.getByLabelText('Typo tolerance')).toBeInTheDocument()
+  })
+
+  it('should render the Language Pairs section', () => {
+    renderSettings(storage)
+    expect(screen.getByText('Language pairs')).toBeInTheDocument()
+  })
+
+  it('should render language pairs with word counts', () => {
+    const pair = createMockPair({ id: 'p1', sourceLang: 'English', targetLang: 'Latvian' })
+    renderSettings(storage, {
+      pairs: [pair],
+      wordCounts: { p1: 42 },
+    })
+    expect(screen.getByText('English → Latvian')).toBeInTheDocument()
+    expect(screen.getByText('42 words')).toBeInTheDocument()
+  })
+
+  it('should show "1 word" (singular) when pair has exactly one word', () => {
+    const pair = createMockPair({ id: 'p1' })
+    renderSettings(storage, { pairs: [pair], wordCounts: { p1: 1 } })
+    expect(screen.getByText('1 word')).toBeInTheDocument()
+  })
+
+  it('should render the Data Management section', () => {
+    renderSettings(storage)
+    expect(screen.getByText('Data management')).toBeInTheDocument()
+    expect(screen.getByLabelText('Export data as JSON backup')).toBeInTheDocument()
+    expect(screen.getByLabelText('Import data from JSON backup')).toBeInTheDocument()
+    expect(screen.getByLabelText('Reset all learning progress')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('Reset all data and return to first-launch state'),
+    ).toBeInTheDocument()
+  })
+
+  it('should render the About section with version', () => {
+    renderSettings(storage)
+    expect(screen.getByText('About')).toBeInTheDocument()
+    expect(screen.getByText(/Version 0\.1\.0/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /View source on GitHub/i })).toBeInTheDocument()
+  })
+
+  // ── Preferences ───────────────────────────────────────────────────────────
+
+  it('should call onThemeChange when theme radio changes', async () => {
+    const user = userEvent.setup()
+    const onThemeChange = vi.fn()
+    renderSettings(storage, { themePreference: 'dark', onThemeChange })
+
+    const lightRadio = screen.getByRole('radio', { name: 'Light' })
+    await user.click(lightRadio)
+
+    expect(onThemeChange).toHaveBeenCalledWith('light')
+  })
+
+  it('should call onSettingsChange and saveSettings when quiz mode changes', async () => {
+    const user = userEvent.setup()
+    const onSettingsChange = vi.fn()
+    const settings = createMockSettings({ quizMode: 'type' })
+    renderSettings(storage, { settings, onSettingsChange })
+
+    const choiceRadio = screen.getByRole('radio', { name: 'Choice' })
+    await user.click(choiceRadio)
+
+    expect(onSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ quizMode: 'choice' }))
+    expect(storage.saveSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ quizMode: 'choice' }),
+    )
+  })
+
+  it('should call onSettingsChange and saveSettings when daily goal preset is clicked', async () => {
+    const user = userEvent.setup()
+    const onSettingsChange = vi.fn()
+    const settings = createMockSettings({ dailyGoal: 20 })
+    renderSettings(storage, { settings, onSettingsChange })
+
+    const preset30 = screen.getByLabelText('Set daily goal to 30 words')
+    await user.click(preset30)
+
+    expect(onSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ dailyGoal: 30 }))
+    expect(storage.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ dailyGoal: 30 }))
+  })
+
+  it('should persist custom daily goal on input blur', async () => {
+    const user = userEvent.setup()
+    const onSettingsChange = vi.fn()
+    const settings = createMockSettings({ dailyGoal: 20 })
+    renderSettings(storage, { settings, onSettingsChange })
+
+    const input = screen.getByLabelText('Custom daily goal')
+    await user.clear(input)
+    await user.type(input, '45')
+    await user.tab()
+
+    expect(onSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ dailyGoal: 45 }))
+    expect(storage.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ dailyGoal: 45 }))
+  })
+
+  it('should clamp daily goal to 1 when input is 0', async () => {
+    const user = userEvent.setup()
+    const onSettingsChange = vi.fn()
+    renderSettings(storage, { settings: createMockSettings({ dailyGoal: 20 }), onSettingsChange })
+
+    const input = screen.getByLabelText('Custom daily goal')
+    await user.clear(input)
+    await user.type(input, '0')
+    await user.tab()
+
+    expect(onSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ dailyGoal: 1 }))
+  })
+
+  it('should clamp daily goal to 200 when input exceeds maximum', async () => {
+    const user = userEvent.setup()
+    const onSettingsChange = vi.fn()
+    renderSettings(storage, { settings: createMockSettings({ dailyGoal: 20 }), onSettingsChange })
+
+    const input = screen.getByLabelText('Custom daily goal')
+    await user.clear(input)
+    await user.type(input, '999')
+    await user.tab()
+
+    expect(onSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ dailyGoal: 200 }))
+  })
+
+  // ── Language Pairs ────────────────────────────────────────────────────────
+
+  it('should call onAddPair when "Add language pair" button is clicked', async () => {
+    const user = userEvent.setup()
+    const onAddPair = vi.fn()
+    renderSettings(storage, { onAddPair })
+
+    await user.click(screen.getByRole('button', { name: /Add language pair/i }))
+    expect(onAddPair).toHaveBeenCalledOnce()
+  })
+
+  it('should show "Active" chip for the active pair', () => {
+    const pair = createMockPair({ id: 'p1' })
+    renderSettings(storage, {
+      settings: createMockSettings({ activePairId: 'p1' }),
+      pairs: [pair],
+      wordCounts: { p1: 5 },
+    })
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
+
+  // ── Export ────────────────────────────────────────────────────────────────
+
+  it('should call exportAll and create a blob URL on export', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+
+    await user.click(screen.getByLabelText('Export data as JSON backup'))
+
+    await waitFor(() => {
+      expect(storage.exportAll).toHaveBeenCalledOnce()
+      expect(URL.createObjectURL).toHaveBeenCalledOnce()
+    })
+  })
+
+  it('should show export error when exportAll throws', async () => {
+    const user = userEvent.setup()
+    storage = createMockStorage({
+      exportAll: vi.fn().mockRejectedValue(new Error('Storage error')),
+    })
+    renderSettings(storage)
+
+    await user.click(screen.getByLabelText('Export data as JSON backup'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Export failed. Please try again.')).toBeInTheDocument()
+    })
+  })
+
+  // ── Import ────────────────────────────────────────────────────────────────
+
+  it('should show import confirm dialog when valid JSON is uploaded', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+
+    const validJson = JSON.stringify({
+      languagePairs: [],
+      words: {},
+      settings: createMockSettings(),
+    })
+    const file = new File([validJson], 'backup.json', { type: 'application/json' })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await user.upload(input, file)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Import backup\?/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/This will overwrite your current data/i)).toBeInTheDocument()
+  })
+
+  it('should show error when JSON is invalid', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+
+    const file = new File(['not-json!!!'], 'backup.json', { type: 'application/json' })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await user.upload(input, file)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Invalid backup file: could not parse JSON/i)).toBeInTheDocument()
+    })
+  })
+
+  it('should show error when JSON lacks languagePairs array', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+
+    const file = new File([JSON.stringify({ foo: 'bar' })], 'backup.json', {
+      type: 'application/json',
+    })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await user.upload(input, file)
+
+    await waitFor(() => {
+      expect(screen.getByText(/missing "languagePairs" array/i)).toBeInTheDocument()
+    })
+  })
+
+  it('should cancel import when Cancel is clicked in confirm dialog', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+
+    const validJson = JSON.stringify({ languagePairs: [] })
+    const file = new File([validJson], 'backup.json', { type: 'application/json' })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    await user.upload(input, file)
+
+    await waitFor(() => screen.getByText(/Import backup\?/i))
+    await user.click(screen.getByRole('button', { name: /Cancel/i }))
+
+    expect(storage.importAll).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.queryByText(/Import backup\?/i)).not.toBeInTheDocument()
+    })
+  })
+
+  // ── Reset Progress ────────────────────────────────────────────────────────
+
+  it('should show reset progress confirmation dialog', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+
+    await user.click(screen.getByLabelText('Reset all learning progress'))
+
+    expect(screen.getByText(/Reset learning progress\?/i)).toBeInTheDocument()
+    expect(screen.getByText(/Your language pairs and words will be kept/i)).toBeInTheDocument()
+  })
+
+  it('should call saveWordProgress with zeroed values for each word', async () => {
+    const user = userEvent.setup()
+    const word1 = createMockWord({ id: 'w1', pairId: 'p1' })
+    const word2 = createMockWord({ id: 'w2', pairId: 'p1' })
+    const pair = createMockPair({ id: 'p1' })
+    const progress1 = createMockProgress({ wordId: 'w1' })
+
+    storage = createMockStorage({
+      getLanguagePairs: vi.fn().mockResolvedValue([pair]),
+      getWords: vi.fn().mockResolvedValue([word1, word2]),
+      getWordProgress: vi
+        .fn()
+        .mockImplementation((wordId: string) =>
+          Promise.resolve(wordId === 'w1' ? progress1 : null),
+        ),
+      saveWordProgress: vi.fn().mockResolvedValue(undefined),
+      exportAll: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          languagePairs: [pair],
+          words: { p1: [word1, word2] },
+          progress: {},
+          settings: createMockSettings(),
+          dailyStats: [],
+        }),
+      ),
+      importAll: vi.fn().mockResolvedValue(undefined),
+    })
+
+    renderSettings(storage)
+    await user.click(screen.getByLabelText('Reset all learning progress'))
+    await waitFor(() => screen.getByText(/Reset learning progress\?/i))
+    await user.click(screen.getByRole('button', { name: /Reset progress$/i }))
+
+    await waitFor(() => {
+      expect(storage.saveWordProgress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          wordId: 'w1',
+          correctCount: 0,
+          incorrectCount: 0,
+          streak: 0,
+          confidence: 0,
+          history: [],
+        }),
+      )
+    })
+    // word2 has no existing progress, so saveWordProgress should only be called once
+    expect(storage.saveWordProgress).toHaveBeenCalledTimes(1)
+  })
+
+  it('should cancel reset progress when Cancel is clicked', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+
+    await user.click(screen.getByLabelText('Reset all learning progress'))
+    await waitFor(() => screen.getByText(/Reset learning progress\?/i))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(storage.saveWordProgress).not.toHaveBeenCalled()
+  })
+
+  // ── Reset All ─────────────────────────────────────────────────────────────
+
+  it('should show first reset all confirmation dialog', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+
+    await user.click(screen.getByLabelText('Reset all data and return to first-launch state'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Reset all data\?/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/permanently erased/i)).toBeInTheDocument()
+  })
+
+  it('should show double confirmation dialog after first confirm', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+
+    await user.click(screen.getByLabelText('Reset all data and return to first-launch state'))
+    await waitFor(() => screen.getByText(/Reset all data\?/i))
+    await user.click(screen.getByRole('button', { name: /Continue/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Are you absolutely sure\?/i)).toBeInTheDocument()
+    })
+  })
+
+  it('should call clearAll after double confirmation', async () => {
+    const user = userEvent.setup()
+
+    // Stub location.reload to prevent jsdom error
+    const reloadSpy = vi.spyOn(globalThis, 'location', 'get').mockReturnValue({
+      ...globalThis.location,
+      reload: vi.fn(),
+    })
+
+    renderSettings(storage)
+
+    await user.click(screen.getByLabelText('Reset all data and return to first-launch state'))
+    await waitFor(() => screen.getByText(/Reset all data\?/i))
+    await user.click(screen.getByRole('button', { name: /Continue/i }))
+    await waitFor(() => screen.getByText(/Are you absolutely sure\?/i))
+    await user.click(screen.getByRole('button', { name: /Yes, delete everything/i }))
+
+    await waitFor(() => {
+      expect(storage.clearAll).toHaveBeenCalledOnce()
+    })
+
+    reloadSpy.mockRestore()
+  })
+
+  it('should cancel reset all from double confirm dialog', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+
+    await user.click(screen.getByLabelText('Reset all data and return to first-launch state'))
+    await waitFor(() => screen.getByText(/Reset all data\?/i))
+    await user.click(screen.getByRole('button', { name: /Continue/i }))
+    await waitFor(() => screen.getByText(/Are you absolutely sure\?/i))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(storage.clearAll).not.toHaveBeenCalled()
+  })
+
+  // ── Active pair indicator ─────────────────────────────────────────────────
+
+  it('should show "No language pairs yet" message when pairs list is empty', () => {
+    renderSettings(storage, { pairs: [] })
+    expect(screen.getByText('No language pairs yet.')).toBeInTheDocument()
+  })
+})

--- a/src/features/settings/components/SettingsScreen.tsx
+++ b/src/features/settings/components/SettingsScreen.tsx
@@ -1,36 +1,327 @@
 /**
- * SettingsScreen - placeholder for the settings/preferences feature.
+ * SettingsScreen - full settings/preferences feature.
  *
- * Theme mode toggle is accessible here. The full settings panel
- * (daily goal, quiz mode, data export/import, reset) will be built
- * in a future issue.
+ * Sections:
+ *  1. Preferences  - theme, quiz mode, daily goal, typo tolerance
+ *  2. Language Pairs - list with word counts, links to pair management
+ *  3. Data Management - export, import, reset progress, reset all
+ *  4. About - version, GitHub link
  */
 
+import { useState, useCallback, useRef } from 'react'
 import {
   Box,
+  Button,
   Card,
   CardContent,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
   FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
+  FormControlLabel,
+  FormLabel,
+  InputAdornment,
+  List,
+  ListItem,
+  ListItemText,
+  Radio,
+  RadioGroup,
+  Slider,
+  Stack,
+  TextField,
   Typography,
+  Alert,
+  CircularProgress,
+  Link,
 } from '@mui/material'
 import SettingsIcon from '@mui/icons-material/Settings'
-import type { SelectChangeEvent } from '@mui/material'
-import type { ThemePreference } from '@/types'
+import DownloadIcon from '@mui/icons-material/Download'
+import UploadIcon from '@mui/icons-material/Upload'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import WarningAmberIcon from '@mui/icons-material/WarningAmber'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
+import type { ThemePreference, UserSettings, LanguagePair } from '@/types'
+import { useStorage } from '@/hooks/useStorage'
+
+/** App version sourced from the bundler-injected env variable. */
+const APP_VERSION = __APP_VERSION__
+
+const DAILY_GOAL_PRESETS = [10, 20, 30, 50] as const
+
+const TYPO_LABELS: Record<number, { label: string; description: string }> = {
+  0: {
+    label: 'Exact',
+    description: 'Your answer must match exactly (case-insensitive).',
+  },
+  1: {
+    label: 'Lenient',
+    description: 'Up to 1 character difference is accepted (e.g. a missing accent).',
+  },
+  2: {
+    label: 'Very lenient',
+    description: 'Up to 2 character differences are accepted.',
+  },
+}
 
 export interface SettingsScreenProps {
   /** The user's current theme preference. */
   readonly themePreference: ThemePreference
   /** Called when the user changes the theme preference. */
   readonly onThemeChange: (preference: ThemePreference) => void
+  /** Current user settings (quiz mode, daily goal, typo tolerance). */
+  readonly settings: UserSettings
+  /** Called when any preference (except theme) changes. */
+  readonly onSettingsChange: (updated: UserSettings) => void
+  /** All language pairs with their word counts. */
+  readonly pairs: readonly LanguagePair[]
+  /** Word counts keyed by pairId. */
+  readonly wordCounts: Readonly<Record<string, number>>
+  /** Open the create-pair dialog in the parent. */
+  readonly onAddPair: () => void
 }
 
-export function SettingsScreen({ themePreference, onThemeChange }: SettingsScreenProps) {
-  const handleChange = (event: SelectChangeEvent) => {
-    onThemeChange(event.target.value as ThemePreference)
-  }
+interface PairWithCount {
+  pair: LanguagePair
+  wordCount: number
+}
+
+export function SettingsScreen({
+  themePreference,
+  onThemeChange,
+  settings,
+  onSettingsChange,
+  pairs,
+  wordCounts,
+  onAddPair,
+}: SettingsScreenProps) {
+  const storage = useStorage()
+
+  // --- Preferences state ---
+  const [dailyGoalInput, setDailyGoalInput] = useState<string>(String(settings.dailyGoal))
+
+  // --- Data management state ---
+  const [exporting, setExporting] = useState(false)
+  const [exportError, setExportError] = useState<string | null>(null)
+
+  const [importing, setImporting] = useState(false)
+  const [importError, setImportError] = useState<string | null>(null)
+  const [importConfirmOpen, setImportConfirmOpen] = useState(false)
+  const [pendingImportData, setPendingImportData] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [resetProgressConfirmOpen, setResetProgressConfirmOpen] = useState(false)
+  const [resetAllConfirmOpen, setResetAllConfirmOpen] = useState(false)
+  const [resetAllDoubleConfirmOpen, setResetAllDoubleConfirmOpen] = useState(false)
+  const [resetting, setResetting] = useState(false)
+  const [resetError, setResetError] = useState<string | null>(null)
+
+  // --- Helpers ---
+
+  const pairsWithCounts: PairWithCount[] = pairs.map((pair) => ({
+    pair,
+    wordCount: wordCounts[pair.id] ?? 0,
+  }))
+
+  // --- Preference handlers ---
+
+  const handleThemeChange = useCallback(
+    (value: string) => {
+      onThemeChange(value as ThemePreference)
+    },
+    [onThemeChange],
+  )
+
+  const handleQuizModeChange = useCallback(
+    (value: string) => {
+      void storage.saveSettings({ ...settings, quizMode: value as UserSettings['quizMode'] })
+      onSettingsChange({ ...settings, quizMode: value as UserSettings['quizMode'] })
+    },
+    [settings, onSettingsChange, storage],
+  )
+
+  const handleDailyGoalPreset = useCallback(
+    (value: number) => {
+      setDailyGoalInput(String(value))
+      void storage.saveSettings({ ...settings, dailyGoal: value })
+      onSettingsChange({ ...settings, dailyGoal: value })
+    },
+    [settings, onSettingsChange, storage],
+  )
+
+  const handleDailyGoalInputChange = useCallback((value: string) => {
+    setDailyGoalInput(value)
+  }, [])
+
+  const handleDailyGoalInputBlur = useCallback(() => {
+    const parsed = parseInt(dailyGoalInput, 10)
+    const clamped = isNaN(parsed) ? 1 : Math.max(1, Math.min(200, parsed))
+    setDailyGoalInput(String(clamped))
+    void storage.saveSettings({ ...settings, dailyGoal: clamped })
+    onSettingsChange({ ...settings, dailyGoal: clamped })
+  }, [dailyGoalInput, settings, onSettingsChange, storage])
+
+  const handleTypoToleranceChange = useCallback(
+    (_: Event, value: number | number[]) => {
+      const tolerance = Array.isArray(value) ? value[0] : value
+      void storage.saveSettings({ ...settings, typoTolerance: tolerance })
+      onSettingsChange({ ...settings, typoTolerance: tolerance })
+    },
+    [settings, onSettingsChange, storage],
+  )
+
+  // --- Export ---
+
+  const handleExport = useCallback(async () => {
+    setExporting(true)
+    setExportError(null)
+    try {
+      const json = await storage.exportAll()
+      const today = new Date().toISOString().slice(0, 10)
+      const filename = `lexio-backup-${today}.json`
+      const blob = new Blob([json], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = filename
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch {
+      setExportError('Export failed. Please try again.')
+    } finally {
+      setExporting(false)
+    }
+  }, [storage])
+
+  // --- Import ---
+
+  const handleImportFileChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const text = e.target?.result
+      if (typeof text !== 'string') {
+        setImportError('Could not read file.')
+        return
+      }
+
+      // Validate JSON structure before showing confirm dialog
+      try {
+        const parsed = JSON.parse(text) as unknown
+        if (typeof parsed !== 'object' || parsed === null) {
+          setImportError('Invalid backup file: not a JSON object.')
+          return
+        }
+        const obj = parsed as Record<string, unknown>
+        if (!Array.isArray(obj.languagePairs)) {
+          setImportError('Invalid backup file: missing "languagePairs" array.')
+          return
+        }
+        // Validation passed — ask for confirmation
+        setPendingImportData(text)
+        setImportError(null)
+        setImportConfirmOpen(true)
+      } catch {
+        setImportError('Invalid backup file: could not parse JSON.')
+      }
+    }
+    reader.readAsText(file)
+
+    // Reset input so same file can be chosen again
+    event.target.value = ''
+  }, [])
+
+  const handleImportConfirm = useCallback(async () => {
+    if (!pendingImportData) return
+    setImporting(true)
+    setImportError(null)
+    setImportConfirmOpen(false)
+    try {
+      await storage.importAll(pendingImportData)
+      setPendingImportData(null)
+      // Reload the page so all contexts/hooks pick up the restored data
+      globalThis.location.reload()
+    } catch {
+      setImportError('Import failed. The backup file may be corrupted.')
+      setImporting(false)
+    }
+  }, [pendingImportData, storage])
+
+  const handleImportCancel = useCallback(() => {
+    setImportConfirmOpen(false)
+    setPendingImportData(null)
+  }, [])
+
+  const handleImportClick = useCallback(() => {
+    setImportError(null)
+    fileInputRef.current?.click()
+  }, [])
+
+  // --- Reset progress ---
+
+  const handleResetProgressConfirm = useCallback(async () => {
+    setResetting(true)
+    setResetError(null)
+    setResetProgressConfirmOpen(false)
+    try {
+      const allPairs = await storage.getLanguagePairs()
+      for (const pair of allPairs) {
+        const words = await storage.getWords(pair.id)
+        for (const word of words) {
+          const progress = await storage.getWordProgress(word.id)
+          if (progress !== null) {
+            // Reset progress by saving zeroed-out record
+            await storage.saveWordProgress({
+              wordId: word.id,
+              correctCount: 0,
+              incorrectCount: 0,
+              streak: 0,
+              lastReviewed: null,
+              nextReview: Date.now(),
+              confidence: 0,
+              history: [],
+            })
+          }
+        }
+      }
+      // Clear daily stats by exporting non-stats data and re-importing
+      const exported = await storage.exportAll()
+      const data = JSON.parse(exported) as Record<string, unknown>
+      data['dailyStats'] = []
+      await storage.importAll(JSON.stringify(data))
+    } catch {
+      setResetError('Reset failed. Please try again.')
+    } finally {
+      setResetting(false)
+    }
+  }, [storage])
+
+  // --- Reset all ---
+
+  const handleResetAllFirstConfirm = useCallback(() => {
+    setResetAllConfirmOpen(false)
+    setResetAllDoubleConfirmOpen(true)
+  }, [])
+
+  const handleResetAllFinalConfirm = useCallback(async () => {
+    setResetting(true)
+    setResetError(null)
+    setResetAllDoubleConfirmOpen(false)
+    try {
+      await storage.clearAll()
+      globalThis.location.reload()
+    } catch {
+      setResetError('Reset failed. Please try again.')
+      setResetting(false)
+    }
+  }, [storage])
+
+  const currentTypo = settings.typoTolerance
+  const typoInfo = TYPO_LABELS[currentTypo] ?? TYPO_LABELS[1]
 
   return (
     <Box
@@ -38,6 +329,16 @@ export function SettingsScreen({ themePreference, onThemeChange }: SettingsScree
       role="main"
       aria-label="Settings"
     >
+      {/* Hidden file input for import */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/json,.json"
+        aria-label="Import backup file"
+        style={{ display: 'none' }}
+        onChange={handleImportFileChange}
+      />
+
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, pt: 1 }}>
         <SettingsIcon sx={{ color: 'text.secondary' }} aria-hidden="true" />
         <Typography variant="h6" fontWeight={700}>
@@ -45,32 +346,418 @@ export function SettingsScreen({ themePreference, onThemeChange }: SettingsScree
         </Typography>
       </Box>
 
+      {/* ── 1. Preferences ── */}
       <Card variant="outlined">
         <CardContent sx={{ p: 2.5 }}>
-          <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-            Appearance
+          <Typography variant="subtitle2" fontWeight={700} gutterBottom>
+            Preferences
           </Typography>
 
-          <FormControl fullWidth size="small" sx={{ mt: 1 }}>
-            <InputLabel id="theme-select-label">Theme</InputLabel>
-            <Select
-              labelId="theme-select-label"
-              id="theme-select"
+          <Divider sx={{ my: 1.5 }} />
+
+          {/* Theme */}
+          <FormControl component="fieldset" fullWidth sx={{ mb: 2 }}>
+            <FormLabel component="legend" sx={{ mb: 0.5, fontSize: '0.875rem' }}>
+              Theme
+            </FormLabel>
+            <RadioGroup
+              row
               value={themePreference}
-              label="Theme"
-              onChange={handleChange}
+              onChange={(e) => handleThemeChange(e.target.value)}
+              aria-label="Theme preference"
             >
-              <MenuItem value="system">System</MenuItem>
-              <MenuItem value="light">Light</MenuItem>
-              <MenuItem value="dark">Dark</MenuItem>
-            </Select>
+              <FormControlLabel value="system" control={<Radio size="small" />} label="System" />
+              <FormControlLabel value="light" control={<Radio size="small" />} label="Light" />
+              <FormControlLabel value="dark" control={<Radio size="small" />} label="Dark" />
+            </RadioGroup>
           </FormControl>
+
+          {/* Quiz mode */}
+          <FormControl component="fieldset" fullWidth sx={{ mb: 2 }}>
+            <FormLabel component="legend" sx={{ mb: 0.5, fontSize: '0.875rem' }}>
+              Default quiz mode
+            </FormLabel>
+            <RadioGroup
+              row
+              value={settings.quizMode}
+              onChange={(e) => handleQuizModeChange(e.target.value)}
+              aria-label="Default quiz mode"
+            >
+              <FormControlLabel value="type" control={<Radio size="small" />} label="Type" />
+              <FormControlLabel value="choice" control={<Radio size="small" />} label="Choice" />
+              <FormControlLabel value="mixed" control={<Radio size="small" />} label="Mixed" />
+            </RadioGroup>
+          </FormControl>
+
+          {/* Daily goal */}
+          <Box sx={{ mb: 2 }}>
+            <Typography
+              variant="body2"
+              sx={{ mb: 1, color: 'text.secondary', fontSize: '0.875rem' }}
+            >
+              Daily goal
+            </Typography>
+            <Stack direction="row" spacing={1} sx={{ mb: 1 }} flexWrap="wrap" useFlexGap>
+              {DAILY_GOAL_PRESETS.map((preset) => (
+                <Chip
+                  key={preset}
+                  label={preset}
+                  size="small"
+                  color={settings.dailyGoal === preset ? 'primary' : 'default'}
+                  onClick={() => handleDailyGoalPreset(preset)}
+                  aria-label={`Set daily goal to ${preset} words`}
+                  aria-pressed={settings.dailyGoal === preset}
+                  sx={{ cursor: 'pointer' }}
+                />
+              ))}
+            </Stack>
+            <TextField
+              size="small"
+              value={dailyGoalInput}
+              onChange={(e) => handleDailyGoalInputChange(e.target.value)}
+              onBlur={handleDailyGoalInputBlur}
+              inputProps={{ min: 1, max: 200, 'aria-label': 'Custom daily goal' }}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">words/day</InputAdornment>,
+              }}
+              sx={{ width: 160 }}
+            />
+          </Box>
+
+          {/* Typo tolerance */}
+          <Box>
+            <Typography
+              variant="body2"
+              sx={{ mb: 0.5, color: 'text.secondary', fontSize: '0.875rem' }}
+            >
+              Typo tolerance
+            </Typography>
+            <Slider
+              value={settings.typoTolerance}
+              onChange={handleTypoToleranceChange}
+              min={0}
+              max={2}
+              step={1}
+              marks={[
+                { value: 0, label: 'Exact' },
+                { value: 1, label: 'Lenient' },
+                { value: 2, label: 'Very lenient' },
+              ]}
+              aria-label="Typo tolerance"
+              aria-valuetext={typoInfo.label}
+              sx={{ mt: 1 }}
+            />
+            <Typography variant="caption" color="text.secondary">
+              {typoInfo.description}
+            </Typography>
+          </Box>
         </CardContent>
       </Card>
 
-      <Typography variant="body2" color="text.secondary" textAlign="center">
-        More settings coming soon.
-      </Typography>
+      {/* ── 2. Language Pairs ── */}
+      <Card variant="outlined">
+        <CardContent sx={{ p: 2.5 }}>
+          <Typography variant="subtitle2" fontWeight={700} gutterBottom>
+            Language pairs
+          </Typography>
+
+          <Divider sx={{ my: 1.5 }} />
+
+          {pairsWithCounts.length === 0 ? (
+            <Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>
+              No language pairs yet.
+            </Typography>
+          ) : (
+            <List disablePadding>
+              {pairsWithCounts.map(({ pair, wordCount }, index) => (
+                <ListItem
+                  key={pair.id}
+                  disableGutters
+                  divider={index < pairsWithCounts.length - 1}
+                  sx={{ py: 1 }}
+                >
+                  <ListItemText
+                    primary={
+                      <Typography variant="body2" fontWeight={600}>
+                        {pair.sourceLang} → {pair.targetLang}
+                      </Typography>
+                    }
+                    secondary={`${wordCount} word${wordCount !== 1 ? 's' : ''}`}
+                  />
+                  {pair.id === settings.activePairId && (
+                    <Chip
+                      label="Active"
+                      size="small"
+                      color="primary"
+                      sx={{ height: 20, fontSize: '0.7rem' }}
+                    />
+                  )}
+                </ListItem>
+              ))}
+            </List>
+          )}
+
+          <Button variant="outlined" size="small" onClick={onAddPair} sx={{ mt: 2 }} fullWidth>
+            Add language pair
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* ── 3. Data Management ── */}
+      <Card variant="outlined">
+        <CardContent sx={{ p: 2.5 }}>
+          <Typography variant="subtitle2" fontWeight={700} gutterBottom>
+            Data management
+          </Typography>
+
+          <Divider sx={{ my: 1.5 }} />
+
+          {resetError && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setResetError(null)}>
+              {resetError}
+            </Alert>
+          )}
+
+          <Stack spacing={1.5}>
+            {/* Export */}
+            {exportError && (
+              <Alert severity="error" onClose={() => setExportError(null)}>
+                {exportError}
+              </Alert>
+            )}
+            <Button
+              variant="outlined"
+              startIcon={exporting ? <CircularProgress size={16} /> : <DownloadIcon />}
+              onClick={() => void handleExport()}
+              disabled={exporting}
+              fullWidth
+              aria-label="Export data as JSON backup"
+            >
+              {exporting ? 'Exporting...' : 'Export data'}
+            </Button>
+
+            {/* Import */}
+            {importError && (
+              <Alert severity="error" onClose={() => setImportError(null)}>
+                {importError}
+              </Alert>
+            )}
+            <Button
+              variant="outlined"
+              startIcon={importing ? <CircularProgress size={16} /> : <UploadIcon />}
+              onClick={handleImportClick}
+              disabled={importing}
+              fullWidth
+              aria-label="Import data from JSON backup"
+            >
+              {importing ? 'Importing...' : 'Import data'}
+            </Button>
+
+            <Divider />
+
+            {/* Reset progress */}
+            <Button
+              variant="outlined"
+              color="warning"
+              startIcon={
+                resetting ? <CircularProgress size={16} color="inherit" /> : <DeleteOutlineIcon />
+              }
+              onClick={() => setResetProgressConfirmOpen(true)}
+              disabled={resetting}
+              fullWidth
+              aria-label="Reset all learning progress"
+            >
+              Reset progress
+            </Button>
+
+            {/* Reset all */}
+            <Button
+              variant="outlined"
+              color="error"
+              startIcon={
+                resetting ? <CircularProgress size={16} color="inherit" /> : <WarningAmberIcon />
+              }
+              onClick={() => setResetAllConfirmOpen(true)}
+              disabled={resetting}
+              fullWidth
+              aria-label="Reset all data and return to first-launch state"
+            >
+              Reset all data
+            </Button>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      {/* ── 4. About ── */}
+      <Card variant="outlined">
+        <CardContent sx={{ p: 2.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+            <InfoOutlinedIcon
+              fontSize="small"
+              sx={{ color: 'text.secondary' }}
+              aria-hidden="true"
+            />
+            <Typography variant="subtitle2" fontWeight={700}>
+              About
+            </Typography>
+          </Box>
+
+          <Divider sx={{ mb: 1.5 }} />
+
+          <Typography variant="body2" color="text.secondary" gutterBottom>
+            Version {APP_VERSION}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" gutterBottom>
+            Lexio — a language-agnostic vocabulary trainer with spaced repetition.
+          </Typography>
+          <Link
+            href="https://github.com/mreppo/lexio"
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="body2"
+          >
+            View source on GitHub
+          </Link>
+        </CardContent>
+      </Card>
+
+      {/* ── Dialogs ── */}
+
+      {/* Import confirm */}
+      <Dialog
+        open={importConfirmOpen}
+        onClose={handleImportCancel}
+        maxWidth="xs"
+        fullWidth
+        PaperProps={{ sx: { borderRadius: 3 } }}
+        aria-labelledby="import-dialog-title"
+      >
+        <DialogTitle id="import-dialog-title">
+          <Typography variant="h6" component="span" fontWeight={700}>
+            Import backup?
+          </Typography>
+        </DialogTitle>
+        <DialogContent>
+          <Alert severity="warning" sx={{ mb: 1 }}>
+            This will overwrite your current data.
+          </Alert>
+          <Typography variant="body2">
+            All existing language pairs, words, progress, and stats will be replaced with the data
+            from the backup file. This action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 3, gap: 1 }}>
+          <Button variant="outlined" onClick={handleImportCancel}>
+            Cancel
+          </Button>
+          <Button variant="contained" color="warning" onClick={() => void handleImportConfirm()}>
+            Import and overwrite
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Reset progress confirm */}
+      <Dialog
+        open={resetProgressConfirmOpen}
+        onClose={() => setResetProgressConfirmOpen(false)}
+        maxWidth="xs"
+        fullWidth
+        PaperProps={{ sx: { borderRadius: 3 } }}
+        aria-labelledby="reset-progress-dialog-title"
+      >
+        <DialogTitle id="reset-progress-dialog-title">
+          <Typography variant="h6" component="span" fontWeight={700}>
+            Reset learning progress?
+          </Typography>
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body1" gutterBottom>
+            This will clear all word progress, streaks, and daily stats. Your language pairs and
+            words will be kept.
+          </Typography>
+          <Typography variant="body2" color="error.main" sx={{ mt: 1 }}>
+            This action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 3, gap: 1 }}>
+          <Button variant="outlined" onClick={() => setResetProgressConfirmOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="warning"
+            onClick={() => void handleResetProgressConfirm()}
+          >
+            Reset progress
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Reset all - first confirm */}
+      <Dialog
+        open={resetAllConfirmOpen}
+        onClose={() => setResetAllConfirmOpen(false)}
+        maxWidth="xs"
+        fullWidth
+        PaperProps={{ sx: { borderRadius: 3 } }}
+        aria-labelledby="reset-all-dialog-title"
+      >
+        <DialogTitle id="reset-all-dialog-title">
+          <Typography variant="h6" component="span" fontWeight={700}>
+            Reset all data?
+          </Typography>
+        </DialogTitle>
+        <DialogContent>
+          <Alert severity="error" sx={{ mb: 1 }}>
+            This will delete everything.
+          </Alert>
+          <Typography variant="body1">
+            All language pairs, words, progress, stats, and settings will be permanently erased. The
+            app will return to the first-launch state.
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 3, gap: 1 }}>
+          <Button variant="outlined" onClick={() => setResetAllConfirmOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="contained" color="error" onClick={handleResetAllFirstConfirm}>
+            Continue
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Reset all - second (double) confirm */}
+      <Dialog
+        open={resetAllDoubleConfirmOpen}
+        onClose={() => setResetAllDoubleConfirmOpen(false)}
+        maxWidth="xs"
+        fullWidth
+        PaperProps={{ sx: { borderRadius: 3 } }}
+        aria-labelledby="reset-all-double-dialog-title"
+      >
+        <DialogTitle id="reset-all-double-dialog-title">
+          <Typography variant="h6" component="span" fontWeight={700}>
+            Are you absolutely sure?
+          </Typography>
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body1">
+            There is no way to undo this. All your data will be gone permanently.
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 3, gap: 1 }}>
+          <Button variant="outlined" onClick={() => setResetAllDoubleConfirmOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => void handleResetAllFinalConfirm()}
+          >
+            Yes, delete everything
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   )
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+/** Injected by Vite at build time from package.json version. */
+declare const __APP_VERSION__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,17 @@ import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
+import { readFileSync } from 'fs'
+
+const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8')) as {
+  version: string
+}
 
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [
     react(),
     // Only upload source maps when the Sentry auth token is available (CI builds).


### PR DESCRIPTION
## Summary

- Replaces the placeholder SettingsScreen with a full implementation covering all four sections required by issue #16
- Preferences (theme, quiz mode, daily goal with presets, typo tolerance), Language Pairs with word counts, Data Management (export/import/reset), and About

## Changes

- `src/features/settings/components/SettingsScreen.tsx` - full rewrite of placeholder; four sections; all dialogs for destructive actions
- `src/features/settings/components/SettingsScreen.test.tsx` - 28 new tests covering all sections, preferences, export/import, reset flows, edge cases
- `src/App.tsx` - loads word counts per pair with ref-cached deduplication; passes 5 new props to SettingsScreen
- `src/vite-env.d.ts` - declares `__APP_VERSION__` global
- `vite.config.ts` - injects `__APP_VERSION__` from package.json at build time

## Testing

- All 622 tests pass (`npm test -- --run`)
- `npx tsc --noEmit` clean
- `npm run build` succeeds
- `npx eslint . --max-warnings 0` clean
- `npx prettier --check .` all files formatted

## Review

- Code review passed - no issues found

Closes #16