### PR TITLE
chore: bump version to 1.0.0 for v1.0.0 release (#72)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lexio",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=mreppo_lexio
 sonar.organization=mreppo
-sonar.projectVersion=0.1.0
+sonar.projectVersion=1.0.0
 sonar.sources=src
 sonar.tests=src
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx

--- a/src/features/settings/components/SettingsScreen.test.tsx
+++ b/src/features/settings/components/SettingsScreen.test.tsx
@@ -30,7 +30,7 @@ import { createElement, type ReactNode } from 'react'
 // __APP_VERSION__ is declared in vite-env.d.ts; in tests it is undefined unless
 // the Vite define plugin runs — provide a fallback via globalThis.
 Object.defineProperty(globalThis, '__APP_VERSION__', {
-  value: '0.1.0',
+  value: '1.0.0',
   writable: true,
 })
 
@@ -143,7 +143,7 @@ describe('SettingsScreen', () => {
   it('should render the About section with version', () => {
     renderSettings(storage)
     expect(screen.getByText('About')).toBeInTheDocument()
-    expect(screen.getByText(/Version 0\.1\.0/)).toBeInTheDocument()
+    expect(screen.getByText(/Version 1\.0\.0/)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /View source on GitHub/i })).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary

Version bump to 1.0.0 marking the completion of the original 19-issue MVP roadmap.

## Changes

- `package.json` — version `0.1.0` → `1.0.0`
- `sonar-project.properties` — `sonar.projectVersion` `0.1.0` → `1.0.0`
- `src/features/settings/components/SettingsScreen.test.tsx` — updated `__APP_VERSION__` test stub and version assertion to match `1.0.0`

## Testing

- All 657 tests pass (43 test files)
- TypeScript strict mode: no errors
- ESLint: no warnings
- Prettier: all files formatted correctly
- Production build: succeeds

## Review

- Code review passed — no issues found

Closes #72