### PR TITLE
fix: audit and fix light mode - replace hardcoded border in LanguagePairSelector (#76)

### DIFF
--- a/src/features/language-pairs/components/LanguagePairSelector.tsx
+++ b/src/features/language-pairs/components/LanguagePairSelector.tsx
@@ -74,7 +74,7 @@ export function LanguagePairSelector({
         aria-haspopup="true"
         aria-expanded={open}
         sx={{
-          borderColor: 'rgba(255,255,255,0.3)',
+          borderColor: 'divider',
           color: 'text.primary',
           minWidth: 140,
           justifyContent: 'flex-start',


### PR DESCRIPTION
## Summary

- Audited all 13 screens listed in the issue for light mode correctness
- Fixed the one genuine hardcoded dark-mode-only colour found: `LanguagePairSelector.tsx` AppBar button border

## Changes

- `src/features/language-pairs/components/LanguagePairSelector.tsx` — replaced `borderColor: 'rgba(255,255,255,0.3)'` with `borderColor: 'divider'`

The `rgba(255,255,255,0.3)` border was always applied regardless of theme. In light mode the AppBar background is a light paper colour, making a white border nearly invisible and providing insufficient contrast. The MUI `divider` token resolves correctly in both modes: `rgba(255,255,255,0.08)` in dark, `rgba(0,0,0,0.08)` in light.

## Audit findings

All other screens use MUI theme tokens correctly:
- Onboarding flow, Dashboard, Quiz Hub/Mode Selector, Active quiz (type + choice), QuizFeedback, SessionSummary, WordList, StarterPack browser, Stats charts (ActivityChart uses `useTheme()`, StreakCalendar is mode-aware), Settings — all clean.
- `DailyProgressCard` and `DashboardScreen` use `rgba(255,255,255,*)` intentionally as white text/icons on a `success.main` (green) background when the daily goal is met — correct in both modes.
- Theme toggle in Settings already correctly wired via `useThemeMode` hook with system preference support.

## Testing

- All 668 tests pass
- `tsc --noEmit` clean
- `npm run build` succeeds
- `eslint . --max-warnings 0` passes
- `prettier --check .` passes

Closes #76