### PR TITLE
feat: onboarding flow - first-launch experience (#17)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -20,13 +20,6 @@ beforeEach(() => {
 })
 
 describe('App', () => {
-  it('should render the Lexio brand name in the AppBar', async () => {
-    await act(async () => {
-      render(<App />)
-    })
-    expect(screen.getByText('Lexio')).toBeInTheDocument()
-  })
-
   it('should render inside a ThemeProvider (MUI CssBaseline present)', async () => {
     let container: Element
     await act(async () => {
@@ -37,21 +30,21 @@ describe('App', () => {
     expect(container!.firstChild).not.toBeNull()
   })
 
-  it('should show the welcome message when no pairs exist', async () => {
+  it('should show onboarding on first launch (no pairs in storage)', async () => {
     await act(async () => {
       render(<App />)
     })
-    // After loading completes, with no pairs stored, welcome screen appears
+    // After loading completes with no pairs, the onboarding welcome step is shown.
     await act(async () => {})
-    expect(screen.getByText('Welcome to Lexio')).toBeInTheDocument()
+    expect(screen.getByText('Get started')).toBeInTheDocument()
   })
 
-  it('should open the create pair dialog on first launch', async () => {
+  it('should show the Lexio heading in the onboarding welcome step on first launch', async () => {
     await act(async () => {
       render(<App />)
     })
     await act(async () => {})
-    // First launch triggers the dialog
-    expect(screen.getByRole('dialog', { name: /Add language pair/i })).toBeInTheDocument()
+    // The onboarding flow renders "Lexio" as the h3 heading on the welcome step.
+    expect(screen.getAllByText('Lexio').length).toBeGreaterThan(0)
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
   Container,
   Button,
+  CircularProgress,
 } from '@mui/material'
 import { createAppTheme } from './theme'
 import { useThemeMode } from './hooks/useThemeMode'
@@ -20,9 +21,10 @@ import { QuizHub } from './features/quiz'
 import { DashboardScreen, useDashboard } from './features/dashboard'
 import { StatsScreen } from './features/stats'
 import { SettingsScreen } from './features/settings'
+import { OnboardingFlow } from './features/onboarding'
 import { BottomNav } from './components'
 import type { AppTab } from './components'
-import type { UserSettings } from './types'
+import type { LanguagePair, UserSettings } from './types'
 import { Sentry } from './services/sentry'
 
 /**
@@ -42,8 +44,12 @@ function AppContent() {
   const { pairs, activePair, loading: pairsLoading, createPair, switchPair } = useLanguagePairs()
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
-  // Whether this is the first launch (no pairs yet, after loading completes).
-  const [isFirstLaunch, setIsFirstLaunch] = useState(false)
+  /**
+   * Whether the onboarding flow is active.
+   * Set to true once loading completes and no pairs exist.
+   * Set to false when the user completes the flow or when pairs are found.
+   */
+  const [showOnboarding, setShowOnboarding] = useState(false)
   // Active navigation tab.
   const [activeTab, setActiveTab] = useState<AppTab>('home')
 
@@ -61,10 +67,10 @@ function AppContent() {
     void storage.getSettings().then((s) => setSettings(s))
   }, [storage])
 
+  // Detect first launch: after pairs have loaded, show onboarding when none exist.
   useEffect(() => {
     if (!pairsLoading && pairs.length === 0) {
-      setIsFirstLaunch(true)
-      setCreateDialogOpen(true)
+      setShowOnboarding(true)
     }
   }, [pairsLoading, pairs.length])
 
@@ -95,10 +101,25 @@ function AppContent() {
     })
   }, [pairs, storage])
 
+  /**
+   * Called by OnboardingFlow step 2 to create a language pair.
+   * Returns the created LanguagePair so the flow can pass it to step 3.
+   */
+  const handleOnboardingCreatePair = useCallback(
+    async (input: CreatePairInput): Promise<LanguagePair> => {
+      return createPair(input, true)
+    },
+    [createPair],
+  )
+
+  /** Called when the user completes (or skips) the onboarding flow. */
+  const handleOnboardingComplete = useCallback(() => {
+    setShowOnboarding(false)
+  }, [])
+
   const handleCreatePair = useCallback(
     async (input: CreatePairInput): Promise<void> => {
       await createPair(input, true)
-      setIsFirstLaunch(false)
     },
     [createPair],
   )
@@ -140,104 +161,111 @@ function AppContent() {
     [dashboardData],
   )
 
-  const showNav = !pairsLoading && pairs.length > 0
+  const showNav = !pairsLoading && pairs.length > 0 && !showOnboarding
 
   return (
     <ThemeProvider theme={appTheme}>
       <CssBaseline />
 
-      <AppBar position="static" color="default" elevation={1}>
-        <Toolbar sx={{ gap: 2 }}>
-          <Typography
-            variant="h6"
-            component="span"
-            sx={{ fontWeight: 700, color: 'primary.main', flexShrink: 0 }}
-          >
-            Lexio
-          </Typography>
+      {/* Onboarding: full-screen wizard, no app bar or nav */}
+      {!pairsLoading && showOnboarding && (
+        <OnboardingFlow
+          onComplete={handleOnboardingComplete}
+          onCreatePair={handleOnboardingCreatePair}
+        />
+      )}
 
-          <Box sx={{ flex: 1 }} />
+      {/* Loading spinner while pairs are being fetched */}
+      {pairsLoading && (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: '100vh',
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      )}
 
-          <LanguagePairSelector
-            pairs={pairs}
-            activePair={activePair}
-            loading={pairsLoading}
-            onSwitch={switchPair}
-            onAddPair={handleOpenCreateDialog}
-          />
-        </Toolbar>
-      </AppBar>
+      {/* Main app shell — only shown after loading and when onboarding is complete */}
+      {!pairsLoading && !showOnboarding && (
+        <>
+          <AppBar position="static" color="default" elevation={1}>
+            <Toolbar sx={{ gap: 2 }}>
+              <Typography
+                variant="h6"
+                component="span"
+                sx={{ fontWeight: 700, color: 'primary.main', flexShrink: 0 }}
+              >
+                Lexio
+              </Typography>
 
-      {/* Main content — bottom padding makes room for the fixed BottomNav */}
-      <Container maxWidth="sm" sx={{ py: 3, pb: showNav ? '72px' : 3 }}>
-        {!pairsLoading && (
-          <>
-            {pairs.length === 0 ? (
-              <Box sx={{ textAlign: 'center', py: 8 }}>
-                <Typography variant="h5" gutterBottom fontWeight={700}>
-                  Welcome to Lexio
-                </Typography>
-                <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-                  Create your first language pair to get started.
-                </Typography>
-                <Button variant="contained" size="large" onClick={handleOpenCreateDialog}>
-                  Create language pair
-                </Button>
-              </Box>
-            ) : (
-              <>
-                {activeTab === 'home' && (
-                  <DashboardScreen
-                    activePair={activePair}
-                    settings={settings}
-                    todayStats={dashboardData.todayStats}
-                    wordProgressList={dashboardData.wordProgressList}
-                    totalWords={dashboardData.totalWords}
-                    streakDays={dashboardData.streakDays}
-                    recentStats={dashboardData.recentStats}
-                    loading={dashboardData.loading}
-                    onStartQuiz={handleStartQuizFromDashboard}
-                  />
-                )}
+              <Box sx={{ flex: 1 }} />
 
-                {activeTab === 'quiz' && (
-                  <QuizHub
-                    pair={activePair}
-                    settings={settings}
-                    onSettingsChange={handleSettingsChange}
-                  />
-                )}
+              <LanguagePairSelector
+                pairs={pairs}
+                activePair={activePair}
+                loading={pairsLoading}
+                onSwitch={switchPair}
+                onAddPair={handleOpenCreateDialog}
+              />
+            </Toolbar>
+          </AppBar>
 
-                {activeTab === 'words' && <WordListScreen activePair={activePair} />}
-
-                {activeTab === 'stats' && <StatsScreen />}
-
-                {activeTab === 'settings' && (
-                  <SettingsScreen
-                    themePreference={themePreference}
-                    onThemeChange={handleThemeChange}
-                    settings={settings}
-                    onSettingsChange={handleSettingsChange}
-                    pairs={pairs}
-                    wordCounts={wordCounts}
-                    onAddPair={handleOpenCreateDialog}
-                  />
-                )}
-              </>
+          {/* Main content — bottom padding makes room for the fixed BottomNav */}
+          <Container maxWidth="sm" sx={{ py: 3, pb: showNav ? '72px' : 3 }}>
+            {activeTab === 'home' && (
+              <DashboardScreen
+                activePair={activePair}
+                settings={settings}
+                todayStats={dashboardData.todayStats}
+                wordProgressList={dashboardData.wordProgressList}
+                totalWords={dashboardData.totalWords}
+                streakDays={dashboardData.streakDays}
+                recentStats={dashboardData.recentStats}
+                loading={dashboardData.loading}
+                onStartQuiz={handleStartQuizFromDashboard}
+              />
             )}
-          </>
-        )}
-      </Container>
 
-      {/* Bottom navigation — only visible when there are language pairs */}
-      {showNav && <BottomNav activeTab={activeTab} onTabChange={handleTabChange} />}
+            {activeTab === 'quiz' && (
+              <QuizHub
+                pair={activePair}
+                settings={settings}
+                onSettingsChange={handleSettingsChange}
+              />
+            )}
 
-      <CreatePairDialog
-        open={createDialogOpen}
-        onClose={handleCloseCreateDialog}
-        onSubmit={handleCreatePair}
-        suggestDefault={isFirstLaunch}
-      />
+            {activeTab === 'words' && <WordListScreen activePair={activePair} />}
+
+            {activeTab === 'stats' && <StatsScreen />}
+
+            {activeTab === 'settings' && (
+              <SettingsScreen
+                themePreference={themePreference}
+                onThemeChange={handleThemeChange}
+                settings={settings}
+                onSettingsChange={handleSettingsChange}
+                pairs={pairs}
+                wordCounts={wordCounts}
+                onAddPair={handleOpenCreateDialog}
+              />
+            )}
+          </Container>
+
+          {/* Bottom navigation — only visible when there are language pairs */}
+          {showNav && <BottomNav activeTab={activeTab} onTabChange={handleTabChange} />}
+
+          <CreatePairDialog
+            open={createDialogOpen}
+            onClose={handleCloseCreateDialog}
+            onSubmit={handleCreatePair}
+            suggestDefault={false}
+          />
+        </>
+      )}
     </ThemeProvider>
   )
 }

--- a/src/features/onboarding/OnboardingFlow.test.tsx
+++ b/src/features/onboarding/OnboardingFlow.test.tsx
@@ -1,0 +1,347 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from '@mui/material'
+import { createAppTheme } from '@/theme'
+import { StorageContext } from '@/hooks/useStorage'
+import type { StorageService } from '@/services/storage/StorageService'
+import { OnboardingFlow } from './OnboardingFlow'
+import type { LanguagePair } from '@/types'
+import type { CreatePairInput } from '@/features/language-pairs'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockTheme = createAppTheme('dark')
+
+function makeStorageMock(): StorageService {
+  return {
+    getLanguagePairs: vi.fn().mockResolvedValue([]),
+    saveLanguagePair: vi.fn().mockResolvedValue(undefined),
+    deleteLanguagePair: vi.fn().mockResolvedValue(undefined),
+    getWords: vi.fn().mockResolvedValue([]),
+    saveWords: vi.fn().mockResolvedValue(undefined),
+    deleteWord: vi.fn().mockResolvedValue(undefined),
+    getWordProgress: vi.fn().mockResolvedValue(null),
+    saveWordProgress: vi.fn().mockResolvedValue(undefined),
+    getAllWordProgress: vi.fn().mockResolvedValue([]),
+    getSettings: vi.fn().mockResolvedValue({
+      activePairId: null,
+      quizMode: 'type',
+      dailyGoal: 20,
+      theme: 'system',
+      typoTolerance: 1,
+    }),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+    getDailyStats: vi.fn().mockResolvedValue(null),
+    saveDailyStats: vi.fn().mockResolvedValue(undefined),
+    getAllDailyStats: vi.fn().mockResolvedValue([]),
+    exportAll: vi.fn().mockResolvedValue({}),
+    importAll: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+  } as unknown as StorageService
+}
+
+function makePair(overrides: Partial<LanguagePair> = {}): LanguagePair {
+  return {
+    id: 'pair-1',
+    sourceLang: 'English',
+    sourceCode: 'en',
+    targetLang: 'Latvian',
+    targetCode: 'lv',
+    createdAt: Date.now(),
+    ...overrides,
+  }
+}
+
+/**
+ * Creates a typed mock for the onCreatePair callback.
+ * Returns the EN-LV pair by default.
+ */
+function makeCreatePairMock(
+  returnValue: LanguagePair = makePair(),
+): (input: CreatePairInput) => Promise<LanguagePair> {
+  return vi.fn<(input: CreatePairInput) => Promise<LanguagePair>>().mockResolvedValue(returnValue)
+}
+
+function renderFlow(
+  onComplete = vi.fn(),
+  onCreatePair: (input: CreatePairInput) => Promise<LanguagePair> = makeCreatePairMock(),
+  storageMock: StorageService = makeStorageMock(),
+) {
+  return render(
+    <StorageContext.Provider value={storageMock}>
+      <ThemeProvider theme={mockTheme}>
+        <OnboardingFlow onComplete={onComplete} onCreatePair={onCreatePair} />
+      </ThemeProvider>
+    </StorageContext.Provider>,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Silence fetch errors from listPacks in the AddWords step during tests.
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no fetch in tests')))
+})
+
+describe('OnboardingFlow', () => {
+  describe('Step 1: Welcome', () => {
+    it('should render the welcome step by default', () => {
+      renderFlow()
+      expect(screen.getByText('Get started')).toBeInTheDocument()
+      // The "Lexio" heading is present in the welcome step.
+      expect(screen.getAllByText('Lexio').length).toBeGreaterThan(0)
+    })
+
+    it('should show a tagline on the welcome step', () => {
+      renderFlow()
+      expect(screen.getByText(/active recall and spaced repetition/i)).toBeInTheDocument()
+    })
+
+    it('should advance to the language pair step when "Get started" is clicked', async () => {
+      renderFlow()
+      await userEvent.click(screen.getByRole('button', { name: /get started/i }))
+      expect(screen.getByText(/create your first language pair/i)).toBeInTheDocument()
+    })
+
+    it('should show a progress stepper with 4 steps', () => {
+      renderFlow()
+      // MobileStepper renders dot elements; we check 4 dots are rendered.
+      const dots = document.querySelectorAll('.MuiMobileStepper-dot')
+      expect(dots.length).toBe(4)
+    })
+  })
+
+  describe('Step 2: Language Pair', () => {
+    async function advanceToStep2() {
+      renderFlow()
+      await userEvent.click(screen.getByRole('button', { name: /get started/i }))
+    }
+
+    it('should pre-fill with EN-LV default pair', async () => {
+      await advanceToStep2()
+      const inputs = screen.getAllByRole('combobox')
+      // First autocomplete is source language.
+      expect(inputs[0]).toHaveValue('English (en)')
+    })
+
+    it('should show popular preset chips', async () => {
+      await advanceToStep2()
+      expect(screen.getByRole('button', { name: /EN → LV/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /EN → DE/i })).toBeInTheDocument()
+    })
+
+    it('should call onCreatePair when Continue is clicked with valid form', async () => {
+      const onCreatePair = makeCreatePairMock()
+      renderFlow(vi.fn(), onCreatePair)
+      await userEvent.click(screen.getByRole('button', { name: /get started/i }))
+      await userEvent.click(screen.getByRole('button', { name: /continue/i }))
+      expect(onCreatePair).toHaveBeenCalledWith({
+        sourceLang: 'English',
+        sourceCode: 'en',
+        targetLang: 'Latvian',
+        targetCode: 'lv',
+      })
+    })
+
+    it('should show error if form fields are empty', async () => {
+      await advanceToStep2()
+
+      // Clear the source language autocomplete.
+      const inputs = screen.getAllByRole('combobox')
+      await userEvent.clear(inputs[0])
+
+      // Find "Continue" button and click.
+      await userEvent.click(screen.getByRole('button', { name: /continue/i }))
+
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+
+    it('should update form when a preset chip is clicked', async () => {
+      await advanceToStep2()
+      await userEvent.click(screen.getByRole('button', { name: /EN → DE/i }))
+      const inputs = screen.getAllByRole('combobox')
+      expect(inputs[1]).toHaveValue('German (de)')
+    })
+
+    it('should advance to add words step after pair creation', async () => {
+      const onCreatePair = makeCreatePairMock()
+      renderFlow(vi.fn(), onCreatePair)
+      await userEvent.click(screen.getByRole('button', { name: /get started/i }))
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: /continue/i }))
+      })
+      await waitFor(() => {
+        expect(screen.getByText(/add your first words/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Step 3: Add Words', () => {
+    async function advanceToStep3() {
+      const onCreatePair = makeCreatePairMock()
+      renderFlow(vi.fn(), onCreatePair)
+      await userEvent.click(screen.getByRole('button', { name: /get started/i }))
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: /continue/i }))
+      })
+      await waitFor(() => {
+        expect(screen.getByText(/add your first words/i)).toBeInTheDocument()
+      })
+    }
+
+    it('should show the add words options', async () => {
+      await advanceToStep3()
+      expect(screen.getByText(/add my own words/i)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /skip for now/i })).toBeInTheDocument()
+    })
+
+    it('should advance to tutorial when "Skip for now" is clicked', async () => {
+      await advanceToStep3()
+      await userEvent.click(screen.getByRole('button', { name: /skip for now/i }))
+      await waitFor(() => {
+        expect(screen.getByText(/how lexio works/i)).toBeInTheDocument()
+      })
+    })
+
+    it('should advance to tutorial when "Add my own words" card is clicked', async () => {
+      await advanceToStep3()
+      await userEvent.click(screen.getByText(/add my own words/i))
+      await waitFor(() => {
+        expect(screen.getByText(/how lexio works/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Step 4: Tutorial', () => {
+    async function advanceToStep4() {
+      const onCreatePair = makeCreatePairMock()
+      renderFlow(vi.fn(), onCreatePair)
+      await userEvent.click(screen.getByRole('button', { name: /get started/i }))
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: /continue/i }))
+      })
+      await waitFor(() => {
+        expect(screen.getByText(/add your first words/i)).toBeInTheDocument()
+      })
+      await userEvent.click(screen.getByRole('button', { name: /skip for now/i }))
+      await waitFor(() => {
+        expect(screen.getByText(/how lexio works/i)).toBeInTheDocument()
+      })
+    }
+
+    it('should render the first tutorial slide', async () => {
+      await advanceToStep4()
+      expect(screen.getByText(/type mode/i)).toBeInTheDocument()
+    })
+
+    it('should navigate to the next slide when "Next" is clicked', async () => {
+      await advanceToStep4()
+      await userEvent.click(screen.getByRole('button', { name: /next/i }))
+      expect(screen.getByText(/choice mode/i)).toBeInTheDocument()
+    })
+
+    it('should navigate back when "Back" is clicked on slide 2', async () => {
+      await advanceToStep4()
+      await userEvent.click(screen.getByRole('button', { name: /next/i }))
+      await userEvent.click(screen.getByRole('button', { name: /back/i }))
+      expect(screen.getByText(/type mode/i)).toBeInTheDocument()
+    })
+
+    it('should show "Start learning!" on the last slide', async () => {
+      await advanceToStep4()
+      // Advance through all slides.
+      await userEvent.click(screen.getByRole('button', { name: /next/i }))
+      await userEvent.click(screen.getByRole('button', { name: /next/i }))
+      await userEvent.click(screen.getByRole('button', { name: /next/i }))
+      expect(screen.getByRole('button', { name: /start learning/i })).toBeInTheDocument()
+    })
+
+    it('should call onComplete when "Start learning!" is clicked', async () => {
+      const onComplete = vi.fn()
+      render(
+        <StorageContext.Provider value={makeStorageMock()}>
+          <ThemeProvider theme={mockTheme}>
+            <OnboardingFlow onComplete={onComplete} onCreatePair={makeCreatePairMock()} />
+          </ThemeProvider>
+        </StorageContext.Provider>,
+      )
+      await userEvent.click(screen.getByRole('button', { name: /get started/i }))
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: /continue/i }))
+      })
+      await waitFor(() => expect(screen.getByText(/add your first words/i)).toBeInTheDocument())
+      await userEvent.click(screen.getByRole('button', { name: /skip for now/i }))
+      await waitFor(() => expect(screen.getByText(/how lexio works/i)).toBeInTheDocument())
+      await userEvent.click(screen.getByRole('button', { name: /next/i }))
+      await userEvent.click(screen.getByRole('button', { name: /next/i }))
+      await userEvent.click(screen.getByRole('button', { name: /next/i }))
+      await userEvent.click(screen.getByRole('button', { name: /start learning!/i }))
+      expect(onComplete).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call onComplete when "Skip tutorial" is clicked', async () => {
+      const onComplete = vi.fn()
+      render(
+        <StorageContext.Provider value={makeStorageMock()}>
+          <ThemeProvider theme={mockTheme}>
+            <OnboardingFlow onComplete={onComplete} onCreatePair={makeCreatePairMock()} />
+          </ThemeProvider>
+        </StorageContext.Provider>,
+      )
+      await userEvent.click(screen.getByRole('button', { name: /get started/i }))
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: /continue/i }))
+      })
+      await waitFor(() => expect(screen.getByText(/add your first words/i)).toBeInTheDocument())
+      await userEvent.click(screen.getByRole('button', { name: /skip for now/i }))
+      await waitFor(() => expect(screen.getByText(/how lexio works/i)).toBeInTheDocument())
+      await userEvent.click(screen.getByRole('button', { name: /skip tutorial/i }))
+      expect(onComplete).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('First-launch detection (App integration)', () => {
+  it('should show onboarding when no language pairs exist in storage', async () => {
+    localStorage.clear()
+    const { default: App } = await import('@/App')
+    await act(async () => {
+      render(<App />)
+    })
+    await act(async () => {})
+    expect(screen.getByText('Get started')).toBeInTheDocument()
+  })
+
+  it('should show the dashboard (skip onboarding) when a pair already exists in storage', async () => {
+    // Pre-seed storage with a language pair so the app skips onboarding.
+    // Keys must match LocalStorageService KEYS constants.
+    const pair: LanguagePair = makePair()
+    localStorage.setItem('lexio:language-pairs', JSON.stringify([pair]))
+    localStorage.setItem(
+      'lexio:settings',
+      JSON.stringify({
+        activePairId: pair.id,
+        quizMode: 'type',
+        dailyGoal: 20,
+        theme: 'dark',
+        typoTolerance: 1,
+      }),
+    )
+
+    const { default: App } = await import('@/App')
+    await act(async () => {
+      render(<App />)
+    })
+    await act(async () => {})
+    // The main app bar "Lexio" brand is present, and onboarding "Get started" is absent.
+    expect(screen.queryByText('Get started')).not.toBeInTheDocument()
+    // AppBar Lexio heading is present.
+    expect(screen.getAllByText('Lexio').length).toBeGreaterThan(0)
+  })
+})

--- a/src/features/onboarding/OnboardingFlow.tsx
+++ b/src/features/onboarding/OnboardingFlow.tsx
@@ -1,0 +1,88 @@
+import { useState, useCallback } from 'react'
+import { Box, MobileStepper } from '@mui/material'
+import type { LanguagePair } from '@/types'
+import type { CreatePairInput } from '@/features/language-pairs'
+import { WelcomeStep } from './steps/WelcomeStep'
+import { LanguagePairStep } from './steps/LanguagePairStep'
+import { AddWordsStep } from './steps/AddWordsStep'
+import { TutorialStep } from './steps/TutorialStep'
+
+export interface OnboardingFlowProps {
+  /** Called when the user completes the flow. */
+  readonly onComplete: () => void
+  /** Called to create a language pair (delegates to useLanguagePairs). */
+  readonly onCreatePair: (input: CreatePairInput) => Promise<LanguagePair>
+}
+
+const TOTAL_STEPS = 4
+
+/**
+ * Multi-step onboarding wizard shown on first launch (when no language pairs exist).
+ * Steps: Welcome → Language Pair → Add Words → Tutorial
+ *
+ * The flow is linear; each step validates before advancing.
+ * The language pair created in Step 2 is passed to Step 3 for pack installation.
+ */
+export function OnboardingFlow({ onComplete, onCreatePair }: OnboardingFlowProps) {
+  const [activeStep, setActiveStep] = useState(0)
+  // The pair created in step 2, used in step 3 for starter-pack installation.
+  const [createdPair, setCreatedPair] = useState<LanguagePair | null>(null)
+
+  const handleNext = useCallback(() => {
+    setActiveStep((prev) => Math.min(prev + 1, TOTAL_STEPS - 1))
+  }, [])
+
+  const handlePairCreated = useCallback(
+    (pair: LanguagePair) => {
+      setCreatedPair(pair)
+      handleNext()
+    },
+    [handleNext],
+  )
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '100vh',
+        bgcolor: 'background.default',
+      }}
+    >
+      {/* Step content — takes all available vertical space */}
+      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        {activeStep === 0 && <WelcomeStep onNext={handleNext} />}
+        {activeStep === 1 && (
+          <LanguagePairStep onPairCreated={handlePairCreated} onCreatePair={onCreatePair} />
+        )}
+        {activeStep === 2 && (
+          <AddWordsStep createdPair={createdPair} onNext={handleNext} onSkip={handleNext} />
+        )}
+        {activeStep === 3 && <TutorialStep onComplete={onComplete} />}
+      </Box>
+
+      {/* Progress indicator at the bottom */}
+      <MobileStepper
+        variant="dots"
+        steps={TOTAL_STEPS}
+        position="static"
+        activeStep={activeStep}
+        nextButton={<Box sx={{ width: 64 }} />}
+        backButton={<Box sx={{ width: 64 }} />}
+        sx={{
+          justifyContent: 'center',
+          bgcolor: 'transparent',
+          pb: 2,
+          '& .MuiMobileStepper-dot': {
+            width: 8,
+            height: 8,
+            mx: 0.5,
+          },
+          '& .MuiMobileStepper-dotActive': {
+            bgcolor: 'primary.main',
+          },
+        }}
+      />
+    </Box>
+  )
+}

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -1,0 +1,2 @@
+export { OnboardingFlow } from './OnboardingFlow'
+export type { OnboardingFlowProps } from './OnboardingFlow'

