### PR TITLE
feat: CEFR level selection with multi-select and quiz filtering (#85)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,7 @@ function AppContent() {
     dailyGoal: 20,
     theme: 'system',
     typoTolerance: 1,
+    selectedLevels: [],
   })
 
   // Load settings on mount.

--- a/src/features/dashboard/components/DashboardScreen.test.tsx
+++ b/src/features/dashboard/components/DashboardScreen.test.tsx
@@ -13,6 +13,7 @@ const defaultSettings: UserSettings = {
   dailyGoal: 20,
   theme: 'dark',
   typoTolerance: 1,
+  selectedLevels: [],
 }
 
 const activePair: LanguagePair = {

--- a/src/features/quiz/components/ActiveQuizView.tsx
+++ b/src/features/quiz/components/ActiveQuizView.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useRef } from 'react'
-import type { LanguagePair, UserSettings, QuizMode } from '@/types'
+import type { LanguagePair, UserSettings, QuizMode, CefrLevel } from '@/types'
 import { useQuizSession } from '../useQuizSession'
 import { TypeQuizContent } from './TypeQuizContent'
 import { ChoiceQuizContent } from './ChoiceQuizContent'
@@ -16,6 +16,8 @@ interface ActiveQuizViewProps {
   readonly mode: QuizMode
   readonly pair: LanguagePair | null
   readonly settings: UserSettings
+  /** Session-only CEFR level override (not persisted). Empty = use settings default. */
+  readonly sessionLevels?: readonly CefrLevel[]
   /**
    * Called once when the session transitions to 'finished'.
    * Receives the final wordsReviewed, correctCount, and bestSessionStreak.
@@ -27,8 +29,14 @@ interface ActiveQuizViewProps {
   ) => void
 }
 
-export function ActiveQuizView({ mode, pair, settings, onSessionFinished }: ActiveQuizViewProps) {
-  const session = useQuizSession(pair, settings, mode)
+export function ActiveQuizView({
+  mode,
+  pair,
+  settings,
+  sessionLevels,
+  onSessionFinished,
+}: ActiveQuizViewProps) {
+  const session = useQuizSession(pair, settings, mode, sessionLevels)
   const { phase, wordsCompleted, correctCount, bestSessionStreak, currentMode } = session.state
 
   // Store onSessionFinished in a ref so the effect dep array only contains the

--- a/src/features/quiz/components/LevelFilterBar.tsx
+++ b/src/features/quiz/components/LevelFilterBar.tsx
@@ -1,0 +1,82 @@
+/**
+ * LevelFilterBar - compact CEFR level filter shown on the quiz mode selector.
+ *
+ * Renders a row of small toggle chips for each level that has words.
+ * Changes are session-only — they are passed up to the parent but never
+ * written to UserSettings / StorageService.
+ */
+
+import { Box, Chip, Stack, Typography } from '@mui/material'
+import FilterListIcon from '@mui/icons-material/FilterList'
+import type { CefrLevel } from '@/types'
+import { CEFR_LEVELS } from '@/types'
+
+export interface LevelFilterBarProps {
+  /** Session-level selected levels. Empty means "all". */
+  readonly sessionLevels: readonly CefrLevel[]
+  /** Word count per level so we can hide or grey out empty levels. */
+  readonly wordCountByLevel: Readonly<Record<CefrLevel, number>>
+  /** Called when the user toggles a level chip. */
+  readonly onChange: (levels: readonly CefrLevel[]) => void
+}
+
+export function LevelFilterBar({ sessionLevels, wordCountByLevel, onChange }: LevelFilterBarProps) {
+  const handleToggle = (level: CefrLevel): void => {
+    const isSelected = sessionLevels.includes(level)
+    const next = isSelected ? sessionLevels.filter((l) => l !== level) : [...sessionLevels, level]
+    onChange(next)
+  }
+
+  // Only show levels that have at least one word to keep the UI clean.
+  const availableLevels = CEFR_LEVELS.filter((l) => wordCountByLevel[l] > 0)
+
+  // If no levels have any words, don't render the bar.
+  if (availableLevels.length === 0) return null
+
+  const allSelected = sessionLevels.length === 0
+
+  return (
+    <Box
+      sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}
+      aria-label="Session level filter"
+    >
+      <FilterListIcon
+        fontSize="small"
+        sx={{ color: 'text.secondary', mt: 0.25, flexShrink: 0 }}
+        aria-hidden="true"
+      />
+      <Box sx={{ flex: 1 }}>
+        <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+          {availableLevels.map((level) => {
+            const count = wordCountByLevel[level]
+            const isSelected = sessionLevels.includes(level)
+
+            return (
+              <Chip
+                key={level}
+                label={`${level} (${count})`}
+                size="small"
+                color={isSelected ? 'primary' : 'default'}
+                variant={isSelected ? 'filled' : 'outlined'}
+                onClick={() => handleToggle(level)}
+                aria-pressed={isSelected}
+                aria-label={`${level} — ${count} words${isSelected ? ', selected' : ''}`}
+                sx={{ cursor: 'pointer', fontSize: '0.7rem' }}
+              />
+            )
+          })}
+        </Stack>
+
+        {allSelected ? (
+          <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+            All levels (session only)
+          </Typography>
+        ) : (
+          <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+            Session override — won&apos;t be saved
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/src/features/quiz/components/QuizHub.tsx
+++ b/src/features/quiz/components/QuizHub.tsx
@@ -13,8 +13,9 @@
 
 import { useState, useCallback, useEffect } from 'react'
 import { Box } from '@mui/material'
-import type { LanguagePair, UserSettings, QuizMode } from '@/types'
+import type { LanguagePair, UserSettings, QuizMode, CefrLevel } from '@/types'
 import { useStorage } from '@/hooks/useStorage'
+import { countWordsByLevel } from '@/utils/cefrFilter'
 import {
   updateDailyStatsAfterSession,
   loadCurrentStreak,
@@ -66,10 +67,42 @@ export function QuizHub({ pair, settings, onSettingsChange }: QuizHubProps) {
   // Stored so SessionSummary can show accurate post-session totals.
   const [wordsReviewedTodayAtEnd, setWordsReviewedTodayAtEnd] = useState(0)
 
+  // Session-only level override. Initialised from settings on each 'select' phase.
+  // Reset to settings default when the user goes back to the select screen.
+  const [sessionLevels, setSessionLevels] = useState<readonly CefrLevel[]>(settings.selectedLevels)
+
+  // Word count per CEFR level for the active pair (used in LevelFilterBar).
+  const [wordCountByLevel, setWordCountByLevel] = useState<Record<CefrLevel, number>>({
+    A1: 0,
+    A2: 0,
+    B1: 0,
+    B2: 0,
+    C1: 0,
+    C2: 0,
+  })
+
   // Keep local selectedMode in sync when settings.quizMode changes externally.
   useEffect(() => {
     setSelectedMode(settings.quizMode)
   }, [settings.quizMode])
+
+  // Reset session levels to settings default when returning to select screen.
+  useEffect(() => {
+    if (hubPhase === 'select') {
+      setSessionLevels(settings.selectedLevels)
+    }
+  }, [hubPhase, settings.selectedLevels])
+
+  // Load word counts for the LevelFilterBar whenever the active pair changes.
+  useEffect(() => {
+    if (pair === null) {
+      setWordCountByLevel({ A1: 0, A2: 0, B1: 0, B2: 0, C1: 0, C2: 0 })
+      return
+    }
+    void storage.getWords(pair.id).then((words) => {
+      setWordCountByLevel(countWordsByLevel(words))
+    })
+  }, [storage, pair])
 
   // Reload streak from storage whenever the hub phase changes (e.g. after session).
   useEffect(() => {
@@ -169,6 +202,9 @@ export function QuizHub({ pair, settings, onSettingsChange }: QuizHubProps) {
           streakDays={streakDays}
           wordsLearned={wordsLearned}
           totalWords={totalWords}
+          sessionLevels={sessionLevels}
+          wordCountByLevel={wordCountByLevel}
+          onSessionLevelsChange={setSessionLevels}
         />
         <GoalCelebration
           open={showCelebration}
@@ -205,6 +241,7 @@ export function QuizHub({ pair, settings, onSettingsChange }: QuizHubProps) {
           mode={selectedMode}
           pair={pair}
           settings={settings}
+          sessionLevels={sessionLevels}
           onSessionFinished={handleSessionFinished}
         />
       </Box>

--- a/src/features/quiz/components/QuizModeSelector.test.tsx
+++ b/src/features/quiz/components/QuizModeSelector.test.tsx
@@ -13,7 +13,16 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ThemeProvider, createTheme } from '@mui/material'
 import { QuizModeSelector } from './QuizModeSelector'
-import type { QuizMode } from '@/types'
+import type { QuizMode, CefrLevel } from '@/types'
+
+const EMPTY_WORD_COUNTS: Record<CefrLevel, number> = {
+  A1: 0,
+  A2: 0,
+  B1: 0,
+  B2: 0,
+  C1: 0,
+  C2: 0,
+}
 
 interface RenderOptions {
   selectedMode?: QuizMode
@@ -24,6 +33,9 @@ interface RenderOptions {
   streakDays?: number
   wordsLearned?: number
   totalWords?: number
+  sessionLevels?: readonly CefrLevel[]
+  wordCountByLevel?: Record<CefrLevel, number>
+  onSessionLevelsChange?: ReturnType<typeof vi.fn>
 }
 
 function renderSelector({
@@ -35,6 +47,9 @@ function renderSelector({
   streakDays = 0,
   wordsLearned = 0,
   totalWords = 0,
+  sessionLevels = [],
+  wordCountByLevel = EMPTY_WORD_COUNTS,
+  onSessionLevelsChange = vi.fn(),
 }: RenderOptions = {}) {
   return render(
     <ThemeProvider theme={createTheme()}>
@@ -47,6 +62,9 @@ function renderSelector({
         streakDays={streakDays}
         wordsLearned={wordsLearned}
         totalWords={totalWords}
+        sessionLevels={sessionLevels}
+        wordCountByLevel={wordCountByLevel}
+        onSessionLevelsChange={onSessionLevelsChange}
       />
     </ThemeProvider>,
   )

--- a/src/features/quiz/components/QuizModeSelector.tsx
+++ b/src/features/quiz/components/QuizModeSelector.tsx
@@ -11,8 +11,9 @@ import { Box, Button, Card, CardActionArea, CardContent, Typography } from '@mui
 import KeyboardIcon from '@mui/icons-material/Keyboard'
 import CheckBoxOutlinedIcon from '@mui/icons-material/CheckBoxOutlined'
 import ShuffleIcon from '@mui/icons-material/Shuffle'
-import type { QuizMode } from '@/types'
+import type { QuizMode, CefrLevel } from '@/types'
 import { DailyProgressCard } from './DailyProgressCard'
+import { LevelFilterBar } from './LevelFilterBar'
 
 // ─── Mode descriptors ─────────────────────────────────────────────────────────
 
@@ -63,6 +64,12 @@ interface QuizModeSelectorProps {
   readonly wordsLearned: number
   /** Total words in the active pair. */
   readonly totalWords: number
+  /** Session-only level override (not persisted to settings). Empty = all levels. */
+  readonly sessionLevels: readonly CefrLevel[]
+  /** Word count per level for displaying counts in the level filter bar. */
+  readonly wordCountByLevel: Readonly<Record<CefrLevel, number>>
+  /** Called when the user changes the session-level filter. */
+  readonly onSessionLevelsChange: (levels: readonly CefrLevel[]) => void
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -76,6 +83,9 @@ export function QuizModeSelector({
   streakDays,
   wordsLearned,
   totalWords,
+  sessionLevels,
+  wordCountByLevel,
+  onSessionLevelsChange,
 }: QuizModeSelectorProps) {
   const handleSelect = useCallback(
     (mode: QuizMode): void => {
@@ -165,6 +175,12 @@ export function QuizModeSelector({
           )
         })}
       </Box>
+
+      <LevelFilterBar
+        sessionLevels={sessionLevels}
+        wordCountByLevel={wordCountByLevel}
+        onChange={onSessionLevelsChange}
+      />
 
       <Button
         variant="contained"

--- a/src/features/quiz/useQuizSession.ts
+++ b/src/features/quiz/useQuizSession.ts
@@ -13,8 +13,8 @@
  * - Tracks session progress against the daily goal.
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react'
-import type { Word, LanguagePair, UserSettings, QuizMode, QuizDirection } from '@/types'
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import type { Word, LanguagePair, UserSettings, QuizMode, QuizDirection, CefrLevel } from '@/types'
 import type { AnswerMatchResult } from '@/utils/matching'
 import { matchAnswer } from '@/utils/matching'
 import { useStorage } from '@/hooks/useStorage'
@@ -150,16 +150,34 @@ export function selectModeForWord(
 /**
  * Manages a full quiz session for a given language pair and mode.
  *
- * @param pair     - The active language pair, or null if none selected.
- * @param settings - Current user settings (daily goal, typo tolerance).
- * @param mode     - The quiz mode: 'type', 'choice', or 'mixed'.
+ * @param pair           - The active language pair, or null if none selected.
+ * @param settings       - Current user settings (daily goal, typo tolerance).
+ * @param mode           - The quiz mode: 'type', 'choice', or 'mixed'.
+ * @param sessionLevels  - Optional session-level CEFR override. When provided it
+ *                         takes precedence over settings.selectedLevels for this
+ *                         session only (not persisted).
  */
 export function useQuizSession(
   pair: LanguagePair | null,
   settings: UserSettings,
   mode: QuizMode,
+  sessionLevels?: readonly CefrLevel[],
 ): UseQuizSessionResult {
   const storage = useStorage()
+
+  // Serialise to a stable string so loadWords only re-fires when the
+  // actual level values change, not just because a new array instance is passed.
+  const effectiveLevelsKey = JSON.stringify(sessionLevels ?? settings.selectedLevels)
+
+  // Effective levels: session override > settings preference.
+  // Memoised so the downstream useCallback gets a stable array reference.
+  const effectiveLevels = useMemo(
+    () => (sessionLevels ?? settings.selectedLevels) as readonly CefrLevel[],
+    // effectiveLevelsKey is a serialised representation of the array — safe to
+    // use as the sole dependency here because it changes iff the values change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [effectiveLevelsKey],
+  )
 
   const [phase, setPhase] = useState<SessionPhase>('loading')
   const [queue, setQueue] = useState<QueueItem[]>([])
@@ -213,7 +231,13 @@ export function useQuizSession(
         return
       }
 
-      const wordsForQuiz = await getNextWords(storage, pair.id, BATCH_SIZE)
+      const wordsForQuiz = await getNextWords(
+        storage,
+        pair.id,
+        BATCH_SIZE,
+        Date.now(),
+        effectiveLevels,
+      )
 
       if (!mountedRef.current) return
 
@@ -287,7 +311,7 @@ export function useQuizSession(
       setError(message)
       setPhase('finished')
     }
-  }, [storage, pair, mode])
+  }, [storage, pair, mode, effectiveLevels])
 
   // Load words on mount and whenever pair or mode changes.
   useEffect(() => {

--- a/src/features/settings/components/CefrLevelSelector.tsx
+++ b/src/features/settings/components/CefrLevelSelector.tsx
@@ -1,0 +1,70 @@
+/**
+ * CefrLevelSelector - multi-select toggle chip row for CEFR levels.
+ *
+ * Displays all six levels (A1–C2). Levels with zero words in the active pair
+ * are greyed out but still selectable (user may install a pack later).
+ * When nothing is selected a helper text clarifies that all levels are included.
+ */
+
+import { Box, Chip, Stack, Typography } from '@mui/material'
+import type { CefrLevel } from '@/types'
+import { CEFR_LEVELS } from '@/types'
+
+export interface CefrLevelSelectorProps {
+  /** Currently selected levels. Empty means "all". */
+  readonly selectedLevels: readonly CefrLevel[]
+  /** Word count per level so we can grey out empty ones. */
+  readonly wordCountByLevel: Readonly<Record<CefrLevel, number>>
+  /** Called when the user toggles a level. */
+  readonly onChange: (levels: readonly CefrLevel[]) => void
+}
+
+export function CefrLevelSelector({
+  selectedLevels,
+  wordCountByLevel,
+  onChange,
+}: CefrLevelSelectorProps) {
+  const handleToggle = (level: CefrLevel): void => {
+    const isSelected = selectedLevels.includes(level)
+    const next = isSelected ? selectedLevels.filter((l) => l !== level) : [...selectedLevels, level]
+    onChange(next)
+  }
+
+  const allSelected = selectedLevels.length === 0
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+        {CEFR_LEVELS.map((level) => {
+          const count = wordCountByLevel[level]
+          const isEmpty = count === 0
+          const isSelected = selectedLevels.includes(level)
+
+          return (
+            <Chip
+              key={level}
+              label={`${level}${count > 0 ? ` (${count})` : ''}`}
+              size="small"
+              color={isSelected ? 'primary' : 'default'}
+              variant={isSelected ? 'filled' : 'outlined'}
+              onClick={() => handleToggle(level)}
+              aria-pressed={isSelected}
+              aria-label={`${level}${isEmpty ? ' — no words installed' : ` — ${count} words`}${isSelected ? ', selected' : ''}`}
+              sx={{
+                cursor: 'pointer',
+                opacity: isEmpty ? 0.45 : 1,
+                transition: 'opacity 0.15s',
+              }}
+            />
+          )
+        })}
+      </Stack>
+
+      {allSelected && (
+        <Typography variant="caption" color="text.secondary">
+          All levels included
+        </Typography>
+      )}
+    </Box>
+  )
+}

--- a/src/features/settings/components/SettingsScreen.tsx
+++ b/src/features/settings/components/SettingsScreen.tsx
@@ -3,12 +3,13 @@
  *
  * Sections:
  *  1. Preferences  - theme, quiz mode, daily goal, typo tolerance
- *  2. Language Pairs - list with word counts, links to pair management
- *  3. Data Management - export, import, reset progress, reset all
- *  4. About - version, GitHub link
+ *  2. Training levels - CEFR level multi-select filter
+ *  3. Language Pairs - list with word counts, links to pair management
+ *  4. Data Management - export, import, reset progress, reset all
+ *  5. About - version, GitHub link
  */
 
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
 import {
   Box,
   Button,
@@ -40,9 +41,11 @@ import UploadIcon from '@mui/icons-material/Upload'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import WarningAmberIcon from '@mui/icons-material/WarningAmber'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
-import type { ThemePreference, UserSettings, LanguagePair } from '@/types'
+import type { ThemePreference, UserSettings, LanguagePair, CefrLevel } from '@/types'
 import { useStorage } from '@/hooks/useStorage'
 import { LanguagePairList } from '@/features/language-pairs'
+import { countWordsByLevel } from '@/utils/cefrFilter'
+import { CefrLevelSelector } from './CefrLevelSelector'
 
 /** App version sourced from the bundler-injected env variable. */
 const APP_VERSION = __APP_VERSION__
@@ -94,6 +97,27 @@ export function SettingsScreen({
 
   // --- Preferences state ---
   const [dailyGoalInput, setDailyGoalInput] = useState<string>(String(settings.dailyGoal))
+
+  // --- CEFR word counts state ---
+  const [wordCountByLevel, setWordCountByLevel] = useState<Record<CefrLevel, number>>({
+    A1: 0,
+    A2: 0,
+    B1: 0,
+    B2: 0,
+    C1: 0,
+    C2: 0,
+  })
+
+  // Reload word counts when the active pair changes.
+  useEffect(() => {
+    if (settings.activePairId === null) {
+      setWordCountByLevel({ A1: 0, A2: 0, B1: 0, B2: 0, C1: 0, C2: 0 })
+      return
+    }
+    void storage.getWords(settings.activePairId).then((words) => {
+      setWordCountByLevel(countWordsByLevel(words))
+    })
+  }, [storage, settings.activePairId])
 
   // --- Data management state ---
   const [exporting, setExporting] = useState(false)
@@ -154,6 +178,14 @@ export function SettingsScreen({
       const tolerance = Array.isArray(value) ? value[0] : value
       void storage.saveSettings({ ...settings, typoTolerance: tolerance })
       onSettingsChange({ ...settings, typoTolerance: tolerance })
+    },
+    [settings, onSettingsChange, storage],
+  )
+
+  const handleSelectedLevelsChange = useCallback(
+    (levels: readonly CefrLevel[]) => {
+      void storage.saveSettings({ ...settings, selectedLevels: levels })
+      onSettingsChange({ ...settings, selectedLevels: levels })
     },
     [settings, onSettingsChange, storage],
   )
@@ -440,7 +472,29 @@ export function SettingsScreen({
         </CardContent>
       </Card>
 
-      {/* ── 2. Language Pairs ── */}
+      {/* ── 2. CEFR Levels ── */}
+      <Card variant="outlined">
+        <CardContent sx={{ p: 2.5 }}>
+          <Typography variant="subtitle2" fontWeight={700} gutterBottom>
+            Training levels
+          </Typography>
+
+          <Divider sx={{ my: 1.5 }} />
+
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+            Choose which CEFR levels to include in your quizzes. Your manually added words are
+            always included.
+          </Typography>
+
+          <CefrLevelSelector
+            selectedLevels={settings.selectedLevels}
+            wordCountByLevel={wordCountByLevel}
+            onChange={handleSelectedLevelsChange}
+          />
+        </CardContent>
+      </Card>
+
+      {/* ── 3. Language Pairs ── */}
       <Card variant="outlined">
         <CardContent sx={{ p: 2.5 }}>
           <Typography variant="subtitle2" fontWeight={700} gutterBottom>
@@ -461,7 +515,7 @@ export function SettingsScreen({
         </CardContent>
       </Card>
 
-      {/* ── 3. Data Management ── */}
+      {/* ── 4. Data Management ── */}
       <Card variant="outlined">
         <CardContent sx={{ p: 2.5 }}>
           <Typography variant="subtitle2" fontWeight={700} gutterBottom>
@@ -546,7 +600,7 @@ export function SettingsScreen({
         </CardContent>
       </Card>
 
-      {/* ── 4. About ── */}
+      {/* ── 5. About ── */}
       <Card variant="outlined">
         <CardContent sx={{ p: 2.5 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>

--- a/src/features/starter-packs/components/PackBrowserDialog.tsx
+++ b/src/features/starter-packs/components/PackBrowserDialog.tsx
@@ -15,7 +15,8 @@ import {
 } from '@mui/material'
 import DownloadIcon from '@mui/icons-material/Download'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import type { StarterPack } from '@/types'
+import type { StarterPack, CefrLevel } from '@/types'
+import { isCefrLevel } from '@/utils/cefrFilter'
 import { listPacks, installPack, packMatchesPair } from '@/services/starterPacks'
 import type { InstallPackResult } from '@/services/starterPacks'
 import { useStorage } from '@/hooks/useStorage'
@@ -115,6 +116,25 @@ export function PackBrowserDialog({
           ...prev,
           [pack.id]: { status: 'done', result },
         }))
+
+        // Auto-add the pack's level to selectedLevels if the user has an active
+        // level filter (non-empty selectedLevels means a filter is applied).
+        // If selectedLevels is empty it means "all levels" — no update needed.
+        if (isCefrLevel(pack.level)) {
+          const packLevel = pack.level as CefrLevel
+          const currentSettings = await storage.getSettings()
+          if (
+            currentSettings.selectedLevels.length > 0 &&
+            !currentSettings.selectedLevels.includes(packLevel)
+          ) {
+            const updated = {
+              ...currentSettings,
+              selectedLevels: [...currentSettings.selectedLevels, packLevel],
+            }
+            await storage.saveSettings(updated)
+          }
+        }
+
         // Refresh the word list immediately so it is populated when the dialog closes.
         onInstalled()
         // Auto-close after a brief delay so the user can read the success message.

--- a/src/services/spacedRepetition.test.ts
+++ b/src/services/spacedRepetition.test.ts
@@ -574,6 +574,79 @@ describe('getNextWords', () => {
   })
 })
 
+// ─── getNextWords — CEFR level filtering ──────────────────────────────────────
+
+describe('getNextWords - CEFR level filtering', () => {
+  const NOW = 1_700_000_000_000
+
+  function makeWordWithTags(id: string, tags: string[]): Word {
+    return { ...makeWord(id), tags }
+  }
+
+  it('should return all words when selectedLevels is empty', async () => {
+    const words = [
+      makeWordWithTags('w-a1', ['A1']),
+      makeWordWithTags('w-b1', ['B1']),
+      makeWordWithTags('w-manual', []),
+    ]
+    const storage = makeMockStorage(words)
+    const result = await getNextWords(storage, 'pair-1', 10, NOW, [])
+    expect(result).toHaveLength(3)
+  })
+
+  it('should filter to a single selected level', async () => {
+    const words = [
+      makeWordWithTags('w-a1', ['A1']),
+      makeWordWithTags('w-b1', ['B1']),
+      makeWordWithTags('w-manual', []),
+    ]
+    const storage = makeMockStorage(words)
+    const result = await getNextWords(storage, 'pair-1', 10, NOW, ['B1'])
+    const ids = result.map((r) => r.word.id)
+    expect(ids).toContain('w-b1')
+    expect(ids).toContain('w-manual') // manual words always included
+    expect(ids).not.toContain('w-a1')
+  })
+
+  it('should filter to multiple selected levels', async () => {
+    const words = [
+      makeWordWithTags('w-a1', ['A1']),
+      makeWordWithTags('w-b1', ['B1']),
+      makeWordWithTags('w-b2', ['B2']),
+      makeWordWithTags('w-manual', []),
+    ]
+    const storage = makeMockStorage(words)
+    const result = await getNextWords(storage, 'pair-1', 10, NOW, ['B1', 'B2'])
+    const ids = result.map((r) => r.word.id)
+    expect(ids).toContain('w-b1')
+    expect(ids).toContain('w-b2')
+    expect(ids).toContain('w-manual')
+    expect(ids).not.toContain('w-a1')
+  })
+
+  it('should always include manually added words (no CEFR tags)', async () => {
+    const words = [
+      makeWordWithTags('w-b1', ['B1']),
+      makeWordWithTags('w-manual', []), // no CEFR tag
+      makeWordWithTags('w-tagged', ['food']), // non-CEFR tag
+    ]
+    const storage = makeMockStorage(words)
+    const result = await getNextWords(storage, 'pair-1', 10, NOW, ['C1'])
+    // C1 has no words but manual/non-CEFR tagged words are always included
+    const ids = result.map((r) => r.word.id)
+    expect(ids).toContain('w-manual')
+    expect(ids).toContain('w-tagged')
+    expect(ids).not.toContain('w-b1')
+  })
+
+  it('should return empty array when filter has no matching words and no manual words', async () => {
+    const words = [makeWordWithTags('w-a1', ['A1']), makeWordWithTags('w-b1', ['B1'])]
+    const storage = makeMockStorage(words)
+    const result = await getNextWords(storage, 'pair-1', 10, NOW, ['C2'])
+    expect(result).toHaveLength(0)
+  })
+})
+
 // ─── recordAttempt ────────────────────────────────────────────────────────────
 
 describe('recordAttempt', () => {

--- a/src/services/spacedRepetition.ts
+++ b/src/services/spacedRepetition.ts
@@ -16,8 +16,10 @@ import type {
   QuizDirection,
   QuizMode,
   DailyStats,
+  CefrLevel,
 } from '@/types'
 import type { StorageService } from '@/services/storage/StorageService'
+import { filterWordsByLevels } from '@/utils/cefrFilter'
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 // All algorithm parameters are here - change these to tune behaviour.
@@ -214,8 +216,13 @@ export async function getNextWords(
   pairId: string,
   count: number,
   now: number = Date.now(),
+  selectedLevels: readonly CefrLevel[] = [],
 ): Promise<WordForQuiz[]> {
-  const words = await storage.getWords(pairId)
+  const allWords = await storage.getWords(pairId)
+  if (allWords.length === 0) return []
+
+  // Apply CEFR level filter. Empty selectedLevels means "all words".
+  const words = filterWordsByLevels(allWords, selectedLevels)
   if (words.length === 0) return []
 
   // Load all existing progress records for this pair's words

--- a/src/services/storage/LocalStorageService.test.ts
+++ b/src/services/storage/LocalStorageService.test.ts
@@ -196,6 +196,7 @@ describe('LocalStorageService', () => {
         dailyGoal: 10,
         theme: 'light',
         typoTolerance: 2,
+        selectedLevels: ['B1', 'B2'],
       }
       await service.saveSettings(settings)
       const retrieved = await service.getSettings()
@@ -304,6 +305,7 @@ describe('LocalStorageService', () => {
         dailyGoal: 30,
         theme: 'light',
         typoTolerance: 0,
+        selectedLevels: [],
       }
       const dailyStats: DailyStats = {
         date: '2026-03-01',
@@ -369,6 +371,7 @@ describe('LocalStorageService', () => {
         dailyGoal: 10,
         theme: 'light',
         typoTolerance: 1,
+        selectedLevels: [],
       })
       // Add a non-lexio key to ensure it survives
       localStorage.setItem('other-app:key', 'should-survive')
@@ -393,6 +396,7 @@ describe('LocalStorageService', () => {
         dailyGoal: 20,
         theme: 'dark',
         typoTolerance: 1,
+        selectedLevels: [],
       })
     })
 

--- a/src/services/storage/LocalStorageService.ts
+++ b/src/services/storage/LocalStorageService.ts
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   dailyGoal: 20,
   theme: 'dark',
   typoTolerance: 1,
+  selectedLevels: [],
 }
 
 function readJson<T>(key: string): T | null {
@@ -138,7 +139,10 @@ export class LocalStorageService implements StorageService {
   // --- Settings ---
 
   async getSettings(): Promise<UserSettings> {
-    return readJson<UserSettings>(KEYS.SETTINGS) ?? DEFAULT_SETTINGS
+    const stored = readJson<Partial<UserSettings>>(KEYS.SETTINGS)
+    if (stored === null) return DEFAULT_SETTINGS
+    // Migrate existing settings that predate the selectedLevels field.
+    return { ...DEFAULT_SETTINGS, ...stored }
   }
 
   async saveSettings(settings: UserSettings): Promise<void> {

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -65,6 +65,7 @@ export function createMockSettings(overrides: Partial<UserSettings> = {}): UserS
     dailyGoal: 20,
     theme: 'dark',
     typoTolerance: 1,
+    selectedLevels: [],
     ...overrides,
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,12 +41,22 @@ export interface WordProgress {
 
 export type ThemePreference = 'light' | 'dark' | 'system'
 
+export type CefrLevel = 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2'
+
+/** All CEFR levels in ascending order. */
+export const CEFR_LEVELS: readonly CefrLevel[] = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2']
+
 export interface UserSettings {
   readonly activePairId: string | null
   readonly quizMode: QuizMode
   readonly dailyGoal: number
   readonly theme: ThemePreference
   readonly typoTolerance: number
+  /**
+   * CEFR levels the user wants to train.
+   * Empty array means "all levels" (no filtering applied).
+   */
+  readonly selectedLevels: readonly CefrLevel[]
 }
 
 export interface DailyStats {

--- a/src/utils/cefrFilter.test.ts
+++ b/src/utils/cefrFilter.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for CEFR level filtering utilities.
+ *
+ * Covers:
+ * - isCefrLevel tag detection
+ * - getWordCefrLevels extraction
+ * - filterWordsByLevels: no filter, single level, multi-level,
+ *   manual words always included, empty selection = all
+ * - countWordsByLevel
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  isCefrLevel,
+  getWordCefrLevels,
+  filterWordsByLevels,
+  countWordsByLevel,
+} from './cefrFilter'
+import { createMockWord } from '@/test/fixtures'
+
+describe('isCefrLevel', () => {
+  it('should return true for all valid CEFR levels', () => {
+    expect(isCefrLevel('A1')).toBe(true)
+    expect(isCefrLevel('A2')).toBe(true)
+    expect(isCefrLevel('B1')).toBe(true)
+    expect(isCefrLevel('B2')).toBe(true)
+    expect(isCefrLevel('C1')).toBe(true)
+    expect(isCefrLevel('C2')).toBe(true)
+  })
+
+  it('should return false for non-CEFR strings', () => {
+    expect(isCefrLevel('food')).toBe(false)
+    expect(isCefrLevel('starter-pack')).toBe(false)
+    expect(isCefrLevel('b1')).toBe(false) // case-sensitive
+    expect(isCefrLevel('')).toBe(false)
+    expect(isCefrLevel('D1')).toBe(false)
+  })
+})
+
+describe('getWordCefrLevels', () => {
+  it('should extract CEFR level tags from a word', () => {
+    const word = createMockWord({ tags: ['food', 'B1', 'starter-pack'] })
+    expect(getWordCefrLevels(word)).toEqual(['B1'])
+  })
+
+  it('should return multiple levels if a word has several', () => {
+    const word = createMockWord({ tags: ['B1', 'B2'] })
+    expect(getWordCefrLevels(word)).toEqual(['B1', 'B2'])
+  })
+
+  it('should return empty array for words with no CEFR tags', () => {
+    const word = createMockWord({ tags: ['food', 'travel'] })
+    expect(getWordCefrLevels(word)).toEqual([])
+  })
+
+  it('should return empty array for words with empty tags', () => {
+    const word = createMockWord({ tags: [] })
+    expect(getWordCefrLevels(word)).toEqual([])
+  })
+})
+
+describe('filterWordsByLevels', () => {
+  const wordA1 = createMockWord({ id: 'w-a1', tags: ['A1', 'starter-pack'] })
+  const wordB1 = createMockWord({ id: 'w-b1', tags: ['B1'] })
+  const wordB2 = createMockWord({ id: 'w-b2', tags: ['B2', 'food'] })
+  const wordB1B2 = createMockWord({ id: 'w-b1b2', tags: ['B1', 'B2'] })
+  const wordManual = createMockWord({ id: 'w-manual', tags: [] })
+  const wordManualTagged = createMockWord({ id: 'w-manual-tagged', tags: ['travel', 'food'] })
+
+  const allWords = [wordA1, wordB1, wordB2, wordB1B2, wordManual, wordManualTagged]
+
+  it('should return all words when selectedLevels is empty (no filter)', () => {
+    const result = filterWordsByLevels(allWords, [])
+    expect(result).toHaveLength(allWords.length)
+  })
+
+  it('should filter to a single level', () => {
+    const result = filterWordsByLevels(allWords, ['A1'])
+    // wordA1 (has A1), wordManual (no CEFR tags), wordManualTagged (no CEFR tags)
+    expect(result.map((w) => w.id)).toEqual(
+      expect.arrayContaining(['w-a1', 'w-manual', 'w-manual-tagged']),
+    )
+    expect(result).toHaveLength(3)
+    expect(result.map((w) => w.id)).not.toContain('w-b1')
+    expect(result.map((w) => w.id)).not.toContain('w-b2')
+  })
+
+  it('should filter to multiple levels', () => {
+    const result = filterWordsByLevels(allWords, ['B1', 'B2'])
+    // wordB1, wordB2, wordB1B2, wordManual, wordManualTagged
+    expect(result).toHaveLength(5)
+    expect(result.map((w) => w.id)).toContain('w-b1')
+    expect(result.map((w) => w.id)).toContain('w-b2')
+    expect(result.map((w) => w.id)).toContain('w-b1b2')
+    expect(result.map((w) => w.id)).not.toContain('w-a1')
+  })
+
+  it('should always include manually added words (no CEFR tags) regardless of filter', () => {
+    const result = filterWordsByLevels(allWords, ['C1'])
+    // No words have C1 tag, but manual words are always included
+    expect(result.map((w) => w.id)).toEqual(expect.arrayContaining(['w-manual', 'w-manual-tagged']))
+    expect(result).toHaveLength(2)
+  })
+
+  it('should treat empty selection as "all levels" — same as no filter', () => {
+    const withFilter = filterWordsByLevels(allWords, [])
+    const withAllLevels = filterWordsByLevels(allWords, [])
+    expect(withFilter).toHaveLength(withAllLevels.length)
+  })
+
+  it('should return a new array (does not mutate input)', () => {
+    const input = [wordA1, wordB1]
+    const result = filterWordsByLevels(input, [])
+    expect(result).not.toBe(input)
+  })
+
+  it('should handle words that have multiple CEFR tags — include if any match', () => {
+    const result = filterWordsByLevels([wordB1B2], ['B2'])
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('w-b1b2')
+  })
+
+  it('should return empty array when no pack words match and there are no manual words', () => {
+    const packWordsOnly = [wordA1, wordB1, wordB2]
+    const result = filterWordsByLevels(packWordsOnly, ['C1'])
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe('countWordsByLevel', () => {
+  it('should count words per level', () => {
+    const words = [
+      createMockWord({ id: 'w1', tags: ['A1'] }),
+      createMockWord({ id: 'w2', tags: ['B1'] }),
+      createMockWord({ id: 'w3', tags: ['B1', 'B2'] }), // counted in both B1 and B2
+    ]
+    const counts = countWordsByLevel(words)
+    expect(counts.A1).toBe(1)
+    expect(counts.A2).toBe(0)
+    expect(counts.B1).toBe(2)
+    expect(counts.B2).toBe(1)
+    expect(counts.C1).toBe(0)
+    expect(counts.C2).toBe(0)
+  })
+
+  it('should return all zeros for empty word list', () => {
+    const counts = countWordsByLevel([])
+    expect(counts).toEqual({ A1: 0, A2: 0, B1: 0, B2: 0, C1: 0, C2: 0 })
+  })
+
+  it('should not count words with no CEFR tags in any level', () => {
+    const words = [
+      createMockWord({ id: 'w1', tags: ['food', 'travel'] }),
+      createMockWord({ id: 'w2', tags: [] }),
+    ]
+    const counts = countWordsByLevel(words)
+    expect(counts).toEqual({ A1: 0, A2: 0, B1: 0, B2: 0, C1: 0, C2: 0 })
+  })
+})

--- a/src/utils/cefrFilter.ts
+++ b/src/utils/cefrFilter.ts
@@ -1,0 +1,73 @@
+/**
+ * Utilities for filtering words by CEFR level.
+ *
+ * Rules:
+ * - If selectedLevels is empty, all words are included (no filtering).
+ * - If selectedLevels has values, only words matching at least one selected level
+ *   are included — PLUS manually added words (words with no CEFR level tag) which
+ *   are always included regardless of filter.
+ */
+
+import type { Word } from '@/types'
+import { CEFR_LEVELS } from '@/types'
+import type { CefrLevel } from '@/types'
+
+/**
+ * Returns true if the tag string is a recognised CEFR level.
+ */
+export function isCefrLevel(tag: string): tag is CefrLevel {
+  return (CEFR_LEVELS as readonly string[]).includes(tag)
+}
+
+/**
+ * Extracts the CEFR level tags from a word's tag array.
+ * Returns an empty array if the word has no CEFR level tags.
+ */
+export function getWordCefrLevels(word: Word): readonly CefrLevel[] {
+  return word.tags.filter(isCefrLevel)
+}
+
+/**
+ * Filters a list of words by selected CEFR levels.
+ *
+ * - Empty selectedLevels → return all words unchanged.
+ * - Non-empty selectedLevels → return words that:
+ *   - Have at least one tag matching a selected level, OR
+ *   - Have NO CEFR level tags at all (manually added words — always included).
+ */
+export function filterWordsByLevels(
+  words: readonly Word[],
+  selectedLevels: readonly CefrLevel[],
+): Word[] {
+  if (selectedLevels.length === 0) return [...words]
+
+  return words.filter((word) => {
+    const wordLevels = getWordCefrLevels(word)
+    // Manually added words (no CEFR tags) are always included.
+    if (wordLevels.length === 0) return true
+    // Pack words: include only if they have at least one selected level.
+    return wordLevels.some((level) => selectedLevels.includes(level))
+  })
+}
+
+/**
+ * Counts words per CEFR level for a list of words.
+ * Words with multiple CEFR tags are counted once per tag.
+ * Words with no CEFR tags are counted in the 'manual' bucket (not in any level).
+ */
+export function countWordsByLevel(words: readonly Word[]): Record<CefrLevel, number> {
+  const counts: Record<CefrLevel, number> = {
+    A1: 0,
+    A2: 0,
+    B1: 0,
+    B2: 0,
+    C1: 0,
+    C2: 0,
+  }
+  for (const word of words) {
+    for (const level of getWordCefrLevels(word)) {
+      counts[level]++
+    }
+  }
+  return counts
+}


### PR DESCRIPTION
## Summary

- Adds `CefrLevel` type (`A1|A2|B1|B2|C1|C2`) and `selectedLevels` to `UserSettings`
- New `filterWordsByLevels` utility: empty = all levels; manually-added words (no CEFR tag) always included
- Quiz word pool (`getNextWords`) filtered by selected levels; session override (not persisted) for per-session adjustments
- Settings screen: new "Training levels" section with toggle chips and word count per level
- Quiz mode selector: compact `LevelFilterBar` for session-only override
- `PackBrowserDialog`: auto-adds newly installed pack level to `selectedLevels` when a filter is active
- Graceful migration for existing users (stored settings without `selectedLevels` get default `[]`)

## Changes

- `src/types/index.ts` — `CefrLevel`, `CEFR_LEVELS`, `selectedLevels` on `UserSettings`
- `src/utils/cefrFilter.ts` — new filtering/counting utilities
- `src/utils/cefrFilter.test.ts` — 17 unit tests
- `src/services/spacedRepetition.ts` — `getNextWords` accepts optional `selectedLevels`
- `src/services/spacedRepetition.test.ts` — 5 new level-filter integration tests
- `src/services/storage/LocalStorageService.ts` — defaults + migration
- `src/features/quiz/useQuizSession.ts` — `sessionLevels` override param
- `src/features/quiz/components/LevelFilterBar.tsx` — new compact quiz-screen filter bar
- `src/features/quiz/components/QuizModeSelector.tsx` — renders `LevelFilterBar`
- `src/features/quiz/components/ActiveQuizView.tsx` — threads `sessionLevels`
- `src/features/quiz/components/QuizHub.tsx` — manages session-level state + word counts
- `src/features/settings/components/CefrLevelSelector.tsx` — new multi-select chip component
- `src/features/settings/components/SettingsScreen.tsx` — new "Training levels" section
- `src/features/starter-packs/components/PackBrowserDialog.tsx` — auto-adds level on install
- Test fixtures and `App.tsx` updated with `selectedLevels: []`

## Testing

- 690 tests pass (22 new)
- `npx tsc --noEmit` clean
- `npx eslint . --max-warnings 0` clean
- `npx prettier --check .` clean
- `npm run build` succeeds

## Review

- Code review passed — no issues found

Closes #85