### PR TITLE
feat: add meta description and Open Graph tags (#100)

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,28 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Lexio" />
     <title>Lexio</title>
+    <!-- SEO description -->
+    <meta
+      name="description"
+      content="Learn vocabulary in any language with spaced repetition - free, offline-capable, no account needed."
+    />
+    <!-- Open Graph / social sharing -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://mreppo.github.io/lexio/" />
+    <meta property="og:title" content="Lexio – Vocabulary Trainer" />
+    <meta
+      property="og:description"
+      content="Learn vocabulary in any language with spaced repetition - free, offline-capable, no account needed."
+    />
+    <meta property="og:image" content="https://mreppo.github.io/lexio/og-image.svg" />
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Lexio – Vocabulary Trainer" />
+    <meta
+      name="twitter:description"
+      content="Learn vocabulary in any language with spaced repetition - free, offline-capable, no account needed."
+    />
+    <meta name="twitter:image" content="https://mreppo.github.io/lexio/og-image.svg" />
     <!-- Google Fonts: Sora (display) + Nunito (body). Both support Latvian diacritics.
          No integrity attribute: Google Fonts CSS is dynamically generated per user-agent
          and changes frequently, making static SRI hashes impractical. -->

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,103 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <!-- Background: dark gradient matching the app's dark theme (#0a0f1a → #1a2340) -->
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0f1a"/>
+      <stop offset="100%" stop-color="#1a2340"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ffa000"/>
+      <stop offset="100%" stop-color="#ffca28"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- Subtle grid pattern for depth -->
+  <g opacity="0.04">
+    <line x1="0" y1="105" x2="1200" y2="105" stroke="#ffffff" stroke-width="1"/>
+    <line x1="0" y1="210" x2="1200" y2="210" stroke="#ffffff" stroke-width="1"/>
+    <line x1="0" y1="315" x2="1200" y2="315" stroke="#ffffff" stroke-width="1"/>
+    <line x1="0" y1="420" x2="1200" y2="420" stroke="#ffffff" stroke-width="1"/>
+    <line x1="0" y1="525" x2="1200" y2="525" stroke="#ffffff" stroke-width="1"/>
+    <line x1="200" y1="0" x2="200" y2="630" stroke="#ffffff" stroke-width="1"/>
+    <line x1="400" y1="0" x2="400" y2="630" stroke="#ffffff" stroke-width="1"/>
+    <line x1="600" y1="0" x2="600" y2="630" stroke="#ffffff" stroke-width="1"/>
+    <line x1="800" y1="0" x2="800" y2="630" stroke="#ffffff" stroke-width="1"/>
+    <line x1="1000" y1="0" x2="1000" y2="630" stroke="#ffffff" stroke-width="1"/>
+  </g>
+
+  <!-- Amber accent glow -->
+  <ellipse cx="600" cy="315" rx="420" ry="200" fill="#ffa000" opacity="0.06"/>
+
+  <!-- Logo mark: stylised "L" book/card icon -->
+  <g transform="translate(480, 160)">
+    <!-- Book shape -->
+    <rect x="0" y="0" width="80" height="100" rx="8" fill="url(#accent)" opacity="0.9"/>
+    <rect x="16" y="0" width="80" height="100" rx="8" fill="none" stroke="url(#accent)" stroke-width="3" opacity="0.5"/>
+    <!-- Pages lines -->
+    <line x1="12" y1="28" x2="68" y2="28" stroke="#0a0f1a" stroke-width="3" stroke-linecap="round"/>
+    <line x1="12" y1="44" x2="68" y2="44" stroke="#0a0f1a" stroke-width="3" stroke-linecap="round"/>
+    <line x1="12" y1="60" x2="50" y2="60" stroke="#0a0f1a" stroke-width="3" stroke-linecap="round"/>
+  </g>
+
+  <!-- App name -->
+  <text
+    x="600"
+    y="320"
+    font-family="'Sora', 'Helvetica Neue', Arial, sans-serif"
+    font-size="96"
+    font-weight="700"
+    fill="#ffffff"
+    text-anchor="middle"
+    letter-spacing="-2"
+  >Lexio</text>
+
+  <!-- Amber underline accent -->
+  <rect x="480" y="338" width="240" height="5" rx="2.5" fill="url(#accent)"/>
+
+  <!-- Tagline -->
+  <text
+    x="600"
+    y="400"
+    font-family="'Nunito', 'Helvetica Neue', Arial, sans-serif"
+    font-size="28"
+    font-weight="400"
+    fill="#b0bcd4"
+    text-anchor="middle"
+    letter-spacing="0.5"
+  >Vocabulary trainer with spaced repetition</text>
+
+  <!-- Feature pills -->
+  <g transform="translate(600, 468)" text-anchor="middle">
+    <!-- Pill 1 -->
+    <rect x="-330" y="-20" width="155" height="40" rx="20" fill="#ffffff" fill-opacity="0.08" stroke="#ffffff" stroke-opacity="0.15" stroke-width="1"/>
+    <text x="-252" y="5" font-family="'Nunito', Arial, sans-serif" font-size="18" fill="#e0e8f0" font-weight="500">Any language</text>
+
+    <!-- Pill 2 -->
+    <rect x="-148" y="-20" width="130" height="40" rx="20" fill="#ffffff" fill-opacity="0.08" stroke="#ffffff" stroke-opacity="0.15" stroke-width="1"/>
+    <text x="-83" y="5" font-family="'Nunito', Arial, sans-serif" font-size="18" fill="#e0e8f0" font-weight="500">Offline</text>
+
+    <!-- Pill 3 -->
+    <rect x="18" y="-20" width="145" height="40" rx="20" fill="#ffffff" fill-opacity="0.08" stroke="#ffffff" stroke-opacity="0.15" stroke-width="1"/>
+    <text x="90" y="5" font-family="'Nunito', Arial, sans-serif" font-size="18" fill="#e0e8f0" font-weight="500">Free forever</text>
+
+    <!-- Pill 4 -->
+    <rect x="183" y="-20" width="150" height="40" rx="20" fill="#ffffff" fill-opacity="0.08" stroke="#ffffff" stroke-opacity="0.15" stroke-width="1"/>
+    <text x="258" y="5" font-family="'Nunito', Arial, sans-serif" font-size="18" fill="#e0e8f0" font-weight="500">No account</text>
+  </g>
+
+  <!-- Bottom URL bar -->
+  <rect x="0" y="570" width="1200" height="60" fill="#000000" fill-opacity="0.3"/>
+  <text
+    x="600"
+    y="607"
+    font-family="'Nunito', 'Helvetica Neue', Arial, sans-serif"
+    font-size="22"
+    font-weight="600"
+    fill="#ffa000"
+    text-anchor="middle"
+    letter-spacing="1"
+  >mreppo.github.io/lexio</text>
+</svg>


### PR DESCRIPTION
## Summary

- Add `<meta name="description">` with a concise app description
- Add full Open Graph tag set: `og:type`, `og:url`, `og:title`, `og:description`, `og:image`
- Add Twitter Card tags: `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`
- Create `public/og-image.svg` (1200x630px) with app dark theme, amber accent, tagline, and feature pills

## Changes

- `index.html` - added SEO description and all social meta tags
- `public/og-image.svg` - new OG image matching the app's MUI theme palette

## Testing

- All 690 tests pass
- `npx tsc --noEmit` - no type errors
- `npm run build` - production build succeeds, meta tags present in `dist/index.html`
- `npx eslint . --max-warnings 0` - no lint warnings
- `npx prettier --check .` - formatting clean
- OG image verified in `dist/` after build

## Review

- Code review approved: all tags correct, SVG colours match MUI theme, conventions followed

Closes #100