--- a/src/features/onboarding/steps/AddWordsStep.tsx
+++ b/src/features/onboarding/steps/AddWordsStep.tsx
@@ -1,0 +1,221 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  Box,
+  Typography,
+  Button,
+  Stack,
+  CircularProgress,
+  Alert,
+  Card,
+  CardActionArea,
+  CardContent,
+} from '@mui/material'
+import LibraryBooksIcon from '@mui/icons-material/LibraryBooks'
+import EditNoteIcon from '@mui/icons-material/EditNote'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import type { LanguagePair, StarterPack } from '@/types'
+import { listPacks, packMatchesPair, installPack } from '@/services/starterPacks'
+import { useStorage } from '@/hooks/useStorage'
+
+export interface AddWordsStepProps {
+  /** The pair created in step 2. May be null only briefly before the step renders. */
+  readonly createdPair: LanguagePair | null
+  readonly onNext: () => void
+  readonly onSkip: () => void
+}
+
+type SelectionState = 'idle' | 'pack' | 'own'
+
+/**
+ * Step 3 of the onboarding flow.
+ * Offers the user three choices:
+ *   A) Load a starter pack (if one is available for the created pair)
+ *   B) Add words manually
+ *   C) Skip for now
+ *
+ * When option A is chosen, the pack is installed immediately and the user
+ * sees a success message before moving to the next step.
+ */
+export function AddWordsStep({ createdPair, onNext, onSkip }: AddWordsStepProps) {
+  const storage = useStorage()
+  const [selection, setSelection] = useState<SelectionState>('idle')
+  const [availablePack, setAvailablePack] = useState<StarterPack | null>(null)
+  const [loadingPacks, setLoadingPacks] = useState(true)
+  const [installing, setInstalling] = useState(false)
+  const [installed, setInstalled] = useState(false)
+  const [installedCount, setInstalledCount] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  // Load packs compatible with the created pair on mount.
+  useEffect(() => {
+    let cancelled = false
+
+    const load = async () => {
+      try {
+        const packs = await listPacks()
+        if (cancelled || !createdPair) return
+
+        const compatible = packs.find(
+          (p) => packMatchesPair(p, createdPair.sourceCode, createdPair.targetCode) !== 'none',
+        )
+        setAvailablePack(compatible ?? null)
+      } catch {
+        // Silently ignore pack loading errors — the user can still add words manually.
+      } finally {
+        if (!cancelled) setLoadingPacks(false)
+      }
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [createdPair])
+
+  const handleInstallPack = useCallback(async () => {
+    if (!availablePack || !createdPair) return
+
+    setInstalling(true)
+    setError(null)
+
+    try {
+      const result = await installPack(
+        availablePack,
+        createdPair.id,
+        createdPair.sourceCode,
+        createdPair.targetCode,
+        storage,
+      )
+      setInstalledCount(result.added)
+      setInstalled(true)
+      // Auto-advance after a short delay so the user can read the success message.
+      setTimeout(() => {
+        onNext()
+      }, 1500)
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      setError(message)
+    } finally {
+      setInstalling(false)
+    }
+  }, [availablePack, createdPair, storage, onNext])
+
+  const handlePackCardClick = useCallback(() => {
+    setSelection('pack')
+    void handleInstallPack()
+  }, [handleInstallPack])
+
+  const handleOwnWordsClick = useCallback(() => {
+    setSelection('own')
+    onSkip()
+  }, [onSkip])
+
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        px: 3,
+        py: 4,
+        maxWidth: 480,
+        mx: 'auto',
+        width: '100%',
+      }}
+    >
+      <Box sx={{ mb: 3, textAlign: 'center' }}>
+        <Typography variant="h5" gutterBottom>
+          Add your first words
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Start with a curated pack or add your own vocabulary.
+        </Typography>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {loadingPacks ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Stack spacing={2}>
+          {availablePack && (
+            <Card
+              variant="outlined"
+              sx={{
+                borderColor: selection === 'pack' ? 'primary.main' : 'divider',
+                borderWidth: 2,
+              }}
+            >
+              <CardActionArea onClick={handlePackCardClick} disabled={installing || installed}>
+                <CardContent sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
+                  <Box sx={{ pt: 0.5 }}>
+                    {installed ? (
+                      <CheckCircleIcon color="success" />
+                    ) : installing ? (
+                      <CircularProgress size={24} />
+                    ) : (
+                      <LibraryBooksIcon color="primary" />
+                    )}
+                  </Box>
+                  <Box>
+                    <Typography variant="subtitle1" fontWeight={700}>
+                      {installed
+                        ? `Loaded ${installedCount} words!`
+                        : `Load starter pack: ${availablePack.name}`}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {installed
+                        ? 'Pack installed successfully.'
+                        : `${availablePack.words.length} curated words — ${availablePack.description}`}
+                    </Typography>
+                  </Box>
+                </CardContent>
+              </CardActionArea>
+            </Card>
+          )}
+
+          <Card
+            variant="outlined"
+            sx={{
+              borderColor: selection === 'own' ? 'primary.main' : 'divider',
+              borderWidth: 2,
+            }}
+          >
+            <CardActionArea onClick={handleOwnWordsClick} disabled={installing || installed}>
+              <CardContent sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
+                <EditNoteIcon color="primary" sx={{ pt: 0.5 }} />
+                <Box>
+                  <Typography variant="subtitle1" fontWeight={700}>
+                    Add my own words
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Build your vocabulary list from scratch or import from CSV.
+                  </Typography>
+                </Box>
+              </CardContent>
+            </CardActionArea>
+          </Card>
+        </Stack>
+      )}
+
+      <Box sx={{ mt: 'auto', pt: 3, textAlign: 'center' }}>
+        <Button
+          variant="text"
+          color="inherit"
+          onClick={onSkip}
+          disabled={installing}
+          sx={{ color: 'text.secondary' }}
+        >
+          Skip for now
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/features/onboarding/steps/LanguagePairStep.tsx
+++ b/src/features/onboarding/steps/LanguagePairStep.tsx
@@ -1,0 +1,248 @@
+import { useState, useCallback } from 'react'
+import { Box, Typography, Button, TextField, Autocomplete, Stack, Alert, Chip } from '@mui/material'
+import TranslateIcon from '@mui/icons-material/Translate'
+import { LANGUAGE_PRESETS, DEFAULT_PAIR_PRESET } from '@/features/language-pairs'
+import type { LanguagePreset, CreatePairInput } from '@/features/language-pairs'
+import type { LanguagePair } from '@/types'
+
+export interface LanguagePairStepProps {
+  readonly onPairCreated: (pair: LanguagePair) => void
+  readonly onCreatePair: (input: CreatePairInput) => Promise<LanguagePair>
+}
+
+interface FormState {
+  sourceLang: string
+  sourceCode: string
+  targetLang: string
+  targetCode: string
+}
+
+const DEFAULT_FORM: FormState = {
+  sourceLang: DEFAULT_PAIR_PRESET.sourceLang,
+  sourceCode: DEFAULT_PAIR_PRESET.sourceCode,
+  targetLang: DEFAULT_PAIR_PRESET.targetLang,
+  targetCode: DEFAULT_PAIR_PRESET.targetCode,
+}
+
+/** Popular preset pairs offered as quick-select chips. */
+const POPULAR_PRESETS = [
+  { label: 'EN → LV', source: 'English', sourceCode: 'en', target: 'Latvian', targetCode: 'lv' },
+  { label: 'EN → DE', source: 'English', sourceCode: 'en', target: 'German', targetCode: 'de' },
+  { label: 'EN → ES', source: 'English', sourceCode: 'en', target: 'Spanish', targetCode: 'es' },
+  { label: 'EN → FR', source: 'English', sourceCode: 'en', target: 'French', targetCode: 'fr' },
+] as const
+
+/**
+ * Step 2 of the onboarding flow.
+ * Lets the user select a language pair via quick-select chips or a custom form.
+ * Pre-fills with the EN-LV default suggestion from the product spec.
+ */
+export function LanguagePairStep({ onPairCreated, onCreatePair }: LanguagePairStepProps) {
+  const [form, setForm] = useState<FormState>(DEFAULT_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handlePresetChipClick = useCallback(
+    (preset: (typeof POPULAR_PRESETS)[number]) => () => {
+      setForm({
+        sourceLang: preset.source,
+        sourceCode: preset.sourceCode,
+        targetLang: preset.target,
+        targetCode: preset.targetCode,
+      })
+      setError(null)
+    },
+    [],
+  )
+
+  const handleSourcePresetChange = useCallback(
+    (_: React.SyntheticEvent, value: LanguagePreset | string | null) => {
+      if (typeof value === 'string') {
+        setForm((prev) => ({ ...prev, sourceLang: value, sourceCode: '' }))
+      } else if (value) {
+        setForm((prev) => ({ ...prev, sourceLang: value.name, sourceCode: value.code }))
+      } else {
+        setForm((prev) => ({ ...prev, sourceLang: '', sourceCode: '' }))
+      }
+    },
+    [],
+  )
+
+  const handleTargetPresetChange = useCallback(
+    (_: React.SyntheticEvent, value: LanguagePreset | string | null) => {
+      if (typeof value === 'string') {
+        setForm((prev) => ({ ...prev, targetLang: value, targetCode: '' }))
+      } else if (value) {
+        setForm((prev) => ({ ...prev, targetLang: value.name, targetCode: value.code }))
+      } else {
+        setForm((prev) => ({ ...prev, targetLang: '', targetCode: '' }))
+      }
+    },
+    [],
+  )
+
+  const handleSubmit = useCallback(async () => {
+    const { sourceLang, sourceCode, targetLang, targetCode } = form
+
+    if (!sourceLang.trim() || !sourceCode.trim() || !targetLang.trim() || !targetCode.trim()) {
+      setError('Please fill in all fields to continue.')
+      return
+    }
+
+    if (sourceLang.trim() === targetLang.trim() && sourceCode.trim() === targetCode.trim()) {
+      setError('Source and target languages must be different.')
+      return
+    }
+
+    setError(null)
+    setSubmitting(true)
+
+    try {
+      const pair = await onCreatePair({
+        sourceLang: sourceLang.trim(),
+        sourceCode: sourceCode.trim().toLowerCase(),
+        targetLang: targetLang.trim(),
+        targetCode: targetCode.trim().toLowerCase(),
+      })
+      onPairCreated(pair)
+    } catch {
+      setError('Failed to create language pair. Please try again.')
+      setSubmitting(false)
+    }
+  }, [form, onCreatePair, onPairCreated])
+
+  const sourcePresetValue = LANGUAGE_PRESETS.find((p) => p.name === form.sourceLang) ?? null
+  const targetPresetValue = LANGUAGE_PRESETS.find((p) => p.name === form.targetLang) ?? null
+
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        px: 3,
+        py: 4,
+        maxWidth: 480,
+        mx: 'auto',
+        width: '100%',
+      }}
+    >
+      <Box sx={{ mb: 3, textAlign: 'center' }}>
+        <TranslateIcon sx={{ fontSize: 48, color: 'primary.main', mb: 1 }} />
+        <Typography variant="h5" gutterBottom>
+          Create your first language pair
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Choose what you already know and what you want to learn.
+        </Typography>
+      </Box>
+
+      {/* Quick-select chips */}
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+          Popular choices
+        </Typography>
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          {POPULAR_PRESETS.map((preset) => {
+            const isSelected =
+              form.sourceLang === preset.source && form.targetLang === preset.target
+            return (
+              <Chip
+                key={preset.label}
+                label={preset.label}
+                onClick={handlePresetChipClick(preset)}
+                color={isSelected ? 'primary' : 'default'}
+                variant={isSelected ? 'filled' : 'outlined'}
+                sx={{ mb: 0.5 }}
+              />
+            )
+          })}
+        </Stack>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Stack spacing={2} sx={{ mb: 3 }}>
+        <Typography variant="subtitle2" color="text.secondary">
+          Source language — the one you already know
+        </Typography>
+
+        <Autocomplete<LanguagePreset, false, false, true>
+          options={[...LANGUAGE_PRESETS]}
+          getOptionLabel={(option) =>
+            typeof option === 'string' ? option : `${option.name} (${option.code})`
+          }
+          value={sourcePresetValue}
+          onChange={handleSourcePresetChange}
+          freeSolo
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Source language"
+              placeholder="e.g. English"
+              inputProps={{ ...params.inputProps, lang: 'und' }}
+            />
+          )}
+          isOptionEqualToValue={(option, value) => option.code === value.code}
+        />
+
+        <TextField
+          label="Language code"
+          placeholder="e.g. en"
+          value={form.sourceCode}
+          onChange={(e) => setForm((prev) => ({ ...prev, sourceCode: e.target.value }))}
+          inputProps={{ maxLength: 10 }}
+          helperText="BCP-47 code (auto-filled from preset)"
+        />
+
+        <Typography variant="subtitle2" color="text.secondary" sx={{ pt: 1 }}>
+          Target language — the one you want to learn
+        </Typography>
+
+        <Autocomplete<LanguagePreset, false, false, true>
+          options={[...LANGUAGE_PRESETS]}
+          getOptionLabel={(option) =>
+            typeof option === 'string' ? option : `${option.name} (${option.code})`
+          }
+          value={targetPresetValue}
+          onChange={handleTargetPresetChange}
+          freeSolo
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Target language"
+              placeholder="e.g. Latvian"
+              inputProps={{ ...params.inputProps, lang: 'und' }}
+            />
+          )}
+          isOptionEqualToValue={(option, value) => option.code === value.code}
+        />
+
+        <TextField
+          label="Language code"
+          placeholder="e.g. lv"
+          value={form.targetCode}
+          onChange={(e) => setForm((prev) => ({ ...prev, targetCode: e.target.value }))}
+          inputProps={{ maxLength: 10 }}
+          helperText="BCP-47 code (auto-filled from preset)"
+        />
+      </Stack>
+
+      <Button
+        variant="contained"
+        size="large"
+        onClick={() => {
+          void handleSubmit()
+        }}
+        disabled={submitting}
+        sx={{ borderRadius: 2, py: 1.5 }}
+      >
+        {submitting ? 'Creating...' : 'Continue'}
+      </Button>
+    </Box>
+  )
+}

