### PR TITLE
fix: add missing favicon.svg to resolve 404 on page load (#99)

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- Dark background matching the app theme (#0a0f1a) -->
+  <rect width="32" height="32" rx="4" fill="#0a0f1a" />
+  <!-- Amber "L" lettermark matching primary brand colour (#f59e0b) -->
+  <path d="M9 7 L9 25 L23 25 L23 21 L13 21 L13 7 Z" fill="#f59e0b" />
+</svg>


### PR DESCRIPTION
## Summary

- Creates `public/favicon.svg` to fix the 404 error generated on every page load
- The SVG icon matches the existing PNG favicon: dark background (`#0a0f1a`) with an amber \"L\" lettermark (`#f59e0b`), consistent with the MUI theme primary colour
- SVG favicons render sharper on HiDPI displays than PNG equivalents

## Changes

- `public/favicon.svg` - new SVG favicon file (6 lines)

## Testing

- All 690 tests pass (`npm test -- --run`)
- TypeScript strict check passes (`npx tsc --noEmit`)
- Production build succeeds (`npm run build`) — file present at `dist/favicon.svg`
- ESLint passes with zero warnings
- Prettier formatted

## Review

- No code changes to application logic
- The `index.html` reference (`/lexio/favicon.svg`) already existed and is correct — Vite rewrites this path at build time using the configured base path

Closes #99