--- a/src/features/onboarding/steps/TutorialStep.tsx
+++ b/src/features/onboarding/steps/TutorialStep.tsx
@@ -1,0 +1,162 @@
+import { useState, useCallback } from 'react'
+import { Box, Typography, Button, Stack, Paper, MobileStepper } from '@mui/material'
+import KeyboardIcon from '@mui/icons-material/Keyboard'
+import TouchAppIcon from '@mui/icons-material/TouchApp'
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents'
+import AutorenewIcon from '@mui/icons-material/Autorenew'
+
+export interface TutorialStepProps {
+  readonly onComplete: () => void
+}
+
+interface TutorialSlide {
+  readonly icon: React.ReactNode
+  readonly title: string
+  readonly body: string
+}
+
+const SLIDES: readonly TutorialSlide[] = [
+  {
+    icon: <KeyboardIcon sx={{ fontSize: 56, color: 'primary.main' }} />,
+    title: 'Type mode',
+    body: 'You see a word and type the translation. Lexio accepts minor typos so you can focus on learning, not spelling.',
+  },
+  {
+    icon: <TouchAppIcon sx={{ fontSize: 56, color: 'primary.main' }} />,
+    title: 'Choice mode',
+    body: 'Pick the correct translation from four options. Great for building recognition quickly.',
+  },
+  {
+    icon: <AutorenewIcon sx={{ fontSize: 56, color: 'primary.main' }} />,
+    title: 'Spaced repetition',
+    body: 'Words you struggle with appear more often. Words you know well are reviewed less frequently. Your time is spent where it matters.',
+  },
+  {
+    icon: <EmojiEventsIcon sx={{ fontSize: 56, color: 'primary.main' }} />,
+    title: 'Daily goal and streaks',
+    body: 'Set a daily word target and build a streak by hitting it every day. Consistency is the key to fluency.',
+  },
+]
+
+/**
+ * Step 4 of the onboarding flow.
+ * A brief visual walkthrough of the quiz mechanics:
+ * type mode, choice mode, spaced repetition, and streaks.
+ * Users can page through slides and finish with "Start learning!".
+ */
+export function TutorialStep({ onComplete }: TutorialStepProps) {
+  const [slideIndex, setSlideIndex] = useState(0)
+  const isLastSlide = slideIndex === SLIDES.length - 1
+  const slide = SLIDES[slideIndex]
+
+  const handleNext = useCallback(() => {
+    if (isLastSlide) {
+      onComplete()
+    } else {
+      setSlideIndex((prev) => prev + 1)
+    }
+  }, [isLastSlide, onComplete])
+
+  const handleBack = useCallback(() => {
+    setSlideIndex((prev) => Math.max(0, prev - 1))
+  }, [])
+
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        px: 3,
+        py: 4,
+        maxWidth: 480,
+        mx: 'auto',
+        width: '100%',
+      }}
+    >
+      <Box sx={{ mb: 3, textAlign: 'center' }}>
+        <Typography variant="h5" gutterBottom>
+          How Lexio works
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          A quick tour before you start learning.
+        </Typography>
+      </Box>
+
+      {/* Slide content */}
+      <Paper
+        variant="outlined"
+        sx={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          p: 4,
+          textAlign: 'center',
+          borderRadius: 3,
+          gap: 2,
+        }}
+      >
+        {slide.icon}
+        <Typography variant="h6" fontWeight={700}>
+          {slide.title}
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ lineHeight: 1.7 }}>
+          {slide.body}
+        </Typography>
+      </Paper>
+
+      {/* Slide navigation dots */}
+      <MobileStepper
+        variant="dots"
+        steps={SLIDES.length}
+        position="static"
+        activeStep={slideIndex}
+        nextButton={<Box sx={{ width: 48 }} />}
+        backButton={<Box sx={{ width: 48 }} />}
+        sx={{
+          justifyContent: 'center',
+          bgcolor: 'transparent',
+          py: 2,
+          '& .MuiMobileStepper-dotActive': {
+            bgcolor: 'primary.main',
+          },
+        }}
+      />
+
+      <Stack direction="row" spacing={2} justifyContent="space-between">
+        <Button
+          variant="outlined"
+          onClick={handleBack}
+          disabled={slideIndex === 0}
+          sx={{ flex: 1, py: 1.5, borderRadius: 2 }}
+        >
+          Back
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleNext}
+          sx={{
+            flex: 2,
+            py: 1.5,
+            borderRadius: 2,
+            fontSize: isLastSlide ? '1rem' : undefined,
+            bgcolor: isLastSlide ? 'primary.main' : undefined,
+          }}
+        >
+          {isLastSlide ? 'Start learning!' : 'Next'}
+        </Button>
+      </Stack>
+
+      {/* Skip tutorial link */}
+      {!isLastSlide && (
+        <Box sx={{ textAlign: 'center', mt: 1 }}>
+          <Button variant="text" size="small" onClick={onComplete} sx={{ color: 'text.secondary' }}>
+            Skip tutorial
+          </Button>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/features/onboarding/steps/WelcomeStep.tsx
+++ b/src/features/onboarding/steps/WelcomeStep.tsx
@@ -1,0 +1,48 @@
+import { Box, Typography, Button } from '@mui/material'
+import AutoStoriesIcon from '@mui/icons-material/AutoStories'
+
+export interface WelcomeStepProps {
+  readonly onNext: () => void
+}
+
+/**
+ * Step 1 of the onboarding flow.
+ * Displays the app name, tagline, and a "Get started" call to action.
+ * Clean, inviting layout centred on the screen.
+ */
+export function WelcomeStep({ onNext }: WelcomeStepProps) {
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        px: 4,
+        textAlign: 'center',
+        gap: 3,
+      }}
+    >
+      <AutoStoriesIcon sx={{ fontSize: 80, color: 'primary.main' }} />
+
+      <Box>
+        <Typography variant="h3" component="h1" gutterBottom>
+          Lexio
+        </Typography>
+        <Typography variant="h6" color="text.secondary" sx={{ fontWeight: 400, lineHeight: 1.5 }}>
+          Learn vocabulary in any language through active recall and spaced repetition.
+        </Typography>
+      </Box>
+
+      <Button
+        variant="contained"
+        size="large"
+        onClick={onNext}
+        sx={{ mt: 2, px: 6, py: 1.5, borderRadius: 3, fontSize: '1.1rem' }}
+      >
+        Get started
+      </Button>
+    </Box>
+  )
+}

--- a/src/features/onboarding/steps/index.ts
+++ b/src/features/onboarding/steps/index.ts
@@ -1,0 +1,11 @@
+export { WelcomeStep } from './WelcomeStep'
+export type { WelcomeStepProps } from './WelcomeStep'
+
+export { LanguagePairStep } from './LanguagePairStep'
+export type { LanguagePairStepProps } from './LanguagePairStep'
+
+export { AddWordsStep } from './AddWordsStep'
+export type { AddWordsStepProps } from './AddWordsStep'
+
+export { TutorialStep } from './TutorialStep'
+export type { TutorialStepProps } from './TutorialStep'


### PR DESCRIPTION
## Summary

- 4-step onboarding wizard (`OnboardingFlow`) shown on first launch when no language pairs exist
- Step 1: Welcome screen with app name and tagline
- Step 2: Language pair creation with EN-LV default, popular preset chips, and autocomplete form
- Step 3: Starter pack install (auto-detected for the chosen pair) or manual words option
- Step 4: Tutorial walkthrough (4 slides: type mode, choice mode, spaced repetition, streaks)
- Returning users bypass onboarding and go directly to the dashboard
- MobileStepper progress indicator throughout the flow

## Changes

- `src/features/onboarding/OnboardingFlow.tsx` — main wizard container
- `src/features/onboarding/steps/WelcomeStep.tsx` — welcome screen
- `src/features/onboarding/steps/LanguagePairStep.tsx` — pair creation step
- `src/features/onboarding/steps/AddWordsStep.tsx` — starter pack / manual words choice
- `src/features/onboarding/steps/TutorialStep.tsx` — tutorial slides
- `src/features/onboarding/index.ts` + `steps/index.ts` — barrel exports
- `src/App.tsx` — first-launch detection, OnboardingFlow integration, loading spinner
- `src/App.test.tsx` — updated tests for new first-launch behaviour
- `src/features/onboarding/OnboardingFlow.test.tsx` — 21 new tests

## Testing

- All 642 tests pass (`npm test -- --run`)
- TypeScript strict: `npx tsc --noEmit` clean
- Production build: `npm run build` succeeds
- ESLint: `npx eslint . --max-warnings 0` clean
- Prettier: `npx prettier --check .` clean
- Acceptance criteria verified: onboarding shown on first launch, skipped for returning users, pair creation, pack install, tutorial

## Review

- Code review passed (no direct localStorage calls, MUI theme used throughout, strict TypeScript, named exports, mobile-friendly layout)

Closes #17