### PR TITLE
data: remove cross-level duplicate words from starter packs (#83)

### DIFF
--- a/public/starter-packs/en-lv-a1.json
+++ b/public/starter-packs/en-lv-a1.json
@@ -6,192 +6,940 @@
   "targetCode": "en",
   "level": "A1",
   "words": [
-    { "source": "sveiki", "target": "hello", "tags": ["greetings", "A1"] },
-    { "source": "čau", "target": "hi", "tags": ["greetings", "A1"] },
-    { "source": "ardievu", "target": "goodbye", "tags": ["greetings", "A1"] },
-    { "source": "lūdzu", "target": "please", "tags": ["greetings", "A1"] },
-    { "source": "paldies", "target": "thank you", "tags": ["greetings", "A1"] },
-    { "source": "jā", "target": "yes", "tags": ["greetings", "A1"] },
-    { "source": "nē", "target": "no", "tags": ["greetings", "A1"] },
-    { "source": "piedodiet", "target": "sorry", "tags": ["greetings", "A1"] },
-    { "source": "labrīt", "target": "good morning", "tags": ["greetings", "A1"] },
-    { "source": "labdien", "target": "good afternoon", "tags": ["greetings", "A1"] },
-    { "source": "labvakar", "target": "good evening", "tags": ["greetings", "A1"] },
-    { "source": "uz redzēšanos", "target": "see you later", "tags": ["greetings", "A1"] },
-    { "source": "viens", "target": "one", "tags": ["numbers", "A1"] },
-    { "source": "divi", "target": "two", "tags": ["numbers", "A1"] },
-    { "source": "trīs", "target": "three", "tags": ["numbers", "A1"] },
-    { "source": "četri", "target": "four", "tags": ["numbers", "A1"] },
-    { "source": "pieci", "target": "five", "tags": ["numbers", "A1"] },
-    { "source": "seši", "target": "six", "tags": ["numbers", "A1"] },
-    { "source": "septiņi", "target": "seven", "tags": ["numbers", "A1"] },
-    { "source": "astoņi", "target": "eight", "tags": ["numbers", "A1"] },
-    { "source": "deviņi", "target": "nine", "tags": ["numbers", "A1"] },
-    { "source": "desmit", "target": "ten", "tags": ["numbers", "A1"] },
-    { "source": "vienpadsmit", "target": "eleven", "tags": ["numbers", "A1"] },
-    { "source": "divpadsmit", "target": "twelve", "tags": ["numbers", "A1"] },
-    { "source": "trīspadsmit", "target": "thirteen", "tags": ["numbers", "A1"] },
-    { "source": "četrpadsmit", "target": "fourteen", "tags": ["numbers", "A1"] },
-    { "source": "piecpadsmit", "target": "fifteen", "tags": ["numbers", "A1"] },
-    { "source": "sešpadsmit", "target": "sixteen", "tags": ["numbers", "A1"] },
-    { "source": "septiņpadsmit", "target": "seventeen", "tags": ["numbers", "A1"] },
-    { "source": "astoņpadsmit", "target": "eighteen", "tags": ["numbers", "A1"] },
-    { "source": "deviņpadsmit", "target": "nineteen", "tags": ["numbers", "A1"] },
-    { "source": "divdesmit", "target": "twenty", "tags": ["numbers", "A1"] },
-    { "source": "sarkans", "target": "red", "tags": ["colours", "A1"] },
-    { "source": "zils", "target": "blue", "tags": ["colours", "A1"] },
-    { "source": "zaļš", "target": "green", "tags": ["colours", "A1"] },
-    { "source": "dzeltens", "target": "yellow", "tags": ["colours", "A1"] },
-    { "source": "balts", "target": "white", "tags": ["colours", "A1"] },
-    { "source": "melns", "target": "black", "tags": ["colours", "A1"] },
-    { "source": "oranžs", "target": "orange", "tags": ["colours", "A1"] },
-    { "source": "rozā", "target": "pink", "tags": ["colours", "A1"] },
-    { "source": "violets", "target": "purple", "tags": ["colours", "A1"] },
-    { "source": "brūns", "target": "brown", "tags": ["colours", "A1"] },
-    { "source": "pelēks", "target": "grey", "tags": ["colours", "A1"] },
-    { "source": "māte", "target": "mother", "tags": ["family", "A1"] },
-    { "source": "tēvs", "target": "father", "tags": ["family", "A1"] },
-    { "source": "māsa", "target": "sister", "tags": ["family", "A1"] },
-    { "source": "brālis", "target": "brother", "tags": ["family", "A1"] },
-    { "source": "vecāmāte", "target": "grandmother", "tags": ["family", "A1"] },
-    { "source": "vectēvs", "target": "grandfather", "tags": ["family", "A1"] },
-    { "source": "bērns", "target": "child", "tags": ["family", "A1"] },
-    { "source": "dēls", "target": "son", "tags": ["family", "A1"] },
-    { "source": "meita", "target": "daughter", "tags": ["family", "A1"] },
-    { "source": "vīrs", "target": "husband", "tags": ["family", "A1"] },
-    { "source": "sieva", "target": "wife", "tags": ["family", "A1"] },
-    { "source": "ģimene", "target": "family", "tags": ["family", "A1"] },
-    { "source": "ūdens", "target": "water", "tags": ["food-drink", "A1"] },
-    { "source": "piens", "target": "milk", "tags": ["food-drink", "A1"] },
-    { "source": "maize", "target": "bread", "tags": ["food-drink", "A1"] },
-    { "source": "ola", "target": "egg", "tags": ["food-drink", "A1"] },
-    { "source": "ābols", "target": "apple", "tags": ["food-drink", "A1"] },
-    { "source": "banāns", "target": "banana", "tags": ["food-drink", "A1"] },
-    { "source": "kafija", "target": "coffee", "tags": ["food-drink", "A1"] },
-    { "source": "tēja", "target": "tea", "tags": ["food-drink", "A1"] },
-    { "source": "siers", "target": "cheese", "tags": ["food-drink", "A1"] },
-    { "source": "gaļa", "target": "meat", "tags": ["food-drink", "A1"] },
-    { "source": "rīsi", "target": "rice", "tags": ["food-drink", "A1"] },
-    { "source": "cukurs", "target": "sugar", "tags": ["food-drink", "A1"] },
-    { "source": "pirmdiena", "target": "Monday", "tags": ["days", "A1"] },
-    { "source": "otrdiena", "target": "Tuesday", "tags": ["days", "A1"] },
-    { "source": "trešdiena", "target": "Wednesday", "tags": ["days", "A1"] },
-    { "source": "ceturtdiena", "target": "Thursday", "tags": ["days", "A1"] },
-    { "source": "piektdiena", "target": "Friday", "tags": ["days", "A1"] },
-    { "source": "sestdiena", "target": "Saturday", "tags": ["days", "A1"] },
-    { "source": "svētdiena", "target": "Sunday", "tags": ["days", "A1"] },
-    { "source": "janvāris", "target": "January", "tags": ["months", "A1"] },
-    { "source": "februāris", "target": "February", "tags": ["months", "A1"] },
-    { "source": "marts", "target": "March", "tags": ["months", "A1"] },
-    { "source": "aprīlis", "target": "April", "tags": ["months", "A1"] },
-    { "source": "maijs", "target": "May", "tags": ["months", "A1"] },
-    { "source": "jūnijs", "target": "June", "tags": ["months", "A1"] },
-    { "source": "jūlijs", "target": "July", "tags": ["months", "A1"] },
-    { "source": "augusts", "target": "August", "tags": ["months", "A1"] },
-    { "source": "septembris", "target": "September", "tags": ["months", "A1"] },
-    { "source": "oktobris", "target": "October", "tags": ["months", "A1"] },
-    { "source": "novembris", "target": "November", "tags": ["months", "A1"] },
-    { "source": "decembris", "target": "December", "tags": ["months", "A1"] },
-    { "source": "būt", "target": "to be", "tags": ["verbs", "A1"] },
-    { "source": "ir", "target": "is", "tags": ["verbs", "A1"] },
-    { "source": "būt", "target": "to have", "tags": ["verbs", "A1"] },
-    { "source": "iet", "target": "to go", "tags": ["verbs", "A1"] },
-    { "source": "gribēt", "target": "to want", "tags": ["verbs", "A1"] },
-    { "source": "patikt", "target": "to like", "tags": ["verbs", "A1"] },
-    { "source": "nākt", "target": "to come", "tags": ["verbs", "A1"] },
-    { "source": "redzēt", "target": "to see", "tags": ["verbs", "A1"] },
-    { "source": "dzirdēt", "target": "to hear", "tags": ["verbs", "A1"] },
-    { "source": "ēst", "target": "to eat", "tags": ["verbs", "A1"] },
-    { "source": "dzert", "target": "to drink", "tags": ["verbs", "A1"] },
-    { "source": "gulēt", "target": "to sleep", "tags": ["verbs", "A1"] },
-    { "source": "sēdēt", "target": "to sit", "tags": ["verbs", "A1"] },
-    { "source": "stāvēt", "target": "to stand", "tags": ["verbs", "A1"] },
-    { "source": "runāt", "target": "to talk", "tags": ["verbs", "A1"] },
-    { "source": "dot", "target": "to give", "tags": ["verbs", "A1"] },
-    { "source": "ņemt", "target": "to take", "tags": ["verbs", "A1"] },
-    { "source": "skatīties", "target": "to look", "tags": ["verbs", "A1"] },
-    { "source": "labi", "target": "good", "tags": ["adjectives", "A1"] },
-    { "source": "slikti", "target": "bad", "tags": ["adjectives", "A1"] },
-    { "source": "liels", "target": "big", "tags": ["adjectives", "A1"] },
-    { "source": "mazs", "target": "small", "tags": ["adjectives", "A1"] },
-    { "source": "karsts", "target": "hot", "tags": ["adjectives", "A1"] },
-    { "source": "auksts", "target": "cold", "tags": ["adjectives", "A1"] },
-    { "source": "jauns", "target": "new", "tags": ["adjectives", "A1"] },
-    { "source": "vecs", "target": "old", "tags": ["adjectives", "A1"] },
-    { "source": "garš", "target": "long", "tags": ["adjectives", "A1"] },
-    { "source": "īss", "target": "short", "tags": ["adjectives", "A1"] },
-    { "source": "augsts", "target": "tall", "tags": ["adjectives", "A1"] },
-    { "source": "zems", "target": "low", "tags": ["adjectives", "A1"] },
-    { "source": "es", "target": "I", "tags": ["pronouns", "A1"] },
-    { "source": "tu", "target": "you", "tags": ["pronouns", "A1"] },
-    { "source": "viņš", "target": "he", "tags": ["pronouns", "A1"] },
-    { "source": "viņa", "target": "she", "tags": ["pronouns", "A1"] },
-    { "source": "mēs", "target": "we", "tags": ["pronouns", "A1"] },
-    { "source": "viņi", "target": "they", "tags": ["pronouns", "A1"] },
-    { "source": "tas", "target": "it", "tags": ["pronouns", "A1"] },
-    { "source": "māja", "target": "house", "tags": ["home", "A1"] },
-    { "source": "istaba", "target": "room", "tags": ["home", "A1"] },
-    { "source": "durvis", "target": "door", "tags": ["home", "A1"] },
-    { "source": "logs", "target": "window", "tags": ["home", "A1"] },
-    { "source": "galds", "target": "table", "tags": ["home", "A1"] },
-    { "source": "krēsls", "target": "chair", "tags": ["home", "A1"] },
-    { "source": "gulta", "target": "bed", "tags": ["home", "A1"] },
-    { "source": "cilvēks", "target": "person", "tags": ["social", "A1"] },
-    { "source": "vīrietis", "target": "man", "tags": ["social", "A1"] },
-    { "source": "sieviete", "target": "woman", "tags": ["social", "A1"] },
-    { "source": "zēns", "target": "boy", "tags": ["social", "A1"] },
-    { "source": "meitene", "target": "girl", "tags": ["social", "A1"] },
-    { "source": "draugs", "target": "friend", "tags": ["social", "A1"] },
-    { "source": "vārds", "target": "name", "tags": ["social", "A1"] },
-    { "source": "vecums", "target": "age", "tags": ["social", "A1"] },
-    { "source": "dzīvnieks", "target": "animal", "tags": ["nature", "A1"] },
-    { "source": "suns", "target": "dog", "tags": ["nature", "A1"] },
-    { "source": "kaķis", "target": "cat", "tags": ["nature", "A1"] },
-    { "source": "putns", "target": "bird", "tags": ["nature", "A1"] },
-    { "source": "zivs", "target": "fish", "tags": ["nature", "A1"] },
-    { "source": "koks", "target": "tree", "tags": ["nature", "A1"] },
-    { "source": "puķe", "target": "flower", "tags": ["nature", "A1"] },
-    { "source": "saule", "target": "sun", "tags": ["nature", "A1"] },
-    { "source": "lietus", "target": "rain", "tags": ["nature", "A1"] },
-    { "source": "sniegs", "target": "snow", "tags": ["nature", "A1"] },
-    { "source": "telefons", "target": "phone", "tags": ["objects", "A1"] },
-    { "source": "grāmata", "target": "book", "tags": ["objects", "A1"] },
-    { "source": "pildspalva", "target": "pen", "tags": ["objects", "A1"] },
-    { "source": "soma", "target": "bag", "tags": ["objects", "A1"] },
-    { "source": "atslēga", "target": "key", "tags": ["objects", "A1"] },
-    { "source": "nauda", "target": "money", "tags": ["objects", "A1"] },
-    { "source": "veikals", "target": "shop", "tags": ["social", "A1"] },
-    { "source": "skola", "target": "school", "tags": ["social", "A1"] },
-    { "source": "automašīna", "target": "car", "tags": ["travel", "A1"] },
-    { "source": "autobuss", "target": "bus", "tags": ["travel", "A1"] },
-    { "source": "iela", "target": "street", "tags": ["travel", "A1"] },
-    { "source": "pilsēta", "target": "city", "tags": ["travel", "A1"] },
-    { "source": "valsts", "target": "country", "tags": ["travel", "A1"] },
-    { "source": "šeit", "target": "here", "tags": ["directions", "A1"] },
-    { "source": "tur", "target": "there", "tags": ["directions", "A1"] },
-    { "source": "pa labi", "target": "to the right", "tags": ["directions", "A1"] },
-    { "source": "pa kreisi", "target": "to the left", "tags": ["directions", "A1"] },
-    { "source": "taisni", "target": "straight ahead", "tags": ["directions", "A1"] },
-    { "source": "augšā", "target": "up", "tags": ["directions", "A1"] },
-    { "source": "lejā", "target": "down", "tags": ["directions", "A1"] },
-    { "source": "diena", "target": "day", "tags": ["time", "A1"] },
-    { "source": "nakts", "target": "night", "tags": ["time", "A1"] },
-    { "source": "rīts", "target": "morning", "tags": ["time", "A1"] },
-    { "source": "vakars", "target": "evening", "tags": ["time", "A1"] },
-    { "source": "tagad", "target": "now", "tags": ["time", "A1"] },
-    { "source": "vakar", "target": "yesterday", "tags": ["time", "A1"] },
-    { "source": "rīt", "target": "tomorrow", "tags": ["time", "A1"] },
-    { "source": "šodien", "target": "today", "tags": ["time", "A1"] },
-    { "source": "nedēļa", "target": "week", "tags": ["time", "A1"] },
-    { "source": "mēnesis", "target": "month", "tags": ["time", "A1"] },
-    { "source": "gads", "target": "year", "tags": ["time", "A1"] },
-    { "source": "galva", "target": "head", "tags": ["body", "A1"] },
-    { "source": "roka", "target": "hand", "tags": ["body", "A1"] },
-    { "source": "kāja", "target": "leg", "tags": ["body", "A1"] },
-    { "source": "acis", "target": "eyes", "tags": ["body", "A1"] },
-    { "source": "ausis", "target": "ears", "tags": ["body", "A1"] },
-    { "source": "deguns", "target": "nose", "tags": ["body", "A1"] },
-    { "source": "mute", "target": "mouth", "tags": ["body", "A1"] },
-    { "source": "sirds", "target": "heart", "tags": ["body", "A1"] }
+    {
+      "source": "sveiki",
+      "target": "hello",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "čau",
+      "target": "hi",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "ardievu",
+      "target": "goodbye",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "lūdzu",
+      "target": "please",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "paldies",
+      "target": "thank you",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "jā",
+      "target": "yes",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "nē",
+      "target": "no",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "piedodiet",
+      "target": "sorry",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "labrīt",
+      "target": "good morning",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "labdien",
+      "target": "good afternoon",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "labvakar",
+      "target": "good evening",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "uz redzēšanos",
+      "target": "see you later",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "viens",
+      "target": "one",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "divi",
+      "target": "two",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "trīs",
+      "target": "three",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "četri",
+      "target": "four",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "pieci",
+      "target": "five",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "seši",
+      "target": "six",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "septiņi",
+      "target": "seven",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "astoņi",
+      "target": "eight",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "deviņi",
+      "target": "nine",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "desmit",
+      "target": "ten",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "vienpadsmit",
+      "target": "eleven",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "divpadsmit",
+      "target": "twelve",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "trīspadsmit",
+      "target": "thirteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "četrpadsmit",
+      "target": "fourteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "piecpadsmit",
+      "target": "fifteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "sešpadsmit",
+      "target": "sixteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "septiņpadsmit",
+      "target": "seventeen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "astoņpadsmit",
+      "target": "eighteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "deviņpadsmit",
+      "target": "nineteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "divdesmit",
+      "target": "twenty",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "sarkans",
+      "target": "red",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "zils",
+      "target": "blue",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "zaļš",
+      "target": "green",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "dzeltens",
+      "target": "yellow",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "balts",
+      "target": "white",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "melns",
+      "target": "black",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "oranžs",
+      "target": "orange",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "rozā",
+      "target": "pink",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "violets",
+      "target": "purple",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "brūns",
+      "target": "brown",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "pelēks",
+      "target": "grey",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "māte",
+      "target": "mother",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "tēvs",
+      "target": "father",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "māsa",
+      "target": "sister",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "brālis",
+      "target": "brother",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "vecāmāte",
+      "target": "grandmother",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "vectēvs",
+      "target": "grandfather",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "bērns",
+      "target": "child",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "dēls",
+      "target": "son",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "meita",
+      "target": "daughter",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "vīrs",
+      "target": "husband",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "sieva",
+      "target": "wife",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "ģimene",
+      "target": "family",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "ūdens",
+      "target": "water",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "piens",
+      "target": "milk",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "maize",
+      "target": "bread",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "ola",
+      "target": "egg",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "ābols",
+      "target": "apple",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "banāns",
+      "target": "banana",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "kafija",
+      "target": "coffee",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "tēja",
+      "target": "tea",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "siers",
+      "target": "cheese",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "gaļa",
+      "target": "meat",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "rīsi",
+      "target": "rice",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "cukurs",
+      "target": "sugar",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "pirmdiena",
+      "target": "Monday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "otrdiena",
+      "target": "Tuesday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "trešdiena",
+      "target": "Wednesday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "ceturtdiena",
+      "target": "Thursday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "piektdiena",
+      "target": "Friday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "sestdiena",
+      "target": "Saturday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "svētdiena",
+      "target": "Sunday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "janvāris",
+      "target": "January",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "februāris",
+      "target": "February",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "marts",
+      "target": "March",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "aprīlis",
+      "target": "April",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "maijs",
+      "target": "May",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "jūnijs",
+      "target": "June",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "jūlijs",
+      "target": "July",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "augusts",
+      "target": "August",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "septembris",
+      "target": "September",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "oktobris",
+      "target": "October",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "novembris",
+      "target": "November",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "decembris",
+      "target": "December",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "būt",
+      "target": "to be",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "ir",
+      "target": "is",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "būt",
+      "target": "to have",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "iet",
+      "target": "to go",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "gribēt",
+      "target": "to want",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "patikt",
+      "target": "to like",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "nākt",
+      "target": "to come",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "redzēt",
+      "target": "to see",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "dzirdēt",
+      "target": "to hear",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "ēst",
+      "target": "to eat",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "dzert",
+      "target": "to drink",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "gulēt",
+      "target": "to sleep",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "sēdēt",
+      "target": "to sit",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "stāvēt",
+      "target": "to stand",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "runāt",
+      "target": "to talk",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "dot",
+      "target": "to give",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "ņemt",
+      "target": "to take",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "skatīties",
+      "target": "to look",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "labi",
+      "target": "good",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "slikti",
+      "target": "bad",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "liels",
+      "target": "big",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "mazs",
+      "target": "small",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "karsts",
+      "target": "hot",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "auksts",
+      "target": "cold",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "jauns",
+      "target": "new",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "vecs",
+      "target": "old",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "garš",
+      "target": "long",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "īss",
+      "target": "short",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "augsts",
+      "target": "tall",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "zems",
+      "target": "low",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "es",
+      "target": "I",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "tu",
+      "target": "you",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "viņš",
+      "target": "he",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "viņa",
+      "target": "she",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "mēs",
+      "target": "we",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "viņi",
+      "target": "they",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "tas",
+      "target": "it",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "māja",
+      "target": "house",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "istaba",
+      "target": "room",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "durvis",
+      "target": "door",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "logs",
+      "target": "window",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "galds",
+      "target": "table",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "krēsls",
+      "target": "chair",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "gulta",
+      "target": "bed",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "cilvēks",
+      "target": "person",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "vīrietis",
+      "target": "man",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "sieviete",
+      "target": "woman",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "zēns",
+      "target": "boy",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "meitene",
+      "target": "girl",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "draugs",
+      "target": "friend",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "vārds",
+      "target": "name",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "vecums",
+      "target": "age",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "dzīvnieks",
+      "target": "animal",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "suns",
+      "target": "dog",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "kaķis",
+      "target": "cat",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "putns",
+      "target": "bird",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "zivs",
+      "target": "fish",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "koks",
+      "target": "tree",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "puķe",
+      "target": "flower",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "saule",
+      "target": "sun",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "lietus",
+      "target": "rain",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "sniegs",
+      "target": "snow",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "telefons",
+      "target": "phone",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "grāmata",
+      "target": "book",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "pildspalva",
+      "target": "pen",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "soma",
+      "target": "bag",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "atslēga",
+      "target": "key",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "nauda",
+      "target": "money",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "veikals",
+      "target": "shop",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "skola",
+      "target": "school",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "automašīna",
+      "target": "car",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "autobuss",
+      "target": "bus",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "iela",
+      "target": "street",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "pilsēta",
+      "target": "city",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "valsts",
+      "target": "country",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "šeit",
+      "target": "here",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "tur",
+      "target": "there",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "pa labi",
+      "target": "to the right",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "pa kreisi",
+      "target": "to the left",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "taisni",
+      "target": "straight ahead",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "augšā",
+      "target": "up",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "lejā",
+      "target": "down",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "diena",
+      "target": "day",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "nakts",
+      "target": "night",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "rīts",
+      "target": "morning",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "vakars",
+      "target": "evening",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "tagad",
+      "target": "now",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "vakar",
+      "target": "yesterday",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "rīt",
+      "target": "tomorrow",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "šodien",
+      "target": "today",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "nedēļa",
+      "target": "week",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "mēnesis",
+      "target": "month",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "gads",
+      "target": "year",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "galva",
+      "target": "head",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "roka",
+      "target": "hand",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "kāja",
+      "target": "leg",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "acis",
+      "target": "eyes",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "ausis",
+      "target": "ears",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "deguns",
+      "target": "nose",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "mute",
+      "target": "mouth",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "sirds",
+      "target": "heart",
+      "tags": ["body", "A1"]
+    }
   ]
 }

--- a/public/starter-packs/en-lv-a2.json
+++ b/public/starter-packs/en-lv-a2.json
@@ -6,150 +6,720 @@
   "targetCode": "en",
   "level": "A2",
   "words": [
-    { "source": "iepirkšanās", "target": "shopping", "tags": ["shopping", "A2"] },
-    { "source": "veikals", "target": "store", "tags": ["shopping", "A2"] },
-    { "source": "cena", "target": "price", "tags": ["shopping", "A2"] },
-    { "source": "lēts", "target": "cheap", "tags": ["shopping", "A2"] },
-    { "source": "dārgs", "target": "expensive", "tags": ["shopping", "A2"] },
-    { "source": "nauda", "target": "money", "tags": ["shopping", "A2"] },
-    { "source": "rēķins", "target": "receipt", "tags": ["shopping", "A2"] },
-    { "source": "atlaides", "target": "discount", "tags": ["shopping", "A2"] },
-    { "source": "izmērs", "target": "size", "tags": ["shopping", "A2"] },
-    { "source": "kaste", "target": "box", "tags": ["shopping", "A2"] },
-    { "source": "maiss", "target": "bag", "tags": ["shopping", "A2"] },
-    { "source": "kārta", "target": "queue", "tags": ["shopping", "A2"] },
-    { "source": "ceļš", "target": "road", "tags": ["directions", "A2"] },
-    { "source": "stūris", "target": "corner", "tags": ["directions", "A2"] },
-    { "source": "krusts", "target": "crossroads", "tags": ["directions", "A2"] },
-    { "source": "tilts", "target": "bridge", "tags": ["directions", "A2"] },
-    { "source": "stacija", "target": "station", "tags": ["directions", "A2"] },
-    { "source": "apstādīšanās vieta", "target": "stop", "tags": ["directions", "A2"] },
-    { "source": "tuvumā", "target": "nearby", "tags": ["directions", "A2"] },
-    { "source": "tālu", "target": "far", "tags": ["directions", "A2"] },
-    { "source": "aiz", "target": "behind", "tags": ["directions", "A2"] },
-    { "source": "priekšā", "target": "in front of", "tags": ["directions", "A2"] },
-    { "source": "blakus", "target": "next to", "tags": ["directions", "A2"] },
-    { "source": "laika apstākļi", "target": "weather", "tags": ["weather", "A2"] },
-    { "source": "saulains", "target": "sunny", "tags": ["weather", "A2"] },
-    { "source": "mākoņains", "target": "cloudy", "tags": ["weather", "A2"] },
-    { "source": "lietains", "target": "rainy", "tags": ["weather", "A2"] },
-    { "source": "vējaini", "target": "windy", "tags": ["weather", "A2"] },
-    { "source": "sniegains", "target": "snowy", "tags": ["weather", "A2"] },
-    { "source": "silts", "target": "warm", "tags": ["weather", "A2"] },
-    { "source": "auksts", "target": "cold", "tags": ["weather", "A2"] },
-    { "source": "pērkons", "target": "thunder", "tags": ["weather", "A2"] },
-    { "source": "zibens", "target": "lightning", "tags": ["weather", "A2"] },
-    { "source": "vāji", "target": "ill", "tags": ["health", "A2"] },
-    { "source": "galvassāpes", "target": "headache", "tags": ["health", "A2"] },
-    { "source": "drudzis", "target": "fever", "tags": ["health", "A2"] },
-    { "source": "klepus", "target": "cough", "tags": ["health", "A2"] },
-    { "source": "iesnas", "target": "cold", "tags": ["health", "A2"] },
-    { "source": "sāpes", "target": "pain", "tags": ["health", "A2"] },
-    { "source": "ārsts", "target": "doctor", "tags": ["health", "A2"] },
-    { "source": "zāles", "target": "medicine", "tags": ["health", "A2"] },
-    { "source": "slimnīca", "target": "hospital", "tags": ["health", "A2"] },
-    { "source": "aptieka", "target": "pharmacy", "tags": ["health", "A2"] },
-    { "source": "veselīgs", "target": "healthy", "tags": ["health", "A2"] },
-    { "source": "sportot", "target": "to exercise", "tags": ["hobbies", "A2"] },
-    { "source": "lasīt", "target": "to read", "tags": ["hobbies", "A2"] },
-    { "source": "klausīties mūziku", "target": "to listen to music", "tags": ["hobbies", "A2"] },
-    { "source": "skatīties televizoru", "target": "to watch TV", "tags": ["hobbies", "A2"] },
-    { "source": "ceļot", "target": "to travel", "tags": ["hobbies", "A2"] },
-    { "source": "gatavot", "target": "to cook", "tags": ["hobbies", "A2"] },
-    { "source": "zīmēt", "target": "to draw", "tags": ["hobbies", "A2"] },
-    { "source": "fotografēt", "target": "to photograph", "tags": ["hobbies", "A2"] },
-    { "source": "spēlēt", "target": "to play", "tags": ["hobbies", "A2"] },
-    { "source": "dejot", "target": "to dance", "tags": ["hobbies", "A2"] },
-    { "source": "dziedāt", "target": "to sing", "tags": ["hobbies", "A2"] },
-    { "source": "peldēties", "target": "to swim", "tags": ["hobbies", "A2"] },
-    { "source": "braukt ar velosipēdu", "target": "to cycle", "tags": ["hobbies", "A2"] },
-    { "source": "interesants", "target": "interesting", "tags": ["adjectives", "A2"] },
-    { "source": "garlaicīgs", "target": "boring", "tags": ["adjectives", "A2"] },
-    { "source": "jautrs", "target": "fun", "tags": ["adjectives", "A2"] },
-    { "source": "aizraujoši", "target": "exciting", "tags": ["adjectives", "A2"] },
-    { "source": "grūts", "target": "difficult", "tags": ["adjectives", "A2"] },
-    { "source": "viegls", "target": "easy", "tags": ["adjectives", "A2"] },
-    { "source": "dārgais", "target": "dear", "tags": ["adjectives", "A2"] },
-    { "source": "draudzīgs", "target": "friendly", "tags": ["adjectives", "A2"] },
-    { "source": "gudrs", "target": "clever", "tags": ["adjectives", "A2"] },
-    { "source": "muļķīgs", "target": "silly", "tags": ["adjectives", "A2"] },
-    { "source": "laipns", "target": "kind", "tags": ["adjectives", "A2"] },
-    { "source": "uzticams", "target": "honest", "tags": ["adjectives", "A2"] },
-    { "source": "laimīgs", "target": "happy", "tags": ["adjectives", "A2"] },
-    { "source": "skumīgs", "target": "sad", "tags": ["adjectives", "A2"] },
-    { "source": "noguris", "target": "tired", "tags": ["adjectives", "A2"] },
-    { "source": "izsalcis", "target": "hungry", "tags": ["adjectives", "A2"] },
-    { "source": "izslāpis", "target": "thirsty", "tags": ["adjectives", "A2"] },
-    { "source": "dikts", "target": "scared", "tags": ["adjectives", "A2"] },
-    { "source": "pārsteigts", "target": "surprised", "tags": ["adjectives", "A2"] },
-    { "source": "apģērbs", "target": "clothes", "tags": ["clothing", "A2"] },
-    { "source": "krekls", "target": "shirt", "tags": ["clothing", "A2"] },
-    { "source": "bikses", "target": "trousers", "tags": ["clothing", "A2"] },
-    { "source": "kleita", "target": "dress", "tags": ["clothing", "A2"] },
-    { "source": "jaka", "target": "jacket", "tags": ["clothing", "A2"] },
-    { "source": "kurpes", "target": "shoes", "tags": ["clothing", "A2"] },
-    { "source": "cepure", "target": "hat", "tags": ["clothing", "A2"] },
-    { "source": "zeķes", "target": "socks", "tags": ["clothing", "A2"] },
-    { "source": "džemperis", "target": "sweater", "tags": ["clothing", "A2"] },
-    { "source": "mētelis", "target": "coat", "tags": ["clothing", "A2"] },
-    { "source": "kafejnīca", "target": "café", "tags": ["food-drink", "A2"] },
-    { "source": "ēdienkarte", "target": "menu", "tags": ["food-drink", "A2"] },
-    { "source": "galdiņš", "target": "table", "tags": ["food-drink", "A2"] },
-    { "source": "pasūtīt", "target": "to order", "tags": ["food-drink", "A2"] },
-    { "source": "vārīts", "target": "boiled", "tags": ["food-drink", "A2"] },
-    { "source": "cepts", "target": "fried", "tags": ["food-drink", "A2"] },
-    { "source": "svaigs", "target": "fresh", "tags": ["food-drink", "A2"] },
-    { "source": "salds", "target": "sweet", "tags": ["food-drink", "A2"] },
-    { "source": "skābs", "target": "sour", "tags": ["food-drink", "A2"] },
-    { "source": "sāļš", "target": "salty", "tags": ["food-drink", "A2"] },
-    { "source": "asa", "target": "spicy", "tags": ["food-drink", "A2"] },
-    { "source": "sula", "target": "juice", "tags": ["food-drink", "A2"] },
-    { "source": "gaļas ēdiens", "target": "main course", "tags": ["food-drink", "A2"] },
-    { "source": "deserts", "target": "dessert", "tags": ["food-drink", "A2"] },
-    { "source": "stundu", "target": "hour", "tags": ["time", "A2"] },
-    { "source": "agrāk", "target": "earlier", "tags": ["time", "A2"] },
-    { "source": "vēlāk", "target": "later", "tags": ["time", "A2"] },
-    { "source": "bieži", "target": "often", "tags": ["time", "A2"] },
-    { "source": "dažreiz", "target": "sometimes", "tags": ["time", "A2"] },
-    { "source": "nekad", "target": "never", "tags": ["time", "A2"] },
-    { "source": "vienmēr", "target": "always", "tags": ["time", "A2"] },
-    { "source": "tūlīt", "target": "soon", "tags": ["time", "A2"] },
-    { "source": "vēl", "target": "still", "tags": ["time", "A2"] },
-    { "source": "jau", "target": "already", "tags": ["time", "A2"] },
-    { "source": "kaimiņš", "target": "neighbour", "tags": ["social", "A2"] },
-    { "source": "klasesbiedrs", "target": "classmate", "tags": ["social", "A2"] },
-    { "source": "paziņa", "target": "acquaintance", "tags": ["social", "A2"] },
-    { "source": "kolēģis", "target": "colleague", "tags": ["social", "A2"] },
-    { "source": "skolotājs", "target": "teacher", "tags": ["social", "A2"] },
-    { "source": "students", "target": "student", "tags": ["social", "A2"] },
-    { "source": "ierēdnis", "target": "official", "tags": ["social", "A2"] },
-    { "source": "svešvaloda", "target": "foreign language", "tags": ["social", "A2"] },
-    { "source": "vārds", "target": "word", "tags": ["social", "A2"] },
-    { "source": "valoda", "target": "language", "tags": ["social", "A2"] },
-    { "source": "skaits", "target": "number", "tags": ["social", "A2"] },
-    { "source": "vēstule", "target": "letter", "tags": ["social", "A2"] },
-    { "source": "adrese", "target": "address", "tags": ["social", "A2"] },
-    { "source": "tālrunis", "target": "telephone", "tags": ["objects", "A2"] },
-    { "source": "dators", "target": "computer", "tags": ["objects", "A2"] },
-    { "source": "pulkstenis", "target": "clock", "tags": ["objects", "A2"] },
-    { "source": "bildē", "target": "picture", "tags": ["objects", "A2"] },
-    { "source": "mūzika", "target": "music", "tags": ["objects", "A2"] },
-    { "source": "filma", "target": "film", "tags": ["objects", "A2"] },
-    { "source": "krāsas", "target": "colours", "tags": ["objects", "A2"] },
-    { "source": "braukt", "target": "to travel", "tags": ["verbs", "A2"] },
-    { "source": "strādāt", "target": "to work", "tags": ["verbs", "A2"] },
-    { "source": "mācīties", "target": "to study", "tags": ["verbs", "A2"] },
-    { "source": "prasīt", "target": "to ask", "tags": ["verbs", "A2"] },
-    { "source": "atbildēt", "target": "to answer", "tags": ["verbs", "A2"] },
-    { "source": "solīt", "target": "to promise", "tags": ["verbs", "A2"] },
-    { "source": "aizmirst", "target": "to forget", "tags": ["verbs", "A2"] },
-    { "source": "atcerēties", "target": "to remember", "tags": ["verbs", "A2"] },
-    { "source": "gaidīt", "target": "to wait", "tags": ["verbs", "A2"] },
-    { "source": "atrast", "target": "to find", "tags": ["verbs", "A2"] },
-    { "source": "pazaudēt", "target": "to lose", "tags": ["verbs", "A2"] },
-    { "source": "mainīt", "target": "to change", "tags": ["verbs", "A2"] },
-    { "source": "atgriezties", "target": "to return", "tags": ["verbs", "A2"] },
-    { "source": "sākt", "target": "to start", "tags": ["verbs", "A2"] },
-    { "source": "beigt", "target": "to finish", "tags": ["verbs", "A2"] }
+    {
+      "source": "iepirkšanās",
+      "target": "shopping",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "veikals",
+      "target": "store",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "cena",
+      "target": "price",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "lēts",
+      "target": "cheap",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "dārgs",
+      "target": "expensive",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "rēķins",
+      "target": "receipt",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "atlaides",
+      "target": "discount",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "izmērs",
+      "target": "size",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "kaste",
+      "target": "box",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "maiss",
+      "target": "bag",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "kārta",
+      "target": "queue",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "ceļš",
+      "target": "road",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "stūris",
+      "target": "corner",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "krusts",
+      "target": "crossroads",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "tilts",
+      "target": "bridge",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "stacija",
+      "target": "station",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "apstādīšanās vieta",
+      "target": "stop",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "tuvumā",
+      "target": "nearby",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "tālu",
+      "target": "far",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "aiz",
+      "target": "behind",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "priekšā",
+      "target": "in front of",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "blakus",
+      "target": "next to",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "laika apstākļi",
+      "target": "weather",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "saulains",
+      "target": "sunny",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "mākoņains",
+      "target": "cloudy",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "lietains",
+      "target": "rainy",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "vējaini",
+      "target": "windy",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "sniegains",
+      "target": "snowy",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "silts",
+      "target": "warm",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "pērkons",
+      "target": "thunder",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "zibens",
+      "target": "lightning",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "vāji",
+      "target": "ill",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "galvassāpes",
+      "target": "headache",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "drudzis",
+      "target": "fever",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "klepus",
+      "target": "cough",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "iesnas",
+      "target": "cold",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "sāpes",
+      "target": "pain",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "ārsts",
+      "target": "doctor",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "zāles",
+      "target": "medicine",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "slimnīca",
+      "target": "hospital",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "aptieka",
+      "target": "pharmacy",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "veselīgs",
+      "target": "healthy",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "sportot",
+      "target": "to exercise",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "lasīt",
+      "target": "to read",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "klausīties mūziku",
+      "target": "to listen to music",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "skatīties televizoru",
+      "target": "to watch TV",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "ceļot",
+      "target": "to travel",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "gatavot",
+      "target": "to cook",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "zīmēt",
+      "target": "to draw",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "fotografēt",
+      "target": "to photograph",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "spēlēt",
+      "target": "to play",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "dejot",
+      "target": "to dance",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "dziedāt",
+      "target": "to sing",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "peldēties",
+      "target": "to swim",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "braukt ar velosipēdu",
+      "target": "to cycle",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "interesants",
+      "target": "interesting",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "garlaicīgs",
+      "target": "boring",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "jautrs",
+      "target": "fun",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "aizraujoši",
+      "target": "exciting",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "grūts",
+      "target": "difficult",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "viegls",
+      "target": "easy",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "dārgais",
+      "target": "dear",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "draudzīgs",
+      "target": "friendly",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "gudrs",
+      "target": "clever",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "muļķīgs",
+      "target": "silly",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "laipns",
+      "target": "kind",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "uzticams",
+      "target": "honest",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "laimīgs",
+      "target": "happy",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "skumīgs",
+      "target": "sad",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "noguris",
+      "target": "tired",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "izsalcis",
+      "target": "hungry",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "izslāpis",
+      "target": "thirsty",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "dikts",
+      "target": "scared",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "pārsteigts",
+      "target": "surprised",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "apģērbs",
+      "target": "clothes",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "krekls",
+      "target": "shirt",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "bikses",
+      "target": "trousers",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "kleita",
+      "target": "dress",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "jaka",
+      "target": "jacket",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "kurpes",
+      "target": "shoes",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "cepure",
+      "target": "hat",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "zeķes",
+      "target": "socks",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "džemperis",
+      "target": "sweater",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "mētelis",
+      "target": "coat",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "kafejnīca",
+      "target": "café",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "ēdienkarte",
+      "target": "menu",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "galdiņš",
+      "target": "table",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "pasūtīt",
+      "target": "to order",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "vārīts",
+      "target": "boiled",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "cepts",
+      "target": "fried",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "svaigs",
+      "target": "fresh",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "salds",
+      "target": "sweet",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "skābs",
+      "target": "sour",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "sāļš",
+      "target": "salty",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "asa",
+      "target": "spicy",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "sula",
+      "target": "juice",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "gaļas ēdiens",
+      "target": "main course",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "deserts",
+      "target": "dessert",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "stundu",
+      "target": "hour",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "agrāk",
+      "target": "earlier",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "vēlāk",
+      "target": "later",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "bieži",
+      "target": "often",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "dažreiz",
+      "target": "sometimes",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "nekad",
+      "target": "never",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "vienmēr",
+      "target": "always",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "tūlīt",
+      "target": "soon",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "vēl",
+      "target": "still",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "jau",
+      "target": "already",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "kaimiņš",
+      "target": "neighbour",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "klasesbiedrs",
+      "target": "classmate",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "paziņa",
+      "target": "acquaintance",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "kolēģis",
+      "target": "colleague",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "skolotājs",
+      "target": "teacher",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "students",
+      "target": "student",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "ierēdnis",
+      "target": "official",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "svešvaloda",
+      "target": "foreign language",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "vārds",
+      "target": "word",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "valoda",
+      "target": "language",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "skaits",
+      "target": "number",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "vēstule",
+      "target": "letter",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "adrese",
+      "target": "address",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "tālrunis",
+      "target": "telephone",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "dators",
+      "target": "computer",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "pulkstenis",
+      "target": "clock",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "bildē",
+      "target": "picture",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "mūzika",
+      "target": "music",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "filma",
+      "target": "film",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "krāsas",
+      "target": "colours",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "braukt",
+      "target": "to travel",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "strādāt",
+      "target": "to work",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "mācīties",
+      "target": "to study",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "prasīt",
+      "target": "to ask",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "atbildēt",
+      "target": "to answer",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "solīt",
+      "target": "to promise",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "aizmirst",
+      "target": "to forget",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "atcerēties",
+      "target": "to remember",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "gaidīt",
+      "target": "to wait",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "atrast",
+      "target": "to find",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "pazaudēt",
+      "target": "to lose",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "mainīt",
+      "target": "to change",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "atgriezties",
+      "target": "to return",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "sākt",
+      "target": "to start",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "beigt",
+      "target": "to finish",
+      "tags": ["verbs", "A2"]
+    }
   ]
 }

--- a/public/starter-packs/en-lv-b1.json
+++ b/public/starter-packs/en-lv-b1.json
@@ -6,223 +6,630 @@
   "targetCode": "en",
   "level": "B1",
   "words": [
-    { "source": "grāmata", "target": "book", "tags": ["objects", "B1"] },
-    { "source": "ceļojums", "target": "journey", "tags": ["travel", "B1"] },
-    { "source": "māja", "target": "house", "tags": ["home", "B1"] },
-    { "source": "ūdens", "target": "water", "tags": ["food-drink", "B1"] },
-    { "source": "maize", "target": "bread", "tags": ["food-drink", "B1"] },
-    { "source": "gaļa", "target": "meat", "tags": ["food-drink", "B1"] },
-    { "source": "piens", "target": "milk", "tags": ["food-drink", "B1"] },
-    { "source": "ola", "target": "egg", "tags": ["food-drink", "B1"] },
-    { "source": "siers", "target": "cheese", "tags": ["food-drink", "B1"] },
-    { "source": "sviests", "target": "butter", "tags": ["food-drink", "B1"] },
-    { "source": "auglis", "target": "fruit", "tags": ["food-drink", "B1"] },
-    { "source": "dārzenis", "target": "vegetable", "tags": ["food-drink", "B1"] },
-    { "source": "ābols", "target": "apple", "tags": ["food-drink", "B1"] },
-    { "source": "banāns", "target": "banana", "tags": ["food-drink", "B1"] },
-    { "source": "apelsīns", "target": "orange", "tags": ["food-drink", "B1"] },
-    { "source": "tomāts", "target": "tomato", "tags": ["food-drink", "B1"] },
-    { "source": "kartupelis", "target": "potato", "tags": ["food-drink", "B1"] },
-    { "source": "kafija", "target": "coffee", "tags": ["food-drink", "B1"] },
-    { "source": "tēja", "target": "tea", "tags": ["food-drink", "B1"] },
-    { "source": "alus", "target": "beer", "tags": ["food-drink", "B1"] },
-    { "source": "cukurs", "target": "sugar", "tags": ["food-drink", "B1"] },
-    { "source": "sāls", "target": "salt", "tags": ["food-drink", "B1"] },
-    { "source": "rīsi", "target": "rice", "tags": ["food-drink", "B1"] },
-    { "source": "zupa", "target": "soup", "tags": ["food-drink", "B1"] },
-    { "source": "salāti", "target": "salad", "tags": ["food-drink", "B1"] },
-    { "source": "pusdienas", "target": "lunch", "tags": ["food-drink", "B1"] },
-    { "source": "vakariņas", "target": "dinner", "tags": ["food-drink", "B1"] },
-    { "source": "brokastis", "target": "breakfast", "tags": ["food-drink", "B1"] },
-    { "source": "restorāns", "target": "restaurant", "tags": ["food-drink", "travel", "B1"] },
-    { "source": "viesnīca", "target": "hotel", "tags": ["travel", "B1"] },
-    { "source": "lidosta", "target": "airport", "tags": ["travel", "B1"] },
-    { "source": "lidmašīna", "target": "airplane", "tags": ["travel", "B1"] },
-    { "source": "vilciens", "target": "train", "tags": ["travel", "B1"] },
-    { "source": "autobuss", "target": "bus", "tags": ["travel", "B1"] },
-    { "source": "auto", "target": "car", "tags": ["travel", "B1"] },
-    { "source": "biļete", "target": "ticket", "tags": ["travel", "B1"] },
-    { "source": "pase", "target": "passport", "tags": ["travel", "B1"] },
-    { "source": "karte", "target": "map", "tags": ["travel", "B1"] },
-    { "source": "iela", "target": "street", "tags": ["travel", "B1"] },
-    { "source": "pilsēta", "target": "city", "tags": ["travel", "B1"] },
-    { "source": "valsts", "target": "country", "tags": ["travel", "B1"] },
-    { "source": "bagāža", "target": "luggage", "tags": ["travel", "B1"] },
-    { "source": "darbs", "target": "work", "tags": ["work", "B1"] },
-    { "source": "birojs", "target": "office", "tags": ["work", "B1"] },
-    { "source": "sanāksme", "target": "meeting", "tags": ["work", "B1"] },
-    { "source": "kolēģis", "target": "colleague", "tags": ["work", "B1"] },
-    { "source": "priekšnieks", "target": "boss", "tags": ["work", "B1"] },
-    { "source": "atvaļinājums", "target": "holiday", "tags": ["work", "travel", "B1"] },
-    { "source": "prieks", "target": "joy", "tags": ["emotions", "B1"] },
-    { "source": "skumjas", "target": "sadness", "tags": ["emotions", "B1"] },
-    { "source": "bailes", "target": "fear", "tags": ["emotions", "B1"] },
-    { "source": "dusmas", "target": "anger", "tags": ["emotions", "B1"] },
-    { "source": "pārsteigums", "target": "surprise", "tags": ["emotions", "B1"] },
-    { "source": "mīlestība", "target": "love", "tags": ["emotions", "B1"] },
-    { "source": "uztraukums", "target": "excitement", "tags": ["emotions", "B1"] },
-    { "source": "meža", "target": "forest", "tags": ["nature", "B1"] },
-    { "source": "jūra", "target": "sea", "tags": ["nature", "B1"] },
-    { "source": "ezers", "target": "lake", "tags": ["nature", "B1"] },
-    { "source": "upe", "target": "river", "tags": ["nature", "B1"] },
-    { "source": "kalns", "target": "mountain", "tags": ["nature", "B1"] },
-    { "source": "lauki", "target": "countryside", "tags": ["nature", "B1"] },
-    { "source": "saule", "target": "sun", "tags": ["nature", "B1"] },
-    { "source": "mēness", "target": "moon", "tags": ["nature", "B1"] },
-    { "source": "zvaigzne", "target": "star", "tags": ["nature", "B1"] },
-    { "source": "lietus", "target": "rain", "tags": ["nature", "B1"] },
-    { "source": "sniegs", "target": "snow", "tags": ["nature", "B1"] },
-    { "source": "vējš", "target": "wind", "tags": ["nature", "B1"] },
-    { "source": "mākoņi", "target": "clouds", "tags": ["nature", "B1"] },
-    { "source": "ziema", "target": "winter", "tags": ["nature", "B1"] },
-    { "source": "vasara", "target": "summer", "tags": ["nature", "B1"] },
-    { "source": "pavasaris", "target": "spring", "tags": ["nature", "B1"] },
-    { "source": "rudens", "target": "autumn", "tags": ["nature", "B1"] },
-    { "source": "koks", "target": "tree", "tags": ["nature", "B1"] },
-    { "source": "puķe", "target": "flower", "tags": ["nature", "B1"] },
-    { "source": "zāle", "target": "grass", "tags": ["nature", "B1"] },
-    { "source": "istaba", "target": "room", "tags": ["home", "B1"] },
-    { "source": "virtuve", "target": "kitchen", "tags": ["home", "B1"] },
-    { "source": "guļamistaba", "target": "bedroom", "tags": ["home", "B1"] },
-    { "source": "vannas istaba", "target": "bathroom", "tags": ["home", "B1"] },
-    { "source": "viesistaba", "target": "living room", "tags": ["home", "B1"] },
-    { "source": "durvis", "target": "door", "tags": ["home", "B1"] },
-    { "source": "logs", "target": "window", "tags": ["home", "B1"] },
-    { "source": "galds", "target": "table", "tags": ["home", "B1"] },
-    { "source": "krēsls", "target": "chair", "tags": ["home", "B1"] },
-    { "source": "dīvāns", "target": "sofa", "tags": ["home", "B1"] },
-    { "source": "gulta", "target": "bed", "tags": ["home", "B1"] },
-    { "source": "spilvens", "target": "pillow", "tags": ["home", "B1"] },
-    { "source": "sega", "target": "blanket", "tags": ["home", "B1"] },
-    { "source": "spogulis", "target": "mirror", "tags": ["home", "B1"] },
-    { "source": "lampa", "target": "lamp", "tags": ["home", "B1"] },
-    { "source": "grīda", "target": "floor", "tags": ["home", "B1"] },
-    { "source": "griesti", "target": "ceiling", "tags": ["home", "B1"] },
-    { "source": "siena", "target": "wall", "tags": ["home", "B1"] },
-    { "source": "jumts", "target": "roof", "tags": ["home", "B1"] },
-    { "source": "dārzs", "target": "garden", "tags": ["home", "B1"] },
-    { "source": "galva", "target": "head", "tags": ["body", "B1"] },
-    { "source": "seja", "target": "face", "tags": ["body", "B1"] },
-    { "source": "acis", "target": "eyes", "tags": ["body", "B1"] },
-    { "source": "ausis", "target": "ears", "tags": ["body", "B1"] },
-    { "source": "deguns", "target": "nose", "tags": ["body", "B1"] },
-    { "source": "mute", "target": "mouth", "tags": ["body", "B1"] },
-    { "source": "zobi", "target": "teeth", "tags": ["body", "B1"] },
-    { "source": "kakls", "target": "neck", "tags": ["body", "B1"] },
-    { "source": "pleci", "target": "shoulders", "tags": ["body", "B1"] },
-    { "source": "roka", "target": "hand", "tags": ["body", "B1"] },
-    { "source": "pirksti", "target": "fingers", "tags": ["body", "B1"] },
-    { "source": "kāja", "target": "leg", "tags": ["body", "B1"] },
-    { "source": "celis", "target": "knee", "tags": ["body", "B1"] },
-    { "source": "pēda", "target": "foot", "tags": ["body", "B1"] },
-    { "source": "sirds", "target": "heart", "tags": ["body", "B1"] },
-    { "source": "diena", "target": "day", "tags": ["time", "B1"] },
-    { "source": "nakts", "target": "night", "tags": ["time", "B1"] },
-    { "source": "rīts", "target": "morning", "tags": ["time", "B1"] },
-    { "source": "vakars", "target": "evening", "tags": ["time", "B1"] },
-    { "source": "nedēļa", "target": "week", "tags": ["time", "B1"] },
-    { "source": "mēnesis", "target": "month", "tags": ["time", "B1"] },
-    { "source": "gads", "target": "year", "tags": ["time", "B1"] },
-    { "source": "stunda", "target": "hour", "tags": ["time", "B1"] },
-    { "source": "minūte", "target": "minute", "tags": ["time", "B1"] },
-    { "source": "sekunde", "target": "second", "tags": ["time", "B1"] },
-    { "source": "tagad", "target": "now", "tags": ["time", "B1"] },
-    { "source": "vakar", "target": "yesterday", "tags": ["time", "B1"] },
-    { "source": "rīt", "target": "tomorrow", "tags": ["time", "B1"] },
-    { "source": "runāt", "target": "to speak", "tags": ["verbs", "B1"] },
-    { "source": "klausīties", "target": "to listen", "tags": ["verbs", "B1"] },
-    { "source": "lasīt", "target": "to read", "tags": ["verbs", "B1"] },
-    { "source": "rakstīt", "target": "to write", "tags": ["verbs", "B1"] },
-    { "source": "ēst", "target": "to eat", "tags": ["verbs", "B1"] },
-    { "source": "dzert", "target": "to drink", "tags": ["verbs", "B1"] },
-    { "source": "gulēt", "target": "to sleep", "tags": ["verbs", "B1"] },
-    { "source": "staigāt", "target": "to walk", "tags": ["verbs", "B1"] },
-    { "source": "skriet", "target": "to run", "tags": ["verbs", "B1"] },
-    { "source": "strādāt", "target": "to work", "tags": ["verbs", "B1"] },
-    { "source": "spēlēt", "target": "to play", "tags": ["verbs", "B1"] },
-    { "source": "mācīties", "target": "to learn", "tags": ["verbs", "B1"] },
-    { "source": "domāt", "target": "to think", "tags": ["verbs", "B1"] },
-    { "source": "zināt", "target": "to know", "tags": ["verbs", "B1"] },
-    { "source": "saprast", "target": "to understand", "tags": ["verbs", "B1"] },
-    { "source": "atbildēt", "target": "to answer", "tags": ["verbs", "B1"] },
-    { "source": "jautāt", "target": "to ask", "tags": ["verbs", "B1"] },
-    { "source": "palīdzēt", "target": "to help", "tags": ["verbs", "B1"] },
-    { "source": "pirkt", "target": "to buy", "tags": ["verbs", "B1"] },
-    { "source": "nākt", "target": "to come", "tags": ["verbs", "B1"] },
-    { "source": "iet", "target": "to go", "tags": ["verbs", "B1"] },
-    { "source": "atgriezties", "target": "to return", "tags": ["verbs", "B1"] },
-    { "source": "aizmirst", "target": "to forget", "tags": ["verbs", "B1"] },
-    { "source": "atcerēties", "target": "to remember", "tags": ["verbs", "B1"] },
-    { "source": "atvērt", "target": "to open", "tags": ["verbs", "B1"] },
-    { "source": "aizvērt", "target": "to close", "tags": ["verbs", "B1"] },
-    { "source": "labi", "target": "good", "tags": ["adjectives", "B1"] },
-    { "source": "slikti", "target": "bad", "tags": ["adjectives", "B1"] },
-    { "source": "liels", "target": "big", "tags": ["adjectives", "B1"] },
-    { "source": "mazs", "target": "small", "tags": ["adjectives", "B1"] },
-    { "source": "jauns", "target": "new", "tags": ["adjectives", "B1"] },
-    { "source": "vecs", "target": "old", "tags": ["adjectives", "B1"] },
-    { "source": "ātrs", "target": "fast", "tags": ["adjectives", "B1"] },
-    { "source": "lēns", "target": "slow", "tags": ["adjectives", "B1"] },
-    { "source": "karsts", "target": "hot", "tags": ["adjectives", "B1"] },
-    { "source": "auksts", "target": "cold", "tags": ["adjectives", "B1"] },
-    { "source": "skaists", "target": "beautiful", "tags": ["adjectives", "B1"] },
-    { "source": "neglīts", "target": "ugly", "tags": ["adjectives", "B1"] },
-    { "source": "stiprs", "target": "strong", "tags": ["adjectives", "B1"] },
-    { "source": "vājš", "target": "weak", "tags": ["adjectives", "B1"] },
-    { "source": "svarīgs", "target": "important", "tags": ["adjectives", "B1"] },
-    { "source": "interesants", "target": "interesting", "tags": ["adjectives", "B1"] },
-    { "source": "grūts", "target": "difficult", "tags": ["adjectives", "B1"] },
-    { "source": "viegls", "target": "easy", "tags": ["adjectives", "B1"] },
-    { "source": "drošs", "target": "safe", "tags": ["adjectives", "B1"] },
-    { "source": "tīrs", "target": "clean", "tags": ["adjectives", "B1"] },
-    { "source": "netīrs", "target": "dirty", "tags": ["adjectives", "B1"] },
-    { "source": "pilns", "target": "full", "tags": ["adjectives", "B1"] },
-    { "source": "tukšs", "target": "empty", "tags": ["adjectives", "B1"] },
-    { "source": "brīvs", "target": "free", "tags": ["adjectives", "B1"] },
-    { "source": "telefons", "target": "phone", "tags": ["objects", "B1"] },
-    { "source": "dators", "target": "computer", "tags": ["objects", "B1"] },
-    { "source": "ekrāns", "target": "screen", "tags": ["objects", "B1"] },
-    { "source": "klaviatūra", "target": "keyboard", "tags": ["objects", "B1"] },
-    { "source": "pele", "target": "mouse", "tags": ["objects", "B1"] },
-    { "source": "internets", "target": "internet", "tags": ["objects", "B1"] },
-    { "source": "soma", "target": "bag", "tags": ["objects", "B1"] },
-    { "source": "maks", "target": "wallet", "tags": ["objects", "B1"] },
-    { "source": "pulkstenis", "target": "watch", "tags": ["objects", "B1"] },
-    { "source": "brilles", "target": "glasses", "tags": ["objects", "B1"] },
-    { "source": "atslēga", "target": "key", "tags": ["objects", "B1"] },
-    { "source": "pildspalva", "target": "pen", "tags": ["objects", "B1"] },
-    { "source": "papīrs", "target": "paper", "tags": ["objects", "B1"] },
-    { "source": "nauda", "target": "money", "tags": ["objects", "B1"] },
-    { "source": "cena", "target": "price", "tags": ["objects", "B1"] },
-    { "source": "rēķins", "target": "bill", "tags": ["objects", "B1"] },
-    { "source": "ģimene", "target": "family", "tags": ["social", "B1"] },
-    { "source": "draugs", "target": "friend", "tags": ["social", "B1"] },
-    { "source": "kaimiņš", "target": "neighbour", "tags": ["social", "B1"] },
-    { "source": "bērns", "target": "child", "tags": ["social", "B1"] },
-    { "source": "vecāki", "target": "parents", "tags": ["social", "B1"] },
-    { "source": "māsa", "target": "sister", "tags": ["social", "B1"] },
-    { "source": "brālis", "target": "brother", "tags": ["social", "B1"] },
-    { "source": "vīrs", "target": "husband", "tags": ["social", "B1"] },
-    { "source": "sieva", "target": "wife", "tags": ["social", "B1"] },
-    { "source": "skolotājs", "target": "teacher", "tags": ["social", "work", "B1"] },
-    { "source": "students", "target": "student", "tags": ["social", "B1"] },
-    { "source": "ārsts", "target": "doctor", "tags": ["social", "work", "B1"] },
-    { "source": "slimnīca", "target": "hospital", "tags": ["social", "B1"] },
-    { "source": "aptiekā", "target": "pharmacy", "tags": ["social", "B1"] },
-    { "source": "tirgus", "target": "market", "tags": ["social", "B1"] },
-    { "source": "veikals", "target": "shop", "tags": ["social", "B1"] },
-    { "source": "banka", "target": "bank", "tags": ["social", "B1"] },
-    { "source": "skolā", "target": "school", "tags": ["social", "B1"] },
-    { "source": "universitāte", "target": "university", "tags": ["social", "B1"] },
-    { "source": "muzejs", "target": "museum", "tags": ["social", "travel", "B1"] },
-    { "source": "bibliotēka", "target": "library", "tags": ["social", "B1"] },
-    { "source": "parks", "target": "park", "tags": ["social", "nature", "B1"] },
-    { "source": "kino", "target": "cinema", "tags": ["social", "B1"] },
-    { "source": "svētki", "target": "celebration", "tags": ["social", "B1"] },
-    { "source": "sports", "target": "sport", "tags": ["social", "B1"] },
-    { "source": "veselība", "target": "health", "tags": ["body", "B1"] },
-    { "source": "slimība", "target": "illness", "tags": ["body", "B1"] },
-    { "source": "sāpes", "target": "pain", "tags": ["body", "B1"] },
-    { "source": "zāles", "target": "medicine", "tags": ["body", "B1"] }
+    {
+      "source": "ceļojums",
+      "target": "journey",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "sviests",
+      "target": "butter",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "auglis",
+      "target": "fruit",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "dārzenis",
+      "target": "vegetable",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "apelsīns",
+      "target": "orange",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "tomāts",
+      "target": "tomato",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "kartupelis",
+      "target": "potato",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "alus",
+      "target": "beer",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "sāls",
+      "target": "salt",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "zupa",
+      "target": "soup",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "salāti",
+      "target": "salad",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "pusdienas",
+      "target": "lunch",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "vakariņas",
+      "target": "dinner",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "brokastis",
+      "target": "breakfast",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "restorāns",
+      "target": "restaurant",
+      "tags": ["food-drink", "travel", "B1"]
+    },
+    {
+      "source": "viesnīca",
+      "target": "hotel",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "lidosta",
+      "target": "airport",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "lidmašīna",
+      "target": "airplane",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "vilciens",
+      "target": "train",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "auto",
+      "target": "car",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "biļete",
+      "target": "ticket",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "pase",
+      "target": "passport",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "karte",
+      "target": "map",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "bagāža",
+      "target": "luggage",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "darbs",
+      "target": "work",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "birojs",
+      "target": "office",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "sanāksme",
+      "target": "meeting",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "priekšnieks",
+      "target": "boss",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "atvaļinājums",
+      "target": "holiday",
+      "tags": ["work", "travel", "B1"]
+    },
+    {
+      "source": "prieks",
+      "target": "joy",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "skumjas",
+      "target": "sadness",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "bailes",
+      "target": "fear",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "dusmas",
+      "target": "anger",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "pārsteigums",
+      "target": "surprise",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "mīlestība",
+      "target": "love",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "uztraukums",
+      "target": "excitement",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "meža",
+      "target": "forest",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "jūra",
+      "target": "sea",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "ezers",
+      "target": "lake",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "upe",
+      "target": "river",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "kalns",
+      "target": "mountain",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "lauki",
+      "target": "countryside",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "mēness",
+      "target": "moon",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "zvaigzne",
+      "target": "star",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "vējš",
+      "target": "wind",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "mākoņi",
+      "target": "clouds",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "ziema",
+      "target": "winter",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "vasara",
+      "target": "summer",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "pavasaris",
+      "target": "spring",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "rudens",
+      "target": "autumn",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "zāle",
+      "target": "grass",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "virtuve",
+      "target": "kitchen",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "guļamistaba",
+      "target": "bedroom",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "vannas istaba",
+      "target": "bathroom",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "viesistaba",
+      "target": "living room",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "dīvāns",
+      "target": "sofa",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "spilvens",
+      "target": "pillow",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "sega",
+      "target": "blanket",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "spogulis",
+      "target": "mirror",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "lampa",
+      "target": "lamp",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "grīda",
+      "target": "floor",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "griesti",
+      "target": "ceiling",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "siena",
+      "target": "wall",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "jumts",
+      "target": "roof",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "dārzs",
+      "target": "garden",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "seja",
+      "target": "face",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "zobi",
+      "target": "teeth",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "kakls",
+      "target": "neck",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "pleci",
+      "target": "shoulders",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "pirksti",
+      "target": "fingers",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "celis",
+      "target": "knee",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "pēda",
+      "target": "foot",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "stunda",
+      "target": "hour",
+      "tags": ["time", "B1"]
+    },
+    {
+      "source": "minūte",
+      "target": "minute",
+      "tags": ["time", "B1"]
+    },
+    {
+      "source": "sekunde",
+      "target": "second",
+      "tags": ["time", "B1"]
+    },
+    {
+      "source": "runāt",
+      "target": "to speak",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "klausīties",
+      "target": "to listen",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "rakstīt",
+      "target": "to write",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "staigāt",
+      "target": "to walk",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "skriet",
+      "target": "to run",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "mācīties",
+      "target": "to learn",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "domāt",
+      "target": "to think",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "zināt",
+      "target": "to know",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "saprast",
+      "target": "to understand",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "jautāt",
+      "target": "to ask",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "palīdzēt",
+      "target": "to help",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "pirkt",
+      "target": "to buy",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "atvērt",
+      "target": "to open",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "aizvērt",
+      "target": "to close",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "ātrs",
+      "target": "fast",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "lēns",
+      "target": "slow",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "skaists",
+      "target": "beautiful",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "neglīts",
+      "target": "ugly",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "stiprs",
+      "target": "strong",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "vājš",
+      "target": "weak",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "svarīgs",
+      "target": "important",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "drošs",
+      "target": "safe",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "tīrs",
+      "target": "clean",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "netīrs",
+      "target": "dirty",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "pilns",
+      "target": "full",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "tukšs",
+      "target": "empty",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "brīvs",
+      "target": "free",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "ekrāns",
+      "target": "screen",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "klaviatūra",
+      "target": "keyboard",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "pele",
+      "target": "mouse",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "internets",
+      "target": "internet",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "maks",
+      "target": "wallet",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "pulkstenis",
+      "target": "watch",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "brilles",
+      "target": "glasses",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "papīrs",
+      "target": "paper",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "rēķins",
+      "target": "bill",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "vecāki",
+      "target": "parents",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "aptiekā",
+      "target": "pharmacy",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "tirgus",
+      "target": "market",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "banka",
+      "target": "bank",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "skolā",
+      "target": "school",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "universitāte",
+      "target": "university",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "muzejs",
+      "target": "museum",
+      "tags": ["social", "travel", "B1"]
+    },
+    {
+      "source": "bibliotēka",
+      "target": "library",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "parks",
+      "target": "park",
+      "tags": ["social", "nature", "B1"]
+    },
+    {
+      "source": "kino",
+      "target": "cinema",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "svētki",
+      "target": "celebration",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "sports",
+      "target": "sport",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "veselība",
+      "target": "health",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "slimība",
+      "target": "illness",
+      "tags": ["body", "B1"]
+    }
   ]
 }

--- a/public/starter-packs/en-lv-b2.json
+++ b/public/starter-packs/en-lv-b2.json
@@ -6,140 +6,645 @@
   "targetCode": "en",
   "level": "B2",
   "words": [
-    { "source": "vīns", "target": "wine", "tags": ["food-drink", "B2"] },
-    { "source": "robeža", "target": "border", "tags": ["travel", "B2"] },
-    { "source": "valūta", "target": "currency", "tags": ["travel", "B2"] },
-    { "source": "ceļojot", "target": "travelling", "tags": ["travel", "B2"] },
-    { "source": "uzturēšanās", "target": "stay", "tags": ["travel", "B2"] },
-    { "source": "rezervācija", "target": "reservation", "tags": ["travel", "B2"] },
-    { "source": "alga", "target": "salary", "tags": ["work", "B2"] },
-    { "source": "projekts", "target": "project", "tags": ["work", "B2"] },
-    { "source": "termiņš", "target": "deadline", "tags": ["work", "B2"] },
-    { "source": "ziņojums", "target": "report", "tags": ["work", "B2"] },
-    { "source": "prezentācija", "target": "presentation", "tags": ["work", "B2"] },
-    { "source": "uzņēmums", "target": "company", "tags": ["work", "B2"] },
-    { "source": "klients", "target": "client", "tags": ["work", "B2"] },
-    { "source": "darba intervija", "target": "job interview", "tags": ["work", "B2"] },
-    { "source": "karjera", "target": "career", "tags": ["work", "B2"] },
-    { "source": "naids", "target": "hatred", "tags": ["emotions", "B2"] },
-    { "source": "cerība", "target": "hope", "tags": ["emotions", "B2"] },
-    { "source": "vilšanās", "target": "disappointment", "tags": ["emotions", "B2"] },
-    { "source": "atvieglojums", "target": "relief", "tags": ["emotions", "B2"] },
-    { "source": "kauns", "target": "shame", "tags": ["emotions", "B2"] },
-    { "source": "vientulība", "target": "loneliness", "tags": ["emotions", "B2"] },
-    { "source": "pateicība", "target": "gratitude", "tags": ["emotions", "B2"] },
-    { "source": "pagrabstāvs", "target": "basement", "tags": ["home", "B2"] },
-    { "source": "plaušas", "target": "lungs", "tags": ["body", "B2"] },
-    { "source": "asinsspiediens", "target": "blood pressure", "tags": ["body", "B2"] },
-    { "source": "temperatūra", "target": "temperature", "tags": ["body", "B2"] },
-    { "source": "pagātne", "target": "past", "tags": ["time", "B2"] },
-    { "source": "nākotne", "target": "future", "tags": ["time", "B2"] },
-    { "source": "grafiks", "target": "schedule", "tags": ["time", "work", "B2"] },
-    { "source": "pārdot", "target": "to sell", "tags": ["verbs", "B2"] },
-    { "source": "mainīt", "target": "to change", "tags": ["verbs", "B2"] },
-    { "source": "lemt", "target": "to decide", "tags": ["verbs", "B2"] },
-    { "source": "pārbaudīt", "target": "to check", "tags": ["verbs", "B2"] },
-    { "source": "plānot", "target": "to plan", "tags": ["verbs", "B2"] },
-    { "source": "organizēt", "target": "to organise", "tags": ["verbs", "B2"] },
-    { "source": "uzlabot", "target": "to improve", "tags": ["verbs", "B2"] },
-    { "source": "sasniegt", "target": "to achieve", "tags": ["verbs", "B2"] },
-    { "source": "izvēlēties", "target": "to choose", "tags": ["verbs", "B2"] },
-    { "source": "apspriest", "target": "to discuss", "tags": ["verbs", "B2"] },
-    { "source": "bīstams", "target": "dangerous", "tags": ["adjectives", "B2"] },
-    { "source": "aizņemts", "target": "busy", "tags": ["adjectives", "B2"] },
-    { "source": "veiksmīgs", "target": "successful", "tags": ["adjectives", "B2"] },
-    { "source": "radošs", "target": "creative", "tags": ["adjectives", "B2"] },
-    { "source": "uzticams", "target": "reliable", "tags": ["adjectives", "B2"] },
-    { "source": "elastīgs", "target": "flexible", "tags": ["adjectives", "B2"] },
-    { "source": "efektīvs", "target": "effective", "tags": ["adjectives", "B2"] },
-    { "source": "programma", "target": "software", "tags": ["objects", "B2"] },
-    { "source": "aplikācija", "target": "application", "tags": ["objects", "B2"] },
-    { "source": "baterija", "target": "battery", "tags": ["objects", "B2"] },
-    { "source": "lādētājs", "target": "charger", "tags": ["objects", "B2"] },
-    { "source": "svešinieks", "target": "stranger", "tags": ["social", "B2"] },
-    { "source": "teātris", "target": "theatre", "tags": ["social", "B2"] },
-    { "source": "pulcēšanās", "target": "gathering", "tags": ["social", "B2"] },
-    { "source": "ārstēšana", "target": "treatment", "tags": ["body", "B2"] },
-    { "source": "operācija", "target": "operation", "tags": ["body", "B2"] },
-    { "source": "alerģija", "target": "allergy", "tags": ["body", "B2"] },
-    { "source": "simptomi", "target": "symptoms", "tags": ["body", "B2"] },
-    { "source": "konsultācija", "target": "consultation", "tags": ["work", "B2"] },
-    { "source": "līgums", "target": "contract", "tags": ["work", "B2"] },
-    { "source": "investīcija", "target": "investment", "tags": ["work", "B2"] },
-    { "source": "budžets", "target": "budget", "tags": ["work", "B2"] },
-    { "source": "nodokļi", "target": "taxes", "tags": ["work", "B2"] },
-    { "source": "apdrošināšana", "target": "insurance", "tags": ["work", "B2"] },
-    { "source": "tiesību akti", "target": "legislation", "tags": ["work", "B2"] },
-    { "source": "dzīvoklis", "target": "apartment", "tags": ["home", "B2"] },
-    { "source": "adrese", "target": "address", "tags": ["social", "B2"] },
-    { "source": "pasts", "target": "post office", "tags": ["social", "B2"] },
-    { "source": "vēstule", "target": "letter", "tags": ["objects", "B2"] },
-    { "source": "sūtījums", "target": "package", "tags": ["objects", "B2"] },
-    { "source": "dziesma", "target": "song", "tags": ["social", "B2"] },
-    { "source": "mūzika", "target": "music", "tags": ["social", "B2"] },
-    { "source": "deja", "target": "dance", "tags": ["social", "B2"] },
-    { "source": "fotogrāfija", "target": "photograph", "tags": ["objects", "B2"] },
-    { "source": "krāsa", "target": "colour", "tags": ["objects", "B2"] },
-    { "source": "izmērs", "target": "size", "tags": ["objects", "B2"] },
-    { "source": "forma", "target": "shape", "tags": ["objects", "B2"] },
-    { "source": "skaņa", "target": "sound", "tags": ["objects", "B2"] },
-    { "source": "smarža", "target": "smell", "tags": ["objects", "B2"] },
-    { "source": "garša", "target": "taste", "tags": ["objects", "B2"] },
-    { "source": "valoda", "target": "language", "tags": ["social", "B2"] },
-    { "source": "vārds", "target": "word", "tags": ["social", "B2"] },
-    { "source": "teikums", "target": "sentence", "tags": ["social", "B2"] },
-    { "source": "jautājums", "target": "question", "tags": ["social", "B2"] },
-    { "source": "atbilde", "target": "answer", "tags": ["social", "B2"] },
-    { "source": "problēma", "target": "problem", "tags": ["social", "B2"] },
-    { "source": "risinājums", "target": "solution", "tags": ["social", "B2"] },
-    { "source": "ideja", "target": "idea", "tags": ["social", "B2"] },
-    { "source": "viedoklis", "target": "opinion", "tags": ["social", "B2"] },
-    { "source": "informācija", "target": "information", "tags": ["social", "B2"] },
-    { "source": "ziņas", "target": "news", "tags": ["social", "B2"] },
-    { "source": "notikums", "target": "event", "tags": ["social", "B2"] },
-    { "source": "iespēja", "target": "opportunity", "tags": ["social", "B2"] },
-    { "source": "pieredze", "target": "experience", "tags": ["social", "B2"] },
-    { "source": "zināšanas", "target": "knowledge", "tags": ["social", "B2"] },
-    { "source": "izglītība", "target": "education", "tags": ["social", "B2"] },
-    { "source": "sabiedrība", "target": "society", "tags": ["social", "B2"] },
-    { "source": "kultūra", "target": "culture", "tags": ["social", "B2"] },
-    { "source": "vide", "target": "environment", "tags": ["nature", "B2"] },
-    { "source": "klimats", "target": "climate", "tags": ["nature", "B2"] },
-    { "source": "enerģija", "target": "energy", "tags": ["nature", "B2"] },
-    { "source": "resursi", "target": "resources", "tags": ["nature", "B2"] },
-    { "source": "piesārņojums", "target": "pollution", "tags": ["nature", "B2"] },
-    { "source": "attīstība", "target": "development", "tags": ["work", "B2"] },
-    { "source": "stratēģija", "target": "strategy", "tags": ["work", "B2"] },
-    { "source": "mērķis", "target": "goal", "tags": ["work", "B2"] },
-    { "source": "rezultāts", "target": "result", "tags": ["work", "B2"] },
-    { "source": "process", "target": "process", "tags": ["work", "B2"] },
-    { "source": "sistēma", "target": "system", "tags": ["work", "B2"] },
-    { "source": "tehnoloģija", "target": "technology", "tags": ["objects", "B2"] },
-    { "source": "ierīce", "target": "device", "tags": ["objects", "B2"] },
-    { "source": "savienojums", "target": "connection", "tags": ["objects", "B2"] },
-    { "source": "drošība", "target": "security", "tags": ["objects", "B2"] },
-    { "source": "privātums", "target": "privacy", "tags": ["social", "B2"] },
-    { "source": "tiesības", "target": "rights", "tags": ["social", "B2"] },
-    { "source": "pienākums", "target": "responsibility", "tags": ["social", "B2"] },
-    { "source": "lēmums", "target": "decision", "tags": ["social", "B2"] },
-    { "source": "vienošanās", "target": "agreement", "tags": ["social", "B2"] },
-    { "source": "konflikts", "target": "conflict", "tags": ["social", "B2"] },
-    { "source": "sadarbība", "target": "cooperation", "tags": ["social", "B2"] },
-    { "source": "kritika", "target": "criticism", "tags": ["social", "B2"] },
-    { "source": "novērtējums", "target": "assessment", "tags": ["social", "B2"] },
-    { "source": "pārskats", "target": "overview", "tags": ["work", "B2"] },
-    { "source": "perspektīva", "target": "perspective", "tags": ["social", "B2"] },
-    { "source": "pieejas", "target": "approach", "tags": ["work", "B2"] },
-    { "source": "izaicinājums", "target": "challenge", "tags": ["social", "B2"] },
-    { "source": "riski", "target": "risk", "tags": ["work", "B2"] },
-    { "source": "atbildība", "target": "accountability", "tags": ["work", "B2"] },
-    { "source": "efektivitāte", "target": "efficiency", "tags": ["work", "B2"] },
-    { "source": "kvalitāte", "target": "quality", "tags": ["work", "B2"] },
-    { "source": "standarts", "target": "standard", "tags": ["work", "B2"] },
-    { "source": "sasniegums", "target": "achievement", "tags": ["work", "B2"] },
-    { "source": "ietekme", "target": "impact", "tags": ["social", "B2"] },
-    { "source": "līdzsvars", "target": "balance", "tags": ["social", "B2"] },
-    { "source": "prioritāte", "target": "priority", "tags": ["work", "B2"] },
-    { "source": "inovācija", "target": "innovation", "tags": ["work", "B2"] }
+    {
+      "source": "vīns",
+      "target": "wine",
+      "tags": ["food-drink", "B2"]
+    },
+    {
+      "source": "robeža",
+      "target": "border",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "valūta",
+      "target": "currency",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "ceļojot",
+      "target": "travelling",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "uzturēšanās",
+      "target": "stay",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "rezervācija",
+      "target": "reservation",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "alga",
+      "target": "salary",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "projekts",
+      "target": "project",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "termiņš",
+      "target": "deadline",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "ziņojums",
+      "target": "report",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "prezentācija",
+      "target": "presentation",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "uzņēmums",
+      "target": "company",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "klients",
+      "target": "client",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "darba intervija",
+      "target": "job interview",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "karjera",
+      "target": "career",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "naids",
+      "target": "hatred",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "cerība",
+      "target": "hope",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "vilšanās",
+      "target": "disappointment",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "atvieglojums",
+      "target": "relief",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "kauns",
+      "target": "shame",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "vientulība",
+      "target": "loneliness",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "pateicība",
+      "target": "gratitude",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "pagrabstāvs",
+      "target": "basement",
+      "tags": ["home", "B2"]
+    },
+    {
+      "source": "plaušas",
+      "target": "lungs",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "asinsspiediens",
+      "target": "blood pressure",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "temperatūra",
+      "target": "temperature",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "pagātne",
+      "target": "past",
+      "tags": ["time", "B2"]
+    },
+    {
+      "source": "nākotne",
+      "target": "future",
+      "tags": ["time", "B2"]
+    },
+    {
+      "source": "grafiks",
+      "target": "schedule",
+      "tags": ["time", "work", "B2"]
+    },
+    {
+      "source": "pārdot",
+      "target": "to sell",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "lemt",
+      "target": "to decide",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "pārbaudīt",
+      "target": "to check",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "plānot",
+      "target": "to plan",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "organizēt",
+      "target": "to organise",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "uzlabot",
+      "target": "to improve",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "sasniegt",
+      "target": "to achieve",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "izvēlēties",
+      "target": "to choose",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "apspriest",
+      "target": "to discuss",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "bīstams",
+      "target": "dangerous",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "aizņemts",
+      "target": "busy",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "veiksmīgs",
+      "target": "successful",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "radošs",
+      "target": "creative",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "uzticams",
+      "target": "reliable",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "elastīgs",
+      "target": "flexible",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "efektīvs",
+      "target": "effective",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "programma",
+      "target": "software",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "aplikācija",
+      "target": "application",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "baterija",
+      "target": "battery",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "lādētājs",
+      "target": "charger",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "svešinieks",
+      "target": "stranger",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "teātris",
+      "target": "theatre",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "pulcēšanās",
+      "target": "gathering",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "ārstēšana",
+      "target": "treatment",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "operācija",
+      "target": "operation",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "alerģija",
+      "target": "allergy",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "simptomi",
+      "target": "symptoms",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "konsultācija",
+      "target": "consultation",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "līgums",
+      "target": "contract",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "investīcija",
+      "target": "investment",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "budžets",
+      "target": "budget",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "nodokļi",
+      "target": "taxes",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "apdrošināšana",
+      "target": "insurance",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "tiesību akti",
+      "target": "legislation",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "dzīvoklis",
+      "target": "apartment",
+      "tags": ["home", "B2"]
+    },
+    {
+      "source": "pasts",
+      "target": "post office",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "sūtījums",
+      "target": "package",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "dziesma",
+      "target": "song",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "deja",
+      "target": "dance",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "fotogrāfija",
+      "target": "photograph",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "krāsa",
+      "target": "colour",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "forma",
+      "target": "shape",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "skaņa",
+      "target": "sound",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "smarža",
+      "target": "smell",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "garša",
+      "target": "taste",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "teikums",
+      "target": "sentence",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "jautājums",
+      "target": "question",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "atbilde",
+      "target": "answer",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "problēma",
+      "target": "problem",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "risinājums",
+      "target": "solution",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "ideja",
+      "target": "idea",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "viedoklis",
+      "target": "opinion",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "informācija",
+      "target": "information",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "ziņas",
+      "target": "news",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "notikums",
+      "target": "event",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "iespēja",
+      "target": "opportunity",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "pieredze",
+      "target": "experience",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "zināšanas",
+      "target": "knowledge",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "izglītība",
+      "target": "education",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "sabiedrība",
+      "target": "society",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "kultūra",
+      "target": "culture",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "vide",
+      "target": "environment",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "klimats",
+      "target": "climate",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "enerģija",
+      "target": "energy",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "resursi",
+      "target": "resources",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "piesārņojums",
+      "target": "pollution",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "attīstība",
+      "target": "development",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "stratēģija",
+      "target": "strategy",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "mērķis",
+      "target": "goal",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "rezultāts",
+      "target": "result",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "process",
+      "target": "process",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "sistēma",
+      "target": "system",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "tehnoloģija",
+      "target": "technology",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "ierīce",
+      "target": "device",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "savienojums",
+      "target": "connection",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "drošība",
+      "target": "security",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "privātums",
+      "target": "privacy",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "tiesības",
+      "target": "rights",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "pienākums",
+      "target": "responsibility",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "lēmums",
+      "target": "decision",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "vienošanās",
+      "target": "agreement",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "konflikts",
+      "target": "conflict",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "sadarbība",
+      "target": "cooperation",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "kritika",
+      "target": "criticism",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "novērtējums",
+      "target": "assessment",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "pārskats",
+      "target": "overview",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "perspektīva",
+      "target": "perspective",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "pieejas",
+      "target": "approach",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "izaicinājums",
+      "target": "challenge",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "riski",
+      "target": "risk",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "atbildība",
+      "target": "accountability",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "efektivitāte",
+      "target": "efficiency",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "kvalitāte",
+      "target": "quality",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "standarts",
+      "target": "standard",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "sasniegums",
+      "target": "achievement",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "ietekme",
+      "target": "impact",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "līdzsvars",
+      "target": "balance",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "prioritāte",
+      "target": "priority",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "inovācija",
+      "target": "innovation",
+      "tags": ["work", "B2"]
+    }
   ]
 }

--- a/public/starter-packs/en-lv-c1.json
+++ b/public/starter-packs/en-lv-c1.json
@@ -6,152 +6,740 @@
   "targetCode": "en",
   "level": "C1",
   "words": [
-    { "source": "abstrakts", "target": "abstract", "tags": ["academic", "C1"] },
-    { "source": "analīze", "target": "analysis", "tags": ["academic", "C1"] },
-    { "source": "sintēze", "target": "synthesis", "tags": ["academic", "C1"] },
-    { "source": "hipotēze", "target": "hypothesis", "tags": ["academic", "C1"] },
-    { "source": "pierādījums", "target": "evidence", "tags": ["academic", "C1"] },
-    { "source": "metodoloģija", "target": "methodology", "tags": ["academic", "C1"] },
-    { "source": "pētījums", "target": "research", "tags": ["academic", "C1"] },
-    { "source": "teorija", "target": "theory", "tags": ["academic", "C1"] },
-    { "source": "koncepcija", "target": "concept", "tags": ["academic", "C1"] },
-    { "source": "paradigma", "target": "paradigm", "tags": ["academic", "C1"] },
-    { "source": "diskurss", "target": "discourse", "tags": ["academic", "C1"] },
-    { "source": "argumentācija", "target": "argumentation", "tags": ["academic", "C1"] },
-    { "source": "pamatojums", "target": "justification", "tags": ["academic", "C1"] },
-    { "source": "secinājums", "target": "conclusion", "tags": ["academic", "C1"] },
-    { "source": "apgalvojums", "target": "assertion", "tags": ["academic", "C1"] },
-    { "source": "atspēkojums", "target": "refutation", "tags": ["academic", "C1"] },
-    { "source": "kritērijs", "target": "criterion", "tags": ["academic", "C1"] },
-    { "source": "novērojums", "target": "observation", "tags": ["academic", "C1"] },
-    { "source": "interpretācija", "target": "interpretation", "tags": ["academic", "C1"] },
-    { "source": "konteksts", "target": "context", "tags": ["academic", "C1"] },
-    { "source": "likuma norma", "target": "legal provision", "tags": ["law", "C1"] },
-    { "source": "jurisdikcija", "target": "jurisdiction", "tags": ["law", "C1"] },
-    { "source": "tiesa", "target": "court", "tags": ["law", "C1"] },
-    { "source": "spriedums", "target": "verdict", "tags": ["law", "C1"] },
-    { "source": "apsūdzība", "target": "prosecution", "tags": ["law", "C1"] },
-    { "source": "aizstāvība", "target": "defence", "tags": ["law", "C1"] },
-    { "source": "pierādīt", "target": "to prove", "tags": ["law", "C1"] },
-    { "source": "likumsargi", "target": "law enforcement", "tags": ["law", "C1"] },
-    { "source": "regulēt", "target": "to regulate", "tags": ["law", "C1"] },
-    { "source": "saukt pie atbildības", "target": "to hold accountable", "tags": ["law", "C1"] },
-    { "source": "diagnozēt", "target": "to diagnose", "tags": ["medicine", "C1"] },
-    { "source": "simptoms", "target": "symptom", "tags": ["medicine", "C1"] },
-    { "source": "diagnoze", "target": "diagnosis", "tags": ["medicine", "C1"] },
-    { "source": "terapija", "target": "therapy", "tags": ["medicine", "C1"] },
-    { "source": "recepte", "target": "prescription", "tags": ["medicine", "C1"] },
-    { "source": "klīnisks", "target": "clinical", "tags": ["medicine", "C1"] },
-    { "source": "profilaktisks", "target": "preventive", "tags": ["medicine", "C1"] },
-    { "source": "hronisks", "target": "chronic", "tags": ["medicine", "C1"] },
-    { "source": "akūts", "target": "acute", "tags": ["medicine", "C1"] },
-    { "source": "imūnsistēma", "target": "immune system", "tags": ["medicine", "C1"] },
-    { "source": "ieņēmumi", "target": "revenue", "tags": ["business", "C1"] },
-    { "source": "peļņa", "target": "profit", "tags": ["business", "C1"] },
-    { "source": "izdevumi", "target": "expenditure", "tags": ["business", "C1"] },
-    { "source": "portfelis", "target": "portfolio", "tags": ["business", "C1"] },
-    { "source": "tirgus daļa", "target": "market share", "tags": ["business", "C1"] },
-    { "source": "konkurence", "target": "competition", "tags": ["business", "C1"] },
-    { "source": "piegādes ķēde", "target": "supply chain", "tags": ["business", "C1"] },
-    { "source": "paplašināšanās", "target": "expansion", "tags": ["business", "C1"] },
-    { "source": "uzņēmējdarbība", "target": "entrepreneurship", "tags": ["business", "C1"] },
-    { "source": "korporatīvs", "target": "corporate", "tags": ["business", "C1"] },
-    { "source": "precīzs", "target": "precise", "tags": ["adjectives", "C1"] },
-    { "source": "izsmeļošs", "target": "comprehensive", "tags": ["adjectives", "C1"] },
-    { "source": "sistemātisks", "target": "systematic", "tags": ["adjectives", "C1"] },
-    { "source": "kritiski", "target": "critical", "tags": ["adjectives", "C1"] },
-    { "source": "analītisks", "target": "analytical", "tags": ["adjectives", "C1"] },
-    { "source": "objektīvs", "target": "objective", "tags": ["adjectives", "C1"] },
-    { "source": "subjektīvs", "target": "subjective", "tags": ["adjectives", "C1"] },
-    { "source": "loģisks", "target": "logical", "tags": ["adjectives", "C1"] },
-    { "source": "racionāls", "target": "rational", "tags": ["adjectives", "C1"] },
-    { "source": "iracionāls", "target": "irrational", "tags": ["adjectives", "C1"] },
-    { "source": "nenovērtēt", "target": "to underestimate", "tags": ["verbs", "C1"] },
-    { "source": "pārvērtēt", "target": "to overestimate", "tags": ["verbs", "C1"] },
-    { "source": "formulēt", "target": "to formulate", "tags": ["verbs", "C1"] },
-    { "source": "analizēt", "target": "to analyse", "tags": ["verbs", "C1"] },
-    { "source": "izzināt", "target": "to investigate", "tags": ["verbs", "C1"] },
-    { "source": "piemērot", "target": "to apply", "tags": ["verbs", "C1"] },
-    { "source": "izvērtēt", "target": "to evaluate", "tags": ["verbs", "C1"] },
-    { "source": "ilustrēt", "target": "to illustrate", "tags": ["verbs", "C1"] },
-    { "source": "pamatot", "target": "to substantiate", "tags": ["verbs", "C1"] },
-    { "source": "nostiprināt", "target": "to consolidate", "tags": ["verbs", "C1"] },
-    { "source": "mācībspēks", "target": "faculty member", "tags": ["academic", "C1"] },
-    { "source": "disertācija", "target": "dissertation", "tags": ["academic", "C1"] },
-    { "source": "referāts", "target": "paper", "tags": ["academic", "C1"] },
-    { "source": "seminārs", "target": "seminar", "tags": ["academic", "C1"] },
-    { "source": "simpozijs", "target": "symposium", "tags": ["academic", "C1"] },
-    { "source": "lekcija", "target": "lecture", "tags": ["academic", "C1"] },
-    { "source": "bakalaurs", "target": "bachelor", "tags": ["academic", "C1"] },
-    { "source": "maģistrs", "target": "master", "tags": ["academic", "C1"] },
-    { "source": "doktorants", "target": "doctoral student", "tags": ["academic", "C1"] },
-    { "source": "profesors", "target": "professor", "tags": ["academic", "C1"] },
-    { "source": "formāls", "target": "formal", "tags": ["register", "C1"] },
-    { "source": "neformāls", "target": "informal", "tags": ["register", "C1"] },
-    { "source": "lietišķs", "target": "professional", "tags": ["register", "C1"] },
-    { "source": "pieklājīgs", "target": "polite", "tags": ["register", "C1"] },
-    { "source": "atturīgs", "target": "reserved", "tags": ["register", "C1"] },
-    { "source": "izteiciens", "target": "expression", "tags": ["register", "C1"] },
-    { "source": "teiciens", "target": "saying", "tags": ["register", "C1"] },
-    { "source": "idioma", "target": "idiom", "tags": ["register", "C1"] },
-    { "source": "vārdu krājums", "target": "vocabulary", "tags": ["register", "C1"] },
-    { "source": "terminoloģija", "target": "terminology", "tags": ["register", "C1"] },
-    { "source": "infrastruktūra", "target": "infrastructure", "tags": ["social", "C1"] },
-    { "source": "institūcija", "target": "institution", "tags": ["social", "C1"] },
-    { "source": "birokrātija", "target": "bureaucracy", "tags": ["social", "C1"] },
-    { "source": "politika", "target": "policy", "tags": ["social", "C1"] },
-    { "source": "diplomātija", "target": "diplomacy", "tags": ["social", "C1"] },
-    { "source": "starptautisks", "target": "international", "tags": ["social", "C1"] },
-    { "source": "valdība", "target": "government", "tags": ["social", "C1"] },
-    { "source": "parlamentārs", "target": "parliamentary", "tags": ["social", "C1"] },
-    { "source": "referendums", "target": "referendum", "tags": ["social", "C1"] },
-    { "source": "demokrātija", "target": "democracy", "tags": ["social", "C1"] },
-    { "source": "nepielūdzams", "target": "relentless", "tags": ["adjectives", "C1"] },
-    { "source": "nenovēršams", "target": "inevitable", "tags": ["adjectives", "C1"] },
-    { "source": "nozīmīgs", "target": "significant", "tags": ["adjectives", "C1"] },
-    { "source": "būtisks", "target": "essential", "tags": ["adjectives", "C1"] },
-    { "source": "atbilstošs", "target": "appropriate", "tags": ["adjectives", "C1"] },
-    { "source": "nepamatots", "target": "unjustified", "tags": ["adjectives", "C1"] },
-    { "source": "ilgtspējīgs", "target": "sustainable", "tags": ["adjectives", "C1"] },
-    { "source": "sarežģīts", "target": "complex", "tags": ["adjectives", "C1"] },
-    { "source": "savdabīgs", "target": "peculiar", "tags": ["adjectives", "C1"] },
-    { "source": "pārejoša", "target": "transient", "tags": ["adjectives", "C1"] },
-    { "source": "sekas", "target": "consequences", "tags": ["social", "C1"] },
-    { "source": "ietekmes novērtējums", "target": "impact assessment", "tags": ["social", "C1"] },
-    { "source": "salīdzinošs", "target": "comparative", "tags": ["academic", "C1"] },
-    { "source": "kvantitatīvs", "target": "quantitative", "tags": ["academic", "C1"] },
-    { "source": "kvalitatīvs", "target": "qualitative", "tags": ["academic", "C1"] },
-    { "source": "empīrisks", "target": "empirical", "tags": ["academic", "C1"] },
-    { "source": "teorētisks", "target": "theoretical", "tags": ["academic", "C1"] },
-    { "source": "integrēt", "target": "to integrate", "tags": ["verbs", "C1"] },
-    { "source": "koordinēt", "target": "to coordinate", "tags": ["verbs", "C1"] },
-    { "source": "pārraudzīt", "target": "to oversee", "tags": ["verbs", "C1"] },
-    { "source": "īstenot", "target": "to implement", "tags": ["verbs", "C1"] },
-    { "source": "delegēt", "target": "to delegate", "tags": ["verbs", "C1"] },
-    { "source": "pārvaldīt", "target": "to manage", "tags": ["verbs", "C1"] },
-    { "source": "uzraudzīt", "target": "to monitor", "tags": ["verbs", "C1"] },
-    { "source": "virzīt", "target": "to facilitate", "tags": ["verbs", "C1"] },
-    { "source": "optimizēt", "target": "to optimise", "tags": ["verbs", "C1"] },
-    { "source": "komunicēt", "target": "to communicate", "tags": ["verbs", "C1"] },
-    { "source": "pārvarēt", "target": "to overcome", "tags": ["verbs", "C1"] },
-    { "source": "nodrošināt", "target": "to ensure", "tags": ["verbs", "C1"] },
-    { "source": "censties", "target": "to strive", "tags": ["verbs", "C1"] },
-    { "source": "novērtēt", "target": "to appreciate", "tags": ["verbs", "C1"] },
-    { "source": "veidot", "target": "to foster", "tags": ["verbs", "C1"] },
-    { "source": "pārskatīt", "target": "to revise", "tags": ["verbs", "C1"] },
-    { "source": "aktualizēt", "target": "to update", "tags": ["verbs", "C1"] },
-    { "source": "sistematizēt", "target": "to systematise", "tags": ["verbs", "C1"] },
-    { "source": "diferenciēt", "target": "to differentiate", "tags": ["verbs", "C1"] },
-    { "source": "apstiprināt", "target": "to confirm", "tags": ["verbs", "C1"] },
-    { "source": "apstrīdēt", "target": "to dispute", "tags": ["verbs", "C1"] },
-    { "source": "atbalstīt", "target": "to support", "tags": ["verbs", "C1"] },
-    { "source": "apvienot", "target": "to unite", "tags": ["verbs", "C1"] },
-    { "source": "adaptēt", "target": "to adapt", "tags": ["verbs", "C1"] },
-    { "source": "paātrināt", "target": "to accelerate", "tags": ["verbs", "C1"] },
-    { "source": "ierosināt", "target": "to propose", "tags": ["verbs", "C1"] },
-    { "source": "apliecināt", "target": "to demonstrate", "tags": ["verbs", "C1"] },
-    { "source": "pārliecināt", "target": "to persuade", "tags": ["verbs", "C1"] },
-    { "source": "iegūt", "target": "to acquire", "tags": ["verbs", "C1"] },
-    { "source": "paplašināt", "target": "to expand", "tags": ["verbs", "C1"] }
+    {
+      "source": "abstrakts",
+      "target": "abstract",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "analīze",
+      "target": "analysis",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "sintēze",
+      "target": "synthesis",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "hipotēze",
+      "target": "hypothesis",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "pierādījums",
+      "target": "evidence",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "metodoloģija",
+      "target": "methodology",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "pētījums",
+      "target": "research",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "teorija",
+      "target": "theory",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "koncepcija",
+      "target": "concept",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "paradigma",
+      "target": "paradigm",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "diskurss",
+      "target": "discourse",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "argumentācija",
+      "target": "argumentation",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "pamatojums",
+      "target": "justification",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "secinājums",
+      "target": "conclusion",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "apgalvojums",
+      "target": "assertion",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "atspēkojums",
+      "target": "refutation",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "kritērijs",
+      "target": "criterion",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "novērojums",
+      "target": "observation",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "interpretācija",
+      "target": "interpretation",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "konteksts",
+      "target": "context",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "likuma norma",
+      "target": "legal provision",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "jurisdikcija",
+      "target": "jurisdiction",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "tiesa",
+      "target": "court",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "spriedums",
+      "target": "verdict",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "apsūdzība",
+      "target": "prosecution",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "aizstāvība",
+      "target": "defence",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "pierādīt",
+      "target": "to prove",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "likumsargi",
+      "target": "law enforcement",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "regulēt",
+      "target": "to regulate",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "saukt pie atbildības",
+      "target": "to hold accountable",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "diagnozēt",
+      "target": "to diagnose",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "simptoms",
+      "target": "symptom",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "diagnoze",
+      "target": "diagnosis",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "terapija",
+      "target": "therapy",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "recepte",
+      "target": "prescription",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "klīnisks",
+      "target": "clinical",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "profilaktisks",
+      "target": "preventive",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "hronisks",
+      "target": "chronic",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "akūts",
+      "target": "acute",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "imūnsistēma",
+      "target": "immune system",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "ieņēmumi",
+      "target": "revenue",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "peļņa",
+      "target": "profit",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "izdevumi",
+      "target": "expenditure",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "portfelis",
+      "target": "portfolio",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "tirgus daļa",
+      "target": "market share",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "konkurence",
+      "target": "competition",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "piegādes ķēde",
+      "target": "supply chain",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "paplašināšanās",
+      "target": "expansion",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "uzņēmējdarbība",
+      "target": "entrepreneurship",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "korporatīvs",
+      "target": "corporate",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "precīzs",
+      "target": "precise",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "izsmeļošs",
+      "target": "comprehensive",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "sistemātisks",
+      "target": "systematic",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "kritiski",
+      "target": "critical",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "analītisks",
+      "target": "analytical",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "objektīvs",
+      "target": "objective",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "subjektīvs",
+      "target": "subjective",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "loģisks",
+      "target": "logical",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "racionāls",
+      "target": "rational",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "iracionāls",
+      "target": "irrational",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "nenovērtēt",
+      "target": "to underestimate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "pārvērtēt",
+      "target": "to overestimate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "formulēt",
+      "target": "to formulate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "analizēt",
+      "target": "to analyse",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "izzināt",
+      "target": "to investigate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "piemērot",
+      "target": "to apply",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "izvērtēt",
+      "target": "to evaluate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "ilustrēt",
+      "target": "to illustrate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "pamatot",
+      "target": "to substantiate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "nostiprināt",
+      "target": "to consolidate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "mācībspēks",
+      "target": "faculty member",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "disertācija",
+      "target": "dissertation",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "referāts",
+      "target": "paper",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "seminārs",
+      "target": "seminar",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "simpozijs",
+      "target": "symposium",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "lekcija",
+      "target": "lecture",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "bakalaurs",
+      "target": "bachelor",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "maģistrs",
+      "target": "master",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "doktorants",
+      "target": "doctoral student",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "profesors",
+      "target": "professor",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "formāls",
+      "target": "formal",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "neformāls",
+      "target": "informal",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "lietišķs",
+      "target": "professional",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "pieklājīgs",
+      "target": "polite",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "atturīgs",
+      "target": "reserved",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "izteiciens",
+      "target": "expression",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "teiciens",
+      "target": "saying",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "idioma",
+      "target": "idiom",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "vārdu krājums",
+      "target": "vocabulary",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "terminoloģija",
+      "target": "terminology",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "infrastruktūra",
+      "target": "infrastructure",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "institūcija",
+      "target": "institution",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "birokrātija",
+      "target": "bureaucracy",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "politika",
+      "target": "policy",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "diplomātija",
+      "target": "diplomacy",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "starptautisks",
+      "target": "international",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "valdība",
+      "target": "government",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "parlamentārs",
+      "target": "parliamentary",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "referendums",
+      "target": "referendum",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "demokrātija",
+      "target": "democracy",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "nepielūdzams",
+      "target": "relentless",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "nenovēršams",
+      "target": "inevitable",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "nozīmīgs",
+      "target": "significant",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "būtisks",
+      "target": "essential",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "atbilstošs",
+      "target": "appropriate",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "nepamatots",
+      "target": "unjustified",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "ilgtspējīgs",
+      "target": "sustainable",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "sarežģīts",
+      "target": "complex",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "savdabīgs",
+      "target": "peculiar",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "pārejoša",
+      "target": "transient",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "sekas",
+      "target": "consequences",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "ietekmes novērtējums",
+      "target": "impact assessment",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "salīdzinošs",
+      "target": "comparative",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "kvantitatīvs",
+      "target": "quantitative",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "kvalitatīvs",
+      "target": "qualitative",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "empīrisks",
+      "target": "empirical",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "teorētisks",
+      "target": "theoretical",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "integrēt",
+      "target": "to integrate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "koordinēt",
+      "target": "to coordinate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "pārraudzīt",
+      "target": "to oversee",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "īstenot",
+      "target": "to implement",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "delegēt",
+      "target": "to delegate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "pārvaldīt",
+      "target": "to manage",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "uzraudzīt",
+      "target": "to monitor",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "virzīt",
+      "target": "to facilitate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "optimizēt",
+      "target": "to optimise",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "komunicēt",
+      "target": "to communicate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "pārvarēt",
+      "target": "to overcome",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "nodrošināt",
+      "target": "to ensure",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "censties",
+      "target": "to strive",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "novērtēt",
+      "target": "to appreciate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "veidot",
+      "target": "to foster",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "pārskatīt",
+      "target": "to revise",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "aktualizēt",
+      "target": "to update",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "sistematizēt",
+      "target": "to systematise",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "diferenciēt",
+      "target": "to differentiate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "apstiprināt",
+      "target": "to confirm",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "apstrīdēt",
+      "target": "to dispute",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "atbalstīt",
+      "target": "to support",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "apvienot",
+      "target": "to unite",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "adaptēt",
+      "target": "to adapt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "paātrināt",
+      "target": "to accelerate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "ierosināt",
+      "target": "to propose",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "apliecināt",
+      "target": "to demonstrate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "pārliecināt",
+      "target": "to persuade",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "iegūt",
+      "target": "to acquire",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "paplašināt",
+      "target": "to expand",
+      "tags": ["verbs", "C1"]
+    }
   ]
 }

--- a/public/starter-packs/en-lv-c2.json
+++ b/public/starter-packs/en-lv-c2.json
@@ -6,135 +6,655 @@
   "targetCode": "en",
   "level": "C2",
   "words": [
-    { "source": "melanholija", "target": "melancholy", "tags": ["emotions", "C2"] },
-    { "source": "nostalģija", "target": "nostalgia", "tags": ["emotions", "C2"] },
-    { "source": "eifōrija", "target": "euphoria", "tags": ["emotions", "C2"] },
-    { "source": "apātija", "target": "apathy", "tags": ["emotions", "C2"] },
-    { "source": "ambivalence", "target": "ambivalence", "tags": ["emotions", "C2"] },
-    { "source": "nemiers", "target": "unease", "tags": ["emotions", "C2"] },
-    { "source": "naivums", "target": "naivety", "tags": ["emotions", "C2"] },
-    { "source": "ironija", "target": "irony", "tags": ["emotions", "C2"] },
-    { "source": "sarkasms", "target": "sarcasm", "tags": ["emotions", "C2"] },
-    { "source": "nicinājums", "target": "contempt", "tags": ["emotions", "C2"] },
-    { "source": "godkārība", "target": "ambition", "tags": ["emotions", "C2"] },
-    { "source": "nevainīgums", "target": "innocence", "tags": ["emotions", "C2"] },
-    { "source": "apbrīna", "target": "admiration", "tags": ["emotions", "C2"] },
-    { "source": "bijāšana", "target": "awe", "tags": ["emotions", "C2"] },
-    { "source": "neuzticēšanās", "target": "distrust", "tags": ["emotions", "C2"] },
-    { "source": "entuziasms", "target": "enthusiasm", "tags": ["emotions", "C2"] },
-    { "source": "atsvešinātība", "target": "alienation", "tags": ["emotions", "C2"] },
-    { "source": "empātija", "target": "empathy", "tags": ["emotions", "C2"] },
-    { "source": "pazemība", "target": "humility", "tags": ["emotions", "C2"] },
-    { "source": "lepnums", "target": "pride", "tags": ["emotions", "C2"] },
-    { "source": "pamatiedzīvotāji", "target": "indigenous people", "tags": ["social", "C2"] },
-    { "source": "koloniālisms", "target": "colonialism", "tags": ["social", "C2"] },
-    { "source": "asimilācija", "target": "assimilation", "tags": ["social", "C2"] },
-    { "source": "akulturācija", "target": "acculturation", "tags": ["social", "C2"] },
-    { "source": "etnocentrisms", "target": "ethnocentrism", "tags": ["social", "C2"] },
-    { "source": "plurālisms", "target": "pluralism", "tags": ["social", "C2"] },
-    { "source": "hegemonija", "target": "hegemony", "tags": ["social", "C2"] },
-    { "source": "diskriminācija", "target": "discrimination", "tags": ["social", "C2"] },
-    { "source": "emancipācija", "target": "emancipation", "tags": ["social", "C2"] },
-    { "source": "segregācija", "target": "segregation", "tags": ["social", "C2"] },
-    { "source": "aforisms", "target": "aphorism", "tags": ["literary", "C2"] },
-    { "source": "metafora", "target": "metaphor", "tags": ["literary", "C2"] },
-    { "source": "alegorija", "target": "allegory", "tags": ["literary", "C2"] },
-    { "source": "epitets", "target": "epithet", "tags": ["literary", "C2"] },
-    { "source": "personifikācija", "target": "personification", "tags": ["literary", "C2"] },
-    { "source": "ironizēt", "target": "to ironise", "tags": ["literary", "C2"] },
-    { "source": "parādīties", "target": "to emerge", "tags": ["literary", "C2"] },
-    { "source": "izzust", "target": "to vanish", "tags": ["literary", "C2"] },
-    { "source": "mirdzeties", "target": "to glimmer", "tags": ["literary", "C2"] },
-    { "source": "drebēt", "target": "to tremble", "tags": ["literary", "C2"] },
-    { "source": "kvintesence", "target": "quintessence", "tags": ["academic", "C2"] },
-    { "source": "aksiomasavstarpējas", "target": "axiom", "tags": ["academic", "C2"] },
-    { "source": "tautologija", "target": "tautology", "tags": ["academic", "C2"] },
-    { "source": "paradokss", "target": "paradox", "tags": ["academic", "C2"] },
-    { "source": "epistemisks", "target": "epistemic", "tags": ["academic", "C2"] },
-    { "source": "ontologs", "target": "ontological", "tags": ["academic", "C2"] },
-    { "source": "fenomenoloģija", "target": "phenomenology", "tags": ["academic", "C2"] },
-    { "source": "hermeneitika", "target": "hermeneutics", "tags": ["academic", "C2"] },
-    { "source": "dialektika", "target": "dialectics", "tags": ["academic", "C2"] },
-    { "source": "pragmatisms", "target": "pragmatism", "tags": ["academic", "C2"] },
-    { "source": "liksnis", "target": "misfortune", "tags": ["archaic", "C2"] },
-    { "source": "diždabonīgs", "target": "magnanimous", "tags": ["archaic", "C2"] },
-    { "source": "krāšņums", "target": "splendour", "tags": ["archaic", "C2"] },
-    { "source": "spožums", "target": "brilliance", "tags": ["archaic", "C2"] },
-    { "source": "tverams", "target": "tangible", "tags": ["archaic", "C2"] },
-    { "source": "netverams", "target": "intangible", "tags": ["archaic", "C2"] },
-    { "source": "divdomīgs", "target": "ambiguous", "tags": ["register", "C2"] },
-    { "source": "neitrāls", "target": "neutral", "tags": ["register", "C2"] },
-    { "source": "smalks", "target": "subtle", "tags": ["register", "C2"] },
-    { "source": "izsmalcināts", "target": "refined", "tags": ["register", "C2"] },
-    { "source": "ekspresīvs", "target": "expressive", "tags": ["register", "C2"] },
-    { "source": "sugestīvs", "target": "suggestive", "tags": ["register", "C2"] },
-    { "source": "eufonisks", "target": "euphonious", "tags": ["register", "C2"] },
-    { "source": "assonanse", "target": "assonance", "tags": ["register", "C2"] },
-    { "source": "aliterācija", "target": "alliteration", "tags": ["register", "C2"] },
-    { "source": "ambiguitāte", "target": "ambiguity", "tags": ["register", "C2"] },
-    { "source": "māksliniecisks", "target": "artistic", "tags": ["register", "C2"] },
-    { "source": "estētisks", "target": "aesthetic", "tags": ["register", "C2"] },
-    { "source": "romantisks", "target": "romantic", "tags": ["register", "C2"] },
-    { "source": "simbolisks", "target": "symbolic", "tags": ["register", "C2"] },
-    { "source": "mistiski", "target": "mystical", "tags": ["register", "C2"] },
-    { "source": "eklektisks", "target": "eclectic", "tags": ["academic", "C2"] },
-    { "source": "sinērgija", "target": "synergy", "tags": ["academic", "C2"] },
-    { "source": "holisktisks", "target": "holistic", "tags": ["academic", "C2"] },
-    { "source": "reduktīvisms", "target": "reductionism", "tags": ["academic", "C2"] },
-    { "source": "determinisms", "target": "determinism", "tags": ["academic", "C2"] },
-    { "source": "relativisms", "target": "relativism", "tags": ["academic", "C2"] },
-    { "source": "nihilisms", "target": "nihilism", "tags": ["academic", "C2"] },
-    { "source": "skepticisms", "target": "scepticism", "tags": ["academic", "C2"] },
-    { "source": "empirisms", "target": "empiricism", "tags": ["academic", "C2"] },
-    { "source": "racionālisms", "target": "rationalism", "tags": ["academic", "C2"] },
-    { "source": "pārnestā nozīmē", "target": "figuratively", "tags": ["literary", "C2"] },
-    { "source": "tiešā nozīmē", "target": "literally", "tags": ["literary", "C2"] },
-    { "source": "retorika", "target": "rhetoric", "tags": ["literary", "C2"] },
-    { "source": "polemika", "target": "polemic", "tags": ["literary", "C2"] },
-    { "source": "epigramma", "target": "epigram", "tags": ["literary", "C2"] },
-    { "source": "satīra", "target": "satire", "tags": ["literary", "C2"] },
-    { "source": "parodija", "target": "parody", "tags": ["literary", "C2"] },
-    { "source": "analoģija", "target": "analogy", "tags": ["literary", "C2"] },
-    { "source": "metonīmija", "target": "metonymy", "tags": ["literary", "C2"] },
-    { "source": "ezopiskais valoda", "target": "Aesopian language", "tags": ["literary", "C2"] },
-    { "source": "eksistenciāls", "target": "existential", "tags": ["academic", "C2"] },
-    { "source": "transcendentāls", "target": "transcendent", "tags": ["academic", "C2"] },
-    { "source": "metafizisks", "target": "metaphysical", "tags": ["academic", "C2"] },
-    { "source": "epistemologs", "target": "epistemology", "tags": ["academic", "C2"] },
-    { "source": "nominālistisks", "target": "nominalist", "tags": ["academic", "C2"] },
-    { "source": "teleologs", "target": "teleological", "tags": ["academic", "C2"] },
-    { "source": "deontologs", "target": "deontological", "tags": ["academic", "C2"] },
-    { "source": "konsekvenciālisms", "target": "consequentialism", "tags": ["academic", "C2"] },
-    { "source": "utilitārisms", "target": "utilitarianism", "tags": ["academic", "C2"] },
-    { "source": "morālisms", "target": "moralism", "tags": ["academic", "C2"] },
-    { "source": "neizpērkams", "target": "irremediable", "tags": ["archaic", "C2"] },
-    { "source": "neatgriezenisks", "target": "irreversible", "tags": ["archaic", "C2"] },
-    { "source": "bēdīgums", "target": "sorrow", "tags": ["archaic", "C2"] },
-    { "source": "gausme", "target": "dawn", "tags": ["archaic", "C2"] },
-    { "source": "vakarvēja", "target": "evening breeze", "tags": ["archaic", "C2"] },
-    { "source": "rīta ausma", "target": "daybreak", "tags": ["archaic", "C2"] },
-    { "source": "nīkuļot", "target": "to languish", "tags": ["archaic", "C2"] },
-    { "source": "lolot", "target": "to cherish", "tags": ["archaic", "C2"] },
-    { "source": "nopūsties", "target": "to sigh", "tags": ["archaic", "C2"] },
-    { "source": "nocietināties", "target": "to fortify oneself", "tags": ["archaic", "C2"] },
-    { "source": "izsekot", "target": "to trace", "tags": ["verbs", "C2"] },
-    { "source": "atsaukt atmiņā", "target": "to reminisce", "tags": ["verbs", "C2"] },
-    { "source": "iemieso", "target": "to embody", "tags": ["verbs", "C2"] },
-    { "source": "izpausties", "target": "to manifest", "tags": ["verbs", "C2"] },
-    { "source": "novākt", "target": "to eradicate", "tags": ["verbs", "C2"] },
-    { "source": "iesakņoties", "target": "to take root", "tags": ["verbs", "C2"] },
-    { "source": "pārvarēt", "target": "to transcend", "tags": ["verbs", "C2"] },
-    { "source": "uzbudinājums", "target": "arousal", "tags": ["emotions", "C2"] },
-    { "source": "pieplūdums", "target": "influx", "tags": ["social", "C2"] },
-    { "source": "sabiedriskā doma", "target": "public opinion", "tags": ["social", "C2"] },
-    { "source": "normatīvs", "target": "normative", "tags": ["academic", "C2"] },
-    { "source": "deskriptīvs", "target": "descriptive", "tags": ["academic", "C2"] },
-    { "source": "preskriptīvs", "target": "prescriptive", "tags": ["academic", "C2"] },
-    { "source": "saistvielas", "target": "ligature", "tags": ["literary", "C2"] },
-    { "source": "paraksts", "target": "signature", "tags": ["literary", "C2"] },
-    { "source": "simbolika", "target": "symbolism", "tags": ["literary", "C2"] },
-    { "source": "ekfrāze", "target": "ekphrasis", "tags": ["literary", "C2"] },
-    { "source": "hiperbola", "target": "hyperbole", "tags": ["literary", "C2"] },
-    { "source": "litota", "target": "litotes", "tags": ["literary", "C2"] }
+    {
+      "source": "melanholija",
+      "target": "melancholy",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "nostalģija",
+      "target": "nostalgia",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "eifōrija",
+      "target": "euphoria",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "apātija",
+      "target": "apathy",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "ambivalence",
+      "target": "ambivalence",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "nemiers",
+      "target": "unease",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "naivums",
+      "target": "naivety",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "ironija",
+      "target": "irony",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "sarkasms",
+      "target": "sarcasm",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "nicinājums",
+      "target": "contempt",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "godkārība",
+      "target": "ambition",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "nevainīgums",
+      "target": "innocence",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "apbrīna",
+      "target": "admiration",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "bijāšana",
+      "target": "awe",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "neuzticēšanās",
+      "target": "distrust",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "entuziasms",
+      "target": "enthusiasm",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "atsvešinātība",
+      "target": "alienation",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "empātija",
+      "target": "empathy",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "pazemība",
+      "target": "humility",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "lepnums",
+      "target": "pride",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "pamatiedzīvotāji",
+      "target": "indigenous people",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "koloniālisms",
+      "target": "colonialism",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "asimilācija",
+      "target": "assimilation",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "akulturācija",
+      "target": "acculturation",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "etnocentrisms",
+      "target": "ethnocentrism",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "plurālisms",
+      "target": "pluralism",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "hegemonija",
+      "target": "hegemony",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "diskriminācija",
+      "target": "discrimination",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "emancipācija",
+      "target": "emancipation",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "segregācija",
+      "target": "segregation",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "aforisms",
+      "target": "aphorism",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "metafora",
+      "target": "metaphor",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "alegorija",
+      "target": "allegory",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "epitets",
+      "target": "epithet",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "personifikācija",
+      "target": "personification",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "ironizēt",
+      "target": "to ironise",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "parādīties",
+      "target": "to emerge",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "izzust",
+      "target": "to vanish",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "mirdzeties",
+      "target": "to glimmer",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "drebēt",
+      "target": "to tremble",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "kvintesence",
+      "target": "quintessence",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "aksiomasavstarpējas",
+      "target": "axiom",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "tautologija",
+      "target": "tautology",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "paradokss",
+      "target": "paradox",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "epistemisks",
+      "target": "epistemic",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "ontologs",
+      "target": "ontological",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "fenomenoloģija",
+      "target": "phenomenology",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "hermeneitika",
+      "target": "hermeneutics",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "dialektika",
+      "target": "dialectics",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "pragmatisms",
+      "target": "pragmatism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "liksnis",
+      "target": "misfortune",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "diždabonīgs",
+      "target": "magnanimous",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "krāšņums",
+      "target": "splendour",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "spožums",
+      "target": "brilliance",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "tverams",
+      "target": "tangible",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "netverams",
+      "target": "intangible",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "divdomīgs",
+      "target": "ambiguous",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "neitrāls",
+      "target": "neutral",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "smalks",
+      "target": "subtle",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "izsmalcināts",
+      "target": "refined",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "ekspresīvs",
+      "target": "expressive",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "sugestīvs",
+      "target": "suggestive",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "eufonisks",
+      "target": "euphonious",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "assonanse",
+      "target": "assonance",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "aliterācija",
+      "target": "alliteration",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "ambiguitāte",
+      "target": "ambiguity",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "māksliniecisks",
+      "target": "artistic",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "estētisks",
+      "target": "aesthetic",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "romantisks",
+      "target": "romantic",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "simbolisks",
+      "target": "symbolic",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "mistiski",
+      "target": "mystical",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "eklektisks",
+      "target": "eclectic",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "sinērgija",
+      "target": "synergy",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "holisktisks",
+      "target": "holistic",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "reduktīvisms",
+      "target": "reductionism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "determinisms",
+      "target": "determinism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "relativisms",
+      "target": "relativism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "nihilisms",
+      "target": "nihilism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "skepticisms",
+      "target": "scepticism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "empirisms",
+      "target": "empiricism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "racionālisms",
+      "target": "rationalism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "pārnestā nozīmē",
+      "target": "figuratively",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "tiešā nozīmē",
+      "target": "literally",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "retorika",
+      "target": "rhetoric",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "polemika",
+      "target": "polemic",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "epigramma",
+      "target": "epigram",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "satīra",
+      "target": "satire",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "parodija",
+      "target": "parody",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "analoģija",
+      "target": "analogy",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "metonīmija",
+      "target": "metonymy",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "ezopiskais valoda",
+      "target": "Aesopian language",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "eksistenciāls",
+      "target": "existential",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "transcendentāls",
+      "target": "transcendent",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "metafizisks",
+      "target": "metaphysical",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "epistemologs",
+      "target": "epistemology",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "nominālistisks",
+      "target": "nominalist",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "teleologs",
+      "target": "teleological",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "deontologs",
+      "target": "deontological",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "konsekvenciālisms",
+      "target": "consequentialism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "utilitārisms",
+      "target": "utilitarianism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "morālisms",
+      "target": "moralism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "neizpērkams",
+      "target": "irremediable",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "neatgriezenisks",
+      "target": "irreversible",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "bēdīgums",
+      "target": "sorrow",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "gausme",
+      "target": "dawn",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "vakarvēja",
+      "target": "evening breeze",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "rīta ausma",
+      "target": "daybreak",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "nīkuļot",
+      "target": "to languish",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "lolot",
+      "target": "to cherish",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "nopūsties",
+      "target": "to sigh",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "nocietināties",
+      "target": "to fortify oneself",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "izsekot",
+      "target": "to trace",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "atsaukt atmiņā",
+      "target": "to reminisce",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "iemieso",
+      "target": "to embody",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "izpausties",
+      "target": "to manifest",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "novākt",
+      "target": "to eradicate",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "iesakņoties",
+      "target": "to take root",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "pārvarēt",
+      "target": "to transcend",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "uzbudinājums",
+      "target": "arousal",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "pieplūdums",
+      "target": "influx",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "sabiedriskā doma",
+      "target": "public opinion",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "normatīvs",
+      "target": "normative",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "deskriptīvs",
+      "target": "descriptive",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "preskriptīvs",
+      "target": "prescriptive",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "saistvielas",
+      "target": "ligature",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "paraksts",
+      "target": "signature",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "simbolika",
+      "target": "symbolism",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "ekfrāze",
+      "target": "ekphrasis",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "hiperbola",
+      "target": "hyperbole",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "litota",
+      "target": "litotes",
+      "tags": ["literary", "C2"]
+    }
   ]
 }

--- a/public/starter-packs/ru-en-a1.json
+++ b/public/starter-packs/ru-en-a1.json
@@ -6,191 +6,935 @@
   "targetCode": "en",
   "level": "A1",
   "words": [
-    { "source": "привет", "target": "hello", "tags": ["greetings", "A1"] },
-    { "source": "пока", "target": "bye", "tags": ["greetings", "A1"] },
-    { "source": "до свидания", "target": "goodbye", "tags": ["greetings", "A1"] },
-    { "source": "пожалуйста", "target": "please", "tags": ["greetings", "A1"] },
-    { "source": "спасибо", "target": "thank you", "tags": ["greetings", "A1"] },
-    { "source": "да", "target": "yes", "tags": ["greetings", "A1"] },
-    { "source": "нет", "target": "no", "tags": ["greetings", "A1"] },
-    { "source": "извините", "target": "sorry", "tags": ["greetings", "A1"] },
-    { "source": "доброе утро", "target": "good morning", "tags": ["greetings", "A1"] },
-    { "source": "добрый день", "target": "good afternoon", "tags": ["greetings", "A1"] },
-    { "source": "добрый вечер", "target": "good evening", "tags": ["greetings", "A1"] },
-    { "source": "до встречи", "target": "see you later", "tags": ["greetings", "A1"] },
-    { "source": "один", "target": "one", "tags": ["numbers", "A1"] },
-    { "source": "два", "target": "two", "tags": ["numbers", "A1"] },
-    { "source": "три", "target": "three", "tags": ["numbers", "A1"] },
-    { "source": "четыре", "target": "four", "tags": ["numbers", "A1"] },
-    { "source": "пять", "target": "five", "tags": ["numbers", "A1"] },
-    { "source": "шесть", "target": "six", "tags": ["numbers", "A1"] },
-    { "source": "семь", "target": "seven", "tags": ["numbers", "A1"] },
-    { "source": "восемь", "target": "eight", "tags": ["numbers", "A1"] },
-    { "source": "девять", "target": "nine", "tags": ["numbers", "A1"] },
-    { "source": "десять", "target": "ten", "tags": ["numbers", "A1"] },
-    { "source": "одиннадцать", "target": "eleven", "tags": ["numbers", "A1"] },
-    { "source": "двенадцать", "target": "twelve", "tags": ["numbers", "A1"] },
-    { "source": "тринадцать", "target": "thirteen", "tags": ["numbers", "A1"] },
-    { "source": "четырнадцать", "target": "fourteen", "tags": ["numbers", "A1"] },
-    { "source": "пятнадцать", "target": "fifteen", "tags": ["numbers", "A1"] },
-    { "source": "шестнадцать", "target": "sixteen", "tags": ["numbers", "A1"] },
-    { "source": "семнадцать", "target": "seventeen", "tags": ["numbers", "A1"] },
-    { "source": "восемнадцать", "target": "eighteen", "tags": ["numbers", "A1"] },
-    { "source": "девятнадцать", "target": "nineteen", "tags": ["numbers", "A1"] },
-    { "source": "двадцать", "target": "twenty", "tags": ["numbers", "A1"] },
-    { "source": "красный", "target": "red", "tags": ["colours", "A1"] },
-    { "source": "синий", "target": "blue", "tags": ["colours", "A1"] },
-    { "source": "зелёный", "target": "green", "tags": ["colours", "A1"] },
-    { "source": "жёлтый", "target": "yellow", "tags": ["colours", "A1"] },
-    { "source": "белый", "target": "white", "tags": ["colours", "A1"] },
-    { "source": "чёрный", "target": "black", "tags": ["colours", "A1"] },
-    { "source": "оранжевый", "target": "orange", "tags": ["colours", "A1"] },
-    { "source": "розовый", "target": "pink", "tags": ["colours", "A1"] },
-    { "source": "фиолетовый", "target": "purple", "tags": ["colours", "A1"] },
-    { "source": "коричневый", "target": "brown", "tags": ["colours", "A1"] },
-    { "source": "серый", "target": "grey", "tags": ["colours", "A1"] },
-    { "source": "мама", "target": "mother", "tags": ["family", "A1"] },
-    { "source": "папа", "target": "father", "tags": ["family", "A1"] },
-    { "source": "сестра", "target": "sister", "tags": ["family", "A1"] },
-    { "source": "брат", "target": "brother", "tags": ["family", "A1"] },
-    { "source": "бабушка", "target": "grandmother", "tags": ["family", "A1"] },
-    { "source": "дедушка", "target": "grandfather", "tags": ["family", "A1"] },
-    { "source": "ребёнок", "target": "child", "tags": ["family", "A1"] },
-    { "source": "сын", "target": "son", "tags": ["family", "A1"] },
-    { "source": "дочь", "target": "daughter", "tags": ["family", "A1"] },
-    { "source": "муж", "target": "husband", "tags": ["family", "A1"] },
-    { "source": "жена", "target": "wife", "tags": ["family", "A1"] },
-    { "source": "семья", "target": "family", "tags": ["family", "A1"] },
-    { "source": "вода", "target": "water", "tags": ["food-drink", "A1"] },
-    { "source": "молоко", "target": "milk", "tags": ["food-drink", "A1"] },
-    { "source": "хлеб", "target": "bread", "tags": ["food-drink", "A1"] },
-    { "source": "яйцо", "target": "egg", "tags": ["food-drink", "A1"] },
-    { "source": "яблоко", "target": "apple", "tags": ["food-drink", "A1"] },
-    { "source": "банан", "target": "banana", "tags": ["food-drink", "A1"] },
-    { "source": "кофе", "target": "coffee", "tags": ["food-drink", "A1"] },
-    { "source": "чай", "target": "tea", "tags": ["food-drink", "A1"] },
-    { "source": "сыр", "target": "cheese", "tags": ["food-drink", "A1"] },
-    { "source": "мясо", "target": "meat", "tags": ["food-drink", "A1"] },
-    { "source": "рис", "target": "rice", "tags": ["food-drink", "A1"] },
-    { "source": "сахар", "target": "sugar", "tags": ["food-drink", "A1"] },
-    { "source": "понедельник", "target": "Monday", "tags": ["days", "A1"] },
-    { "source": "вторник", "target": "Tuesday", "tags": ["days", "A1"] },
-    { "source": "среда", "target": "Wednesday", "tags": ["days", "A1"] },
-    { "source": "четверг", "target": "Thursday", "tags": ["days", "A1"] },
-    { "source": "пятница", "target": "Friday", "tags": ["days", "A1"] },
-    { "source": "суббота", "target": "Saturday", "tags": ["days", "A1"] },
-    { "source": "воскресенье", "target": "Sunday", "tags": ["days", "A1"] },
-    { "source": "январь", "target": "January", "tags": ["months", "A1"] },
-    { "source": "февраль", "target": "February", "tags": ["months", "A1"] },
-    { "source": "март", "target": "March", "tags": ["months", "A1"] },
-    { "source": "апрель", "target": "April", "tags": ["months", "A1"] },
-    { "source": "май", "target": "May", "tags": ["months", "A1"] },
-    { "source": "июнь", "target": "June", "tags": ["months", "A1"] },
-    { "source": "июль", "target": "July", "tags": ["months", "A1"] },
-    { "source": "август", "target": "August", "tags": ["months", "A1"] },
-    { "source": "сентябрь", "target": "September", "tags": ["months", "A1"] },
-    { "source": "октябрь", "target": "October", "tags": ["months", "A1"] },
-    { "source": "ноябрь", "target": "November", "tags": ["months", "A1"] },
-    { "source": "декабрь", "target": "December", "tags": ["months", "A1"] },
-    { "source": "быть", "target": "to be", "tags": ["verbs", "A1"] },
-    { "source": "иметь", "target": "to have", "tags": ["verbs", "A1"] },
-    { "source": "идти", "target": "to go", "tags": ["verbs", "A1"] },
-    { "source": "хотеть", "target": "to want", "tags": ["verbs", "A1"] },
-    { "source": "любить", "target": "to like", "tags": ["verbs", "A1"] },
-    { "source": "прийти", "target": "to come", "tags": ["verbs", "A1"] },
-    { "source": "видеть", "target": "to see", "tags": ["verbs", "A1"] },
-    { "source": "слышать", "target": "to hear", "tags": ["verbs", "A1"] },
-    { "source": "есть", "target": "to eat", "tags": ["verbs", "A1"] },
-    { "source": "пить", "target": "to drink", "tags": ["verbs", "A1"] },
-    { "source": "спать", "target": "to sleep", "tags": ["verbs", "A1"] },
-    { "source": "сидеть", "target": "to sit", "tags": ["verbs", "A1"] },
-    { "source": "стоять", "target": "to stand", "tags": ["verbs", "A1"] },
-    { "source": "говорить", "target": "to talk", "tags": ["verbs", "A1"] },
-    { "source": "дать", "target": "to give", "tags": ["verbs", "A1"] },
-    { "source": "взять", "target": "to take", "tags": ["verbs", "A1"] },
-    { "source": "смотреть", "target": "to look", "tags": ["verbs", "A1"] },
-    { "source": "хороший", "target": "good", "tags": ["adjectives", "A1"] },
-    { "source": "плохой", "target": "bad", "tags": ["adjectives", "A1"] },
-    { "source": "большой", "target": "big", "tags": ["adjectives", "A1"] },
-    { "source": "маленький", "target": "small", "tags": ["adjectives", "A1"] },
-    { "source": "горячий", "target": "hot", "tags": ["adjectives", "A1"] },
-    { "source": "холодный", "target": "cold", "tags": ["adjectives", "A1"] },
-    { "source": "новый", "target": "new", "tags": ["adjectives", "A1"] },
-    { "source": "старый", "target": "old", "tags": ["adjectives", "A1"] },
-    { "source": "длинный", "target": "long", "tags": ["adjectives", "A1"] },
-    { "source": "короткий", "target": "short", "tags": ["adjectives", "A1"] },
-    { "source": "высокий", "target": "tall", "tags": ["adjectives", "A1"] },
-    { "source": "низкий", "target": "low", "tags": ["adjectives", "A1"] },
-    { "source": "я", "target": "I", "tags": ["pronouns", "A1"] },
-    { "source": "ты", "target": "you", "tags": ["pronouns", "A1"] },
-    { "source": "он", "target": "he", "tags": ["pronouns", "A1"] },
-    { "source": "она", "target": "she", "tags": ["pronouns", "A1"] },
-    { "source": "мы", "target": "we", "tags": ["pronouns", "A1"] },
-    { "source": "они", "target": "they", "tags": ["pronouns", "A1"] },
-    { "source": "оно", "target": "it", "tags": ["pronouns", "A1"] },
-    { "source": "дом", "target": "house", "tags": ["home", "A1"] },
-    { "source": "комната", "target": "room", "tags": ["home", "A1"] },
-    { "source": "дверь", "target": "door", "tags": ["home", "A1"] },
-    { "source": "окно", "target": "window", "tags": ["home", "A1"] },
-    { "source": "стол", "target": "table", "tags": ["home", "A1"] },
-    { "source": "стул", "target": "chair", "tags": ["home", "A1"] },
-    { "source": "кровать", "target": "bed", "tags": ["home", "A1"] },
-    { "source": "человек", "target": "person", "tags": ["social", "A1"] },
-    { "source": "мужчина", "target": "man", "tags": ["social", "A1"] },
-    { "source": "женщина", "target": "woman", "tags": ["social", "A1"] },
-    { "source": "мальчик", "target": "boy", "tags": ["social", "A1"] },
-    { "source": "девочка", "target": "girl", "tags": ["social", "A1"] },
-    { "source": "друг", "target": "friend", "tags": ["social", "A1"] },
-    { "source": "имя", "target": "name", "tags": ["social", "A1"] },
-    { "source": "возраст", "target": "age", "tags": ["social", "A1"] },
-    { "source": "животное", "target": "animal", "tags": ["nature", "A1"] },
-    { "source": "собака", "target": "dog", "tags": ["nature", "A1"] },
-    { "source": "кошка", "target": "cat", "tags": ["nature", "A1"] },
-    { "source": "птица", "target": "bird", "tags": ["nature", "A1"] },
-    { "source": "рыба", "target": "fish", "tags": ["nature", "A1"] },
-    { "source": "дерево", "target": "tree", "tags": ["nature", "A1"] },
-    { "source": "цветок", "target": "flower", "tags": ["nature", "A1"] },
-    { "source": "солнце", "target": "sun", "tags": ["nature", "A1"] },
-    { "source": "дождь", "target": "rain", "tags": ["nature", "A1"] },
-    { "source": "снег", "target": "snow", "tags": ["nature", "A1"] },
-    { "source": "телефон", "target": "phone", "tags": ["objects", "A1"] },
-    { "source": "книга", "target": "book", "tags": ["objects", "A1"] },
-    { "source": "ручка", "target": "pen", "tags": ["objects", "A1"] },
-    { "source": "сумка", "target": "bag", "tags": ["objects", "A1"] },
-    { "source": "ключ", "target": "key", "tags": ["objects", "A1"] },
-    { "source": "деньги", "target": "money", "tags": ["objects", "A1"] },
-    { "source": "магазин", "target": "shop", "tags": ["social", "A1"] },
-    { "source": "школа", "target": "school", "tags": ["social", "A1"] },
-    { "source": "машина", "target": "car", "tags": ["travel", "A1"] },
-    { "source": "автобус", "target": "bus", "tags": ["travel", "A1"] },
-    { "source": "улица", "target": "street", "tags": ["travel", "A1"] },
-    { "source": "город", "target": "city", "tags": ["travel", "A1"] },
-    { "source": "страна", "target": "country", "tags": ["travel", "A1"] },
-    { "source": "здесь", "target": "here", "tags": ["directions", "A1"] },
-    { "source": "там", "target": "there", "tags": ["directions", "A1"] },
-    { "source": "направо", "target": "to the right", "tags": ["directions", "A1"] },
-    { "source": "налево", "target": "to the left", "tags": ["directions", "A1"] },
-    { "source": "прямо", "target": "straight ahead", "tags": ["directions", "A1"] },
-    { "source": "вверх", "target": "up", "tags": ["directions", "A1"] },
-    { "source": "вниз", "target": "down", "tags": ["directions", "A1"] },
-    { "source": "день", "target": "day", "tags": ["time", "A1"] },
-    { "source": "ночь", "target": "night", "tags": ["time", "A1"] },
-    { "source": "утро", "target": "morning", "tags": ["time", "A1"] },
-    { "source": "вечер", "target": "evening", "tags": ["time", "A1"] },
-    { "source": "сейчас", "target": "now", "tags": ["time", "A1"] },
-    { "source": "вчера", "target": "yesterday", "tags": ["time", "A1"] },
-    { "source": "завтра", "target": "tomorrow", "tags": ["time", "A1"] },
-    { "source": "сегодня", "target": "today", "tags": ["time", "A1"] },
-    { "source": "неделя", "target": "week", "tags": ["time", "A1"] },
-    { "source": "месяц", "target": "month", "tags": ["time", "A1"] },
-    { "source": "год", "target": "year", "tags": ["time", "A1"] },
-    { "source": "голова", "target": "head", "tags": ["body", "A1"] },
-    { "source": "рука", "target": "hand", "tags": ["body", "A1"] },
-    { "source": "нога", "target": "leg", "tags": ["body", "A1"] },
-    { "source": "глаза", "target": "eyes", "tags": ["body", "A1"] },
-    { "source": "уши", "target": "ears", "tags": ["body", "A1"] },
-    { "source": "нос", "target": "nose", "tags": ["body", "A1"] },
-    { "source": "рот", "target": "mouth", "tags": ["body", "A1"] },
-    { "source": "сердце", "target": "heart", "tags": ["body", "A1"] }
+    {
+      "source": "привет",
+      "target": "hello",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "пока",
+      "target": "bye",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "до свидания",
+      "target": "goodbye",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "пожалуйста",
+      "target": "please",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "спасибо",
+      "target": "thank you",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "да",
+      "target": "yes",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "нет",
+      "target": "no",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "извините",
+      "target": "sorry",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "доброе утро",
+      "target": "good morning",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "добрый день",
+      "target": "good afternoon",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "добрый вечер",
+      "target": "good evening",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "до встречи",
+      "target": "see you later",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "один",
+      "target": "one",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "два",
+      "target": "two",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "три",
+      "target": "three",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "четыре",
+      "target": "four",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "пять",
+      "target": "five",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "шесть",
+      "target": "six",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "семь",
+      "target": "seven",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "восемь",
+      "target": "eight",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "девять",
+      "target": "nine",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "десять",
+      "target": "ten",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "одиннадцать",
+      "target": "eleven",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "двенадцать",
+      "target": "twelve",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "тринадцать",
+      "target": "thirteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "четырнадцать",
+      "target": "fourteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "пятнадцать",
+      "target": "fifteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "шестнадцать",
+      "target": "sixteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "семнадцать",
+      "target": "seventeen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "восемнадцать",
+      "target": "eighteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "девятнадцать",
+      "target": "nineteen",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "двадцать",
+      "target": "twenty",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "красный",
+      "target": "red",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "синий",
+      "target": "blue",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "зелёный",
+      "target": "green",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "жёлтый",
+      "target": "yellow",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "белый",
+      "target": "white",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "чёрный",
+      "target": "black",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "оранжевый",
+      "target": "orange",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "розовый",
+      "target": "pink",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "фиолетовый",
+      "target": "purple",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "коричневый",
+      "target": "brown",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "серый",
+      "target": "grey",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "мама",
+      "target": "mother",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "папа",
+      "target": "father",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "сестра",
+      "target": "sister",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "брат",
+      "target": "brother",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "бабушка",
+      "target": "grandmother",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "дедушка",
+      "target": "grandfather",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "ребёнок",
+      "target": "child",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "сын",
+      "target": "son",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "дочь",
+      "target": "daughter",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "муж",
+      "target": "husband",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "жена",
+      "target": "wife",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "семья",
+      "target": "family",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "вода",
+      "target": "water",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "молоко",
+      "target": "milk",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "хлеб",
+      "target": "bread",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "яйцо",
+      "target": "egg",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "яблоко",
+      "target": "apple",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "банан",
+      "target": "banana",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "кофе",
+      "target": "coffee",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "чай",
+      "target": "tea",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "сыр",
+      "target": "cheese",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "мясо",
+      "target": "meat",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "рис",
+      "target": "rice",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "сахар",
+      "target": "sugar",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "понедельник",
+      "target": "Monday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "вторник",
+      "target": "Tuesday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "среда",
+      "target": "Wednesday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "четверг",
+      "target": "Thursday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "пятница",
+      "target": "Friday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "суббота",
+      "target": "Saturday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "воскресенье",
+      "target": "Sunday",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "январь",
+      "target": "January",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "февраль",
+      "target": "February",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "март",
+      "target": "March",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "апрель",
+      "target": "April",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "май",
+      "target": "May",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "июнь",
+      "target": "June",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "июль",
+      "target": "July",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "август",
+      "target": "August",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "сентябрь",
+      "target": "September",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "октябрь",
+      "target": "October",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "ноябрь",
+      "target": "November",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "декабрь",
+      "target": "December",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "быть",
+      "target": "to be",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "иметь",
+      "target": "to have",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "идти",
+      "target": "to go",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "хотеть",
+      "target": "to want",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "любить",
+      "target": "to like",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "прийти",
+      "target": "to come",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "видеть",
+      "target": "to see",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "слышать",
+      "target": "to hear",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "есть",
+      "target": "to eat",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "пить",
+      "target": "to drink",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "спать",
+      "target": "to sleep",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "сидеть",
+      "target": "to sit",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "стоять",
+      "target": "to stand",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "говорить",
+      "target": "to talk",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "дать",
+      "target": "to give",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "взять",
+      "target": "to take",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "смотреть",
+      "target": "to look",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "хороший",
+      "target": "good",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "плохой",
+      "target": "bad",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "большой",
+      "target": "big",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "маленький",
+      "target": "small",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "горячий",
+      "target": "hot",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "холодный",
+      "target": "cold",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "новый",
+      "target": "new",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "старый",
+      "target": "old",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "длинный",
+      "target": "long",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "короткий",
+      "target": "short",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "высокий",
+      "target": "tall",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "низкий",
+      "target": "low",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "я",
+      "target": "I",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "ты",
+      "target": "you",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "он",
+      "target": "he",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "она",
+      "target": "she",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "мы",
+      "target": "we",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "они",
+      "target": "they",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "оно",
+      "target": "it",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "дом",
+      "target": "house",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "комната",
+      "target": "room",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "дверь",
+      "target": "door",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "окно",
+      "target": "window",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "стол",
+      "target": "table",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "стул",
+      "target": "chair",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "кровать",
+      "target": "bed",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "человек",
+      "target": "person",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "мужчина",
+      "target": "man",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "женщина",
+      "target": "woman",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "мальчик",
+      "target": "boy",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "девочка",
+      "target": "girl",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "друг",
+      "target": "friend",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "имя",
+      "target": "name",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "возраст",
+      "target": "age",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "животное",
+      "target": "animal",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "собака",
+      "target": "dog",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "кошка",
+      "target": "cat",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "птица",
+      "target": "bird",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "рыба",
+      "target": "fish",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "дерево",
+      "target": "tree",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "цветок",
+      "target": "flower",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "солнце",
+      "target": "sun",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "дождь",
+      "target": "rain",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "снег",
+      "target": "snow",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "телефон",
+      "target": "phone",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "книга",
+      "target": "book",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "ручка",
+      "target": "pen",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "сумка",
+      "target": "bag",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "ключ",
+      "target": "key",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "деньги",
+      "target": "money",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "магазин",
+      "target": "shop",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "школа",
+      "target": "school",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "машина",
+      "target": "car",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "автобус",
+      "target": "bus",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "улица",
+      "target": "street",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "город",
+      "target": "city",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "страна",
+      "target": "country",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "здесь",
+      "target": "here",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "там",
+      "target": "there",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "направо",
+      "target": "to the right",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "налево",
+      "target": "to the left",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "прямо",
+      "target": "straight ahead",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "вверх",
+      "target": "up",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "вниз",
+      "target": "down",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "день",
+      "target": "day",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "ночь",
+      "target": "night",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "утро",
+      "target": "morning",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "вечер",
+      "target": "evening",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "сейчас",
+      "target": "now",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "вчера",
+      "target": "yesterday",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "завтра",
+      "target": "tomorrow",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "сегодня",
+      "target": "today",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "неделя",
+      "target": "week",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "месяц",
+      "target": "month",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "год",
+      "target": "year",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "голова",
+      "target": "head",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "рука",
+      "target": "hand",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "нога",
+      "target": "leg",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "глаза",
+      "target": "eyes",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "уши",
+      "target": "ears",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "нос",
+      "target": "nose",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "рот",
+      "target": "mouth",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "сердце",
+      "target": "heart",
+      "tags": ["body", "A1"]
+    }
   ]
 }

--- a/public/starter-packs/ru-en-a2.json
+++ b/public/starter-packs/ru-en-a2.json
@@ -6,145 +6,695 @@
   "targetCode": "en",
   "level": "A2",
   "words": [
-    { "source": "покупки", "target": "shopping", "tags": ["shopping", "A2"] },
-    { "source": "магазин", "target": "store", "tags": ["shopping", "A2"] },
-    { "source": "цена", "target": "price", "tags": ["shopping", "A2"] },
-    { "source": "дешёвый", "target": "cheap", "tags": ["shopping", "A2"] },
-    { "source": "дорогой", "target": "expensive", "tags": ["shopping", "A2"] },
-    { "source": "деньги", "target": "money", "tags": ["shopping", "A2"] },
-    { "source": "чек", "target": "receipt", "tags": ["shopping", "A2"] },
-    { "source": "скидка", "target": "discount", "tags": ["shopping", "A2"] },
-    { "source": "размер", "target": "size", "tags": ["shopping", "A2"] },
-    { "source": "коробка", "target": "box", "tags": ["shopping", "A2"] },
-    { "source": "пакет", "target": "bag", "tags": ["shopping", "A2"] },
-    { "source": "очередь", "target": "queue", "tags": ["shopping", "A2"] },
-    { "source": "дорога", "target": "road", "tags": ["directions", "A2"] },
-    { "source": "угол", "target": "corner", "tags": ["directions", "A2"] },
-    { "source": "перекрёсток", "target": "crossroads", "tags": ["directions", "A2"] },
-    { "source": "мост", "target": "bridge", "tags": ["directions", "A2"] },
-    { "source": "вокзал", "target": "station", "tags": ["directions", "A2"] },
-    { "source": "остановка", "target": "stop", "tags": ["directions", "A2"] },
-    { "source": "рядом", "target": "nearby", "tags": ["directions", "A2"] },
-    { "source": "далеко", "target": "far", "tags": ["directions", "A2"] },
-    { "source": "за", "target": "behind", "tags": ["directions", "A2"] },
-    { "source": "перед", "target": "in front of", "tags": ["directions", "A2"] },
-    { "source": "рядом с", "target": "next to", "tags": ["directions", "A2"] },
-    { "source": "погода", "target": "weather", "tags": ["weather", "A2"] },
-    { "source": "солнечный", "target": "sunny", "tags": ["weather", "A2"] },
-    { "source": "облачный", "target": "cloudy", "tags": ["weather", "A2"] },
-    { "source": "дождливый", "target": "rainy", "tags": ["weather", "A2"] },
-    { "source": "ветреный", "target": "windy", "tags": ["weather", "A2"] },
-    { "source": "снежный", "target": "snowy", "tags": ["weather", "A2"] },
-    { "source": "тёплый", "target": "warm", "tags": ["weather", "A2"] },
-    { "source": "холодный", "target": "cold", "tags": ["weather", "A2"] },
-    { "source": "гром", "target": "thunder", "tags": ["weather", "A2"] },
-    { "source": "молния", "target": "lightning", "tags": ["weather", "A2"] },
-    { "source": "больной", "target": "ill", "tags": ["health", "A2"] },
-    { "source": "головная боль", "target": "headache", "tags": ["health", "A2"] },
-    { "source": "жар", "target": "fever", "tags": ["health", "A2"] },
-    { "source": "кашель", "target": "cough", "tags": ["health", "A2"] },
-    { "source": "насморк", "target": "cold", "tags": ["health", "A2"] },
-    { "source": "боль", "target": "pain", "tags": ["health", "A2"] },
-    { "source": "врач", "target": "doctor", "tags": ["health", "A2"] },
-    { "source": "лекарство", "target": "medicine", "tags": ["health", "A2"] },
-    { "source": "больница", "target": "hospital", "tags": ["health", "A2"] },
-    { "source": "аптека", "target": "pharmacy", "tags": ["health", "A2"] },
-    { "source": "здоровый", "target": "healthy", "tags": ["health", "A2"] },
-    { "source": "заниматься спортом", "target": "to exercise", "tags": ["hobbies", "A2"] },
-    { "source": "читать", "target": "to read", "tags": ["hobbies", "A2"] },
-    { "source": "слушать музыку", "target": "to listen to music", "tags": ["hobbies", "A2"] },
-    { "source": "смотреть телевизор", "target": "to watch TV", "tags": ["hobbies", "A2"] },
-    { "source": "путешествовать", "target": "to travel", "tags": ["hobbies", "A2"] },
-    { "source": "готовить", "target": "to cook", "tags": ["hobbies", "A2"] },
-    { "source": "рисовать", "target": "to draw", "tags": ["hobbies", "A2"] },
-    { "source": "фотографировать", "target": "to photograph", "tags": ["hobbies", "A2"] },
-    { "source": "играть", "target": "to play", "tags": ["hobbies", "A2"] },
-    { "source": "танцевать", "target": "to dance", "tags": ["hobbies", "A2"] },
-    { "source": "петь", "target": "to sing", "tags": ["hobbies", "A2"] },
-    { "source": "плавать", "target": "to swim", "tags": ["hobbies", "A2"] },
-    { "source": "ездить на велосипеде", "target": "to cycle", "tags": ["hobbies", "A2"] },
-    { "source": "интересный", "target": "interesting", "tags": ["adjectives", "A2"] },
-    { "source": "скучный", "target": "boring", "tags": ["adjectives", "A2"] },
-    { "source": "весёлый", "target": "fun", "tags": ["adjectives", "A2"] },
-    { "source": "захватывающий", "target": "exciting", "tags": ["adjectives", "A2"] },
-    { "source": "трудный", "target": "difficult", "tags": ["adjectives", "A2"] },
-    { "source": "лёгкий", "target": "easy", "tags": ["adjectives", "A2"] },
-    { "source": "дружелюбный", "target": "friendly", "tags": ["adjectives", "A2"] },
-    { "source": "умный", "target": "clever", "tags": ["adjectives", "A2"] },
-    { "source": "глупый", "target": "silly", "tags": ["adjectives", "A2"] },
-    { "source": "добрый", "target": "kind", "tags": ["adjectives", "A2"] },
-    { "source": "честный", "target": "honest", "tags": ["adjectives", "A2"] },
-    { "source": "счастливый", "target": "happy", "tags": ["adjectives", "A2"] },
-    { "source": "грустный", "target": "sad", "tags": ["adjectives", "A2"] },
-    { "source": "усталый", "target": "tired", "tags": ["adjectives", "A2"] },
-    { "source": "голодный", "target": "hungry", "tags": ["adjectives", "A2"] },
-    { "source": "жаждущий", "target": "thirsty", "tags": ["adjectives", "A2"] },
-    { "source": "испуганный", "target": "scared", "tags": ["adjectives", "A2"] },
-    { "source": "удивлённый", "target": "surprised", "tags": ["adjectives", "A2"] },
-    { "source": "одежда", "target": "clothes", "tags": ["clothing", "A2"] },
-    { "source": "рубашка", "target": "shirt", "tags": ["clothing", "A2"] },
-    { "source": "брюки", "target": "trousers", "tags": ["clothing", "A2"] },
-    { "source": "платье", "target": "dress", "tags": ["clothing", "A2"] },
-    { "source": "куртка", "target": "jacket", "tags": ["clothing", "A2"] },
-    { "source": "туфли", "target": "shoes", "tags": ["clothing", "A2"] },
-    { "source": "шляпа", "target": "hat", "tags": ["clothing", "A2"] },
-    { "source": "носки", "target": "socks", "tags": ["clothing", "A2"] },
-    { "source": "свитер", "target": "sweater", "tags": ["clothing", "A2"] },
-    { "source": "пальто", "target": "coat", "tags": ["clothing", "A2"] },
-    { "source": "кафе", "target": "café", "tags": ["food-drink", "A2"] },
-    { "source": "меню", "target": "menu", "tags": ["food-drink", "A2"] },
-    { "source": "заказать", "target": "to order", "tags": ["food-drink", "A2"] },
-    { "source": "варёный", "target": "boiled", "tags": ["food-drink", "A2"] },
-    { "source": "жареный", "target": "fried", "tags": ["food-drink", "A2"] },
-    { "source": "свежий", "target": "fresh", "tags": ["food-drink", "A2"] },
-    { "source": "сладкий", "target": "sweet", "tags": ["food-drink", "A2"] },
-    { "source": "кислый", "target": "sour", "tags": ["food-drink", "A2"] },
-    { "source": "солёный", "target": "salty", "tags": ["food-drink", "A2"] },
-    { "source": "острый", "target": "spicy", "tags": ["food-drink", "A2"] },
-    { "source": "сок", "target": "juice", "tags": ["food-drink", "A2"] },
-    { "source": "основное блюдо", "target": "main course", "tags": ["food-drink", "A2"] },
-    { "source": "десерт", "target": "dessert", "tags": ["food-drink", "A2"] },
-    { "source": "раньше", "target": "earlier", "tags": ["time", "A2"] },
-    { "source": "позже", "target": "later", "tags": ["time", "A2"] },
-    { "source": "часто", "target": "often", "tags": ["time", "A2"] },
-    { "source": "иногда", "target": "sometimes", "tags": ["time", "A2"] },
-    { "source": "никогда", "target": "never", "tags": ["time", "A2"] },
-    { "source": "всегда", "target": "always", "tags": ["time", "A2"] },
-    { "source": "скоро", "target": "soon", "tags": ["time", "A2"] },
-    { "source": "ещё", "target": "still", "tags": ["time", "A2"] },
-    { "source": "уже", "target": "already", "tags": ["time", "A2"] },
-    { "source": "сосед", "target": "neighbour", "tags": ["social", "A2"] },
-    { "source": "одноклассник", "target": "classmate", "tags": ["social", "A2"] },
-    { "source": "знакомый", "target": "acquaintance", "tags": ["social", "A2"] },
-    { "source": "коллега", "target": "colleague", "tags": ["social", "A2"] },
-    { "source": "учитель", "target": "teacher", "tags": ["social", "A2"] },
-    { "source": "студент", "target": "student", "tags": ["social", "A2"] },
-    { "source": "иностранный язык", "target": "foreign language", "tags": ["social", "A2"] },
-    { "source": "слово", "target": "word", "tags": ["social", "A2"] },
-    { "source": "язык", "target": "language", "tags": ["social", "A2"] },
-    { "source": "число", "target": "number", "tags": ["social", "A2"] },
-    { "source": "письмо", "target": "letter", "tags": ["social", "A2"] },
-    { "source": "адрес", "target": "address", "tags": ["social", "A2"] },
-    { "source": "телефон", "target": "telephone", "tags": ["objects", "A2"] },
-    { "source": "компьютер", "target": "computer", "tags": ["objects", "A2"] },
-    { "source": "часы", "target": "clock", "tags": ["objects", "A2"] },
-    { "source": "картина", "target": "picture", "tags": ["objects", "A2"] },
-    { "source": "музыка", "target": "music", "tags": ["objects", "A2"] },
-    { "source": "фильм", "target": "film", "tags": ["objects", "A2"] },
-    { "source": "ехать", "target": "to travel", "tags": ["verbs", "A2"] },
-    { "source": "работать", "target": "to work", "tags": ["verbs", "A2"] },
-    { "source": "учиться", "target": "to study", "tags": ["verbs", "A2"] },
-    { "source": "спрашивать", "target": "to ask", "tags": ["verbs", "A2"] },
-    { "source": "отвечать", "target": "to answer", "tags": ["verbs", "A2"] },
-    { "source": "обещать", "target": "to promise", "tags": ["verbs", "A2"] },
-    { "source": "забывать", "target": "to forget", "tags": ["verbs", "A2"] },
-    { "source": "помнить", "target": "to remember", "tags": ["verbs", "A2"] },
-    { "source": "ждать", "target": "to wait", "tags": ["verbs", "A2"] },
-    { "source": "найти", "target": "to find", "tags": ["verbs", "A2"] },
-    { "source": "потерять", "target": "to lose", "tags": ["verbs", "A2"] },
-    { "source": "изменить", "target": "to change", "tags": ["verbs", "A2"] },
-    { "source": "вернуться", "target": "to return", "tags": ["verbs", "A2"] },
-    { "source": "начать", "target": "to start", "tags": ["verbs", "A2"] },
-    { "source": "закончить", "target": "to finish", "tags": ["verbs", "A2"] }
+    {
+      "source": "покупки",
+      "target": "shopping",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "магазин",
+      "target": "store",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "цена",
+      "target": "price",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "дешёвый",
+      "target": "cheap",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "дорогой",
+      "target": "expensive",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "чек",
+      "target": "receipt",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "скидка",
+      "target": "discount",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "размер",
+      "target": "size",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "коробка",
+      "target": "box",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "пакет",
+      "target": "bag",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "очередь",
+      "target": "queue",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "дорога",
+      "target": "road",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "угол",
+      "target": "corner",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "перекрёсток",
+      "target": "crossroads",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "мост",
+      "target": "bridge",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "вокзал",
+      "target": "station",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "остановка",
+      "target": "stop",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "рядом",
+      "target": "nearby",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "далеко",
+      "target": "far",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "за",
+      "target": "behind",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "перед",
+      "target": "in front of",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "рядом с",
+      "target": "next to",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "погода",
+      "target": "weather",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "солнечный",
+      "target": "sunny",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "облачный",
+      "target": "cloudy",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "дождливый",
+      "target": "rainy",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "ветреный",
+      "target": "windy",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "снежный",
+      "target": "snowy",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "тёплый",
+      "target": "warm",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "гром",
+      "target": "thunder",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "молния",
+      "target": "lightning",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "больной",
+      "target": "ill",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "головная боль",
+      "target": "headache",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "жар",
+      "target": "fever",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "кашель",
+      "target": "cough",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "насморк",
+      "target": "cold",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "боль",
+      "target": "pain",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "врач",
+      "target": "doctor",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "лекарство",
+      "target": "medicine",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "больница",
+      "target": "hospital",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "аптека",
+      "target": "pharmacy",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "здоровый",
+      "target": "healthy",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "заниматься спортом",
+      "target": "to exercise",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "читать",
+      "target": "to read",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "слушать музыку",
+      "target": "to listen to music",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "смотреть телевизор",
+      "target": "to watch TV",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "путешествовать",
+      "target": "to travel",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "готовить",
+      "target": "to cook",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "рисовать",
+      "target": "to draw",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "фотографировать",
+      "target": "to photograph",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "играть",
+      "target": "to play",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "танцевать",
+      "target": "to dance",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "петь",
+      "target": "to sing",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "плавать",
+      "target": "to swim",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "ездить на велосипеде",
+      "target": "to cycle",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "интересный",
+      "target": "interesting",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "скучный",
+      "target": "boring",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "весёлый",
+      "target": "fun",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "захватывающий",
+      "target": "exciting",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "трудный",
+      "target": "difficult",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "лёгкий",
+      "target": "easy",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "дружелюбный",
+      "target": "friendly",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "умный",
+      "target": "clever",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "глупый",
+      "target": "silly",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "добрый",
+      "target": "kind",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "честный",
+      "target": "honest",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "счастливый",
+      "target": "happy",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "грустный",
+      "target": "sad",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "усталый",
+      "target": "tired",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "голодный",
+      "target": "hungry",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "жаждущий",
+      "target": "thirsty",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "испуганный",
+      "target": "scared",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "удивлённый",
+      "target": "surprised",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "одежда",
+      "target": "clothes",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "рубашка",
+      "target": "shirt",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "брюки",
+      "target": "trousers",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "платье",
+      "target": "dress",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "куртка",
+      "target": "jacket",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "туфли",
+      "target": "shoes",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "шляпа",
+      "target": "hat",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "носки",
+      "target": "socks",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "свитер",
+      "target": "sweater",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "пальто",
+      "target": "coat",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "кафе",
+      "target": "café",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "меню",
+      "target": "menu",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "заказать",
+      "target": "to order",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "варёный",
+      "target": "boiled",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "жареный",
+      "target": "fried",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "свежий",
+      "target": "fresh",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "сладкий",
+      "target": "sweet",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "кислый",
+      "target": "sour",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "солёный",
+      "target": "salty",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "острый",
+      "target": "spicy",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "сок",
+      "target": "juice",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "основное блюдо",
+      "target": "main course",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "десерт",
+      "target": "dessert",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "раньше",
+      "target": "earlier",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "позже",
+      "target": "later",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "часто",
+      "target": "often",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "иногда",
+      "target": "sometimes",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "никогда",
+      "target": "never",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "всегда",
+      "target": "always",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "скоро",
+      "target": "soon",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "ещё",
+      "target": "still",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "уже",
+      "target": "already",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "сосед",
+      "target": "neighbour",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "одноклассник",
+      "target": "classmate",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "знакомый",
+      "target": "acquaintance",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "коллега",
+      "target": "colleague",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "учитель",
+      "target": "teacher",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "студент",
+      "target": "student",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "иностранный язык",
+      "target": "foreign language",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "слово",
+      "target": "word",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "язык",
+      "target": "language",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "число",
+      "target": "number",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "письмо",
+      "target": "letter",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "адрес",
+      "target": "address",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "телефон",
+      "target": "telephone",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "компьютер",
+      "target": "computer",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "часы",
+      "target": "clock",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "картина",
+      "target": "picture",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "музыка",
+      "target": "music",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "фильм",
+      "target": "film",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "ехать",
+      "target": "to travel",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "работать",
+      "target": "to work",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "учиться",
+      "target": "to study",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "спрашивать",
+      "target": "to ask",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "отвечать",
+      "target": "to answer",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "обещать",
+      "target": "to promise",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "забывать",
+      "target": "to forget",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "помнить",
+      "target": "to remember",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "ждать",
+      "target": "to wait",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "найти",
+      "target": "to find",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "потерять",
+      "target": "to lose",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "изменить",
+      "target": "to change",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "вернуться",
+      "target": "to return",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "начать",
+      "target": "to start",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "закончить",
+      "target": "to finish",
+      "tags": ["verbs", "A2"]
+    }
   ]
 }

--- a/public/starter-packs/ru-en-b1.json
+++ b/public/starter-packs/ru-en-b1.json
@@ -6,223 +6,625 @@
   "targetCode": "en",
   "level": "B1",
   "words": [
-    { "source": "книга", "target": "book", "tags": ["objects", "B1"] },
-    { "source": "вода", "target": "water", "tags": ["food-drink", "B1"] },
-    { "source": "хлеб", "target": "bread", "tags": ["food-drink", "B1"] },
-    { "source": "мясо", "target": "meat", "tags": ["food-drink", "B1"] },
-    { "source": "молоко", "target": "milk", "tags": ["food-drink", "B1"] },
-    { "source": "яйцо", "target": "egg", "tags": ["food-drink", "B1"] },
-    { "source": "сыр", "target": "cheese", "tags": ["food-drink", "B1"] },
-    { "source": "масло", "target": "butter", "tags": ["food-drink", "B1"] },
-    { "source": "фрукт", "target": "fruit", "tags": ["food-drink", "B1"] },
-    { "source": "овощ", "target": "vegetable", "tags": ["food-drink", "B1"] },
-    { "source": "яблоко", "target": "apple", "tags": ["food-drink", "B1"] },
-    { "source": "банан", "target": "banana", "tags": ["food-drink", "B1"] },
-    { "source": "апельсин", "target": "orange", "tags": ["food-drink", "B1"] },
-    { "source": "помидор", "target": "tomato", "tags": ["food-drink", "B1"] },
-    { "source": "картофель", "target": "potato", "tags": ["food-drink", "B1"] },
-    { "source": "кофе", "target": "coffee", "tags": ["food-drink", "B1"] },
-    { "source": "чай", "target": "tea", "tags": ["food-drink", "B1"] },
-    { "source": "пиво", "target": "beer", "tags": ["food-drink", "B1"] },
-    { "source": "сахар", "target": "sugar", "tags": ["food-drink", "B1"] },
-    { "source": "соль", "target": "salt", "tags": ["food-drink", "B1"] },
-    { "source": "рис", "target": "rice", "tags": ["food-drink", "B1"] },
-    { "source": "суп", "target": "soup", "tags": ["food-drink", "B1"] },
-    { "source": "салат", "target": "salad", "tags": ["food-drink", "B1"] },
-    { "source": "обед", "target": "lunch", "tags": ["food-drink", "B1"] },
-    { "source": "ужин", "target": "dinner", "tags": ["food-drink", "B1"] },
-    { "source": "завтрак", "target": "breakfast", "tags": ["food-drink", "B1"] },
-    { "source": "ресторан", "target": "restaurant", "tags": ["food-drink", "travel", "B1"] },
-    { "source": "гостиница", "target": "hotel", "tags": ["travel", "B1"] },
-    { "source": "аэропорт", "target": "airport", "tags": ["travel", "B1"] },
-    { "source": "самолёт", "target": "airplane", "tags": ["travel", "B1"] },
-    { "source": "поезд", "target": "train", "tags": ["travel", "B1"] },
-    { "source": "автобус", "target": "bus", "tags": ["travel", "B1"] },
-    { "source": "машина", "target": "car", "tags": ["travel", "B1"] },
-    { "source": "билет", "target": "ticket", "tags": ["travel", "B1"] },
-    { "source": "паспорт", "target": "passport", "tags": ["travel", "B1"] },
-    { "source": "карта", "target": "map", "tags": ["travel", "B1"] },
-    { "source": "улица", "target": "street", "tags": ["travel", "B1"] },
-    { "source": "город", "target": "city", "tags": ["travel", "B1"] },
-    { "source": "страна", "target": "country", "tags": ["travel", "B1"] },
-    { "source": "багаж", "target": "luggage", "tags": ["travel", "B1"] },
-    { "source": "работа", "target": "work", "tags": ["work", "B1"] },
-    { "source": "офис", "target": "office", "tags": ["work", "B1"] },
-    { "source": "встреча", "target": "meeting", "tags": ["work", "B1"] },
-    { "source": "коллега", "target": "colleague", "tags": ["work", "B1"] },
-    { "source": "начальник", "target": "boss", "tags": ["work", "B1"] },
-    { "source": "отпуск", "target": "holiday", "tags": ["work", "travel", "B1"] },
-    { "source": "радость", "target": "joy", "tags": ["emotions", "B1"] },
-    { "source": "грусть", "target": "sadness", "tags": ["emotions", "B1"] },
-    { "source": "страх", "target": "fear", "tags": ["emotions", "B1"] },
-    { "source": "злость", "target": "anger", "tags": ["emotions", "B1"] },
-    { "source": "удивление", "target": "surprise", "tags": ["emotions", "B1"] },
-    { "source": "любовь", "target": "love", "tags": ["emotions", "B1"] },
-    { "source": "волнение", "target": "excitement", "tags": ["emotions", "B1"] },
-    { "source": "лес", "target": "forest", "tags": ["nature", "B1"] },
-    { "source": "море", "target": "sea", "tags": ["nature", "B1"] },
-    { "source": "озеро", "target": "lake", "tags": ["nature", "B1"] },
-    { "source": "река", "target": "river", "tags": ["nature", "B1"] },
-    { "source": "гора", "target": "mountain", "tags": ["nature", "B1"] },
-    { "source": "деревня", "target": "countryside", "tags": ["nature", "B1"] },
-    { "source": "солнце", "target": "sun", "tags": ["nature", "B1"] },
-    { "source": "луна", "target": "moon", "tags": ["nature", "B1"] },
-    { "source": "звезда", "target": "star", "tags": ["nature", "B1"] },
-    { "source": "дождь", "target": "rain", "tags": ["nature", "B1"] },
-    { "source": "снег", "target": "snow", "tags": ["nature", "B1"] },
-    { "source": "ветер", "target": "wind", "tags": ["nature", "B1"] },
-    { "source": "облака", "target": "clouds", "tags": ["nature", "B1"] },
-    { "source": "зима", "target": "winter", "tags": ["nature", "B1"] },
-    { "source": "лето", "target": "summer", "tags": ["nature", "B1"] },
-    { "source": "весна", "target": "spring", "tags": ["nature", "B1"] },
-    { "source": "осень", "target": "autumn", "tags": ["nature", "B1"] },
-    { "source": "дерево", "target": "tree", "tags": ["nature", "B1"] },
-    { "source": "цветок", "target": "flower", "tags": ["nature", "B1"] },
-    { "source": "трава", "target": "grass", "tags": ["nature", "B1"] },
-    { "source": "комната", "target": "room", "tags": ["home", "B1"] },
-    { "source": "кухня", "target": "kitchen", "tags": ["home", "B1"] },
-    { "source": "спальня", "target": "bedroom", "tags": ["home", "B1"] },
-    { "source": "ванная", "target": "bathroom", "tags": ["home", "B1"] },
-    { "source": "гостиная", "target": "living room", "tags": ["home", "B1"] },
-    { "source": "дверь", "target": "door", "tags": ["home", "B1"] },
-    { "source": "окно", "target": "window", "tags": ["home", "B1"] },
-    { "source": "стол", "target": "table", "tags": ["home", "B1"] },
-    { "source": "стул", "target": "chair", "tags": ["home", "B1"] },
-    { "source": "диван", "target": "sofa", "tags": ["home", "B1"] },
-    { "source": "кровать", "target": "bed", "tags": ["home", "B1"] },
-    { "source": "подушка", "target": "pillow", "tags": ["home", "B1"] },
-    { "source": "одеяло", "target": "blanket", "tags": ["home", "B1"] },
-    { "source": "зеркало", "target": "mirror", "tags": ["home", "B1"] },
-    { "source": "лампа", "target": "lamp", "tags": ["home", "B1"] },
-    { "source": "пол", "target": "floor", "tags": ["home", "B1"] },
-    { "source": "потолок", "target": "ceiling", "tags": ["home", "B1"] },
-    { "source": "стена", "target": "wall", "tags": ["home", "B1"] },
-    { "source": "крыша", "target": "roof", "tags": ["home", "B1"] },
-    { "source": "сад", "target": "garden", "tags": ["home", "B1"] },
-    { "source": "голова", "target": "head", "tags": ["body", "B1"] },
-    { "source": "лицо", "target": "face", "tags": ["body", "B1"] },
-    { "source": "глаза", "target": "eyes", "tags": ["body", "B1"] },
-    { "source": "уши", "target": "ears", "tags": ["body", "B1"] },
-    { "source": "нос", "target": "nose", "tags": ["body", "B1"] },
-    { "source": "рот", "target": "mouth", "tags": ["body", "B1"] },
-    { "source": "зубы", "target": "teeth", "tags": ["body", "B1"] },
-    { "source": "шея", "target": "neck", "tags": ["body", "B1"] },
-    { "source": "плечи", "target": "shoulders", "tags": ["body", "B1"] },
-    { "source": "рука", "target": "hand", "tags": ["body", "B1"] },
-    { "source": "пальцы", "target": "fingers", "tags": ["body", "B1"] },
-    { "source": "нога", "target": "leg", "tags": ["body", "B1"] },
-    { "source": "колено", "target": "knee", "tags": ["body", "B1"] },
-    { "source": "стопа", "target": "foot", "tags": ["body", "B1"] },
-    { "source": "сердце", "target": "heart", "tags": ["body", "B1"] },
-    { "source": "день", "target": "day", "tags": ["time", "B1"] },
-    { "source": "ночь", "target": "night", "tags": ["time", "B1"] },
-    { "source": "утро", "target": "morning", "tags": ["time", "B1"] },
-    { "source": "вечер", "target": "evening", "tags": ["time", "B1"] },
-    { "source": "неделя", "target": "week", "tags": ["time", "B1"] },
-    { "source": "месяц", "target": "month", "tags": ["time", "B1"] },
-    { "source": "год", "target": "year", "tags": ["time", "B1"] },
-    { "source": "час", "target": "hour", "tags": ["time", "B1"] },
-    { "source": "минута", "target": "minute", "tags": ["time", "B1"] },
-    { "source": "секунда", "target": "second", "tags": ["time", "B1"] },
-    { "source": "сейчас", "target": "now", "tags": ["time", "B1"] },
-    { "source": "вчера", "target": "yesterday", "tags": ["time", "B1"] },
-    { "source": "завтра", "target": "tomorrow", "tags": ["time", "B1"] },
-    { "source": "говорить", "target": "to speak", "tags": ["verbs", "B1"] },
-    { "source": "слушать", "target": "to listen", "tags": ["verbs", "B1"] },
-    { "source": "читать", "target": "to read", "tags": ["verbs", "B1"] },
-    { "source": "писать", "target": "to write", "tags": ["verbs", "B1"] },
-    { "source": "есть", "target": "to eat", "tags": ["verbs", "B1"] },
-    { "source": "пить", "target": "to drink", "tags": ["verbs", "B1"] },
-    { "source": "спать", "target": "to sleep", "tags": ["verbs", "B1"] },
-    { "source": "идти", "target": "to walk", "tags": ["verbs", "B1"] },
-    { "source": "бежать", "target": "to run", "tags": ["verbs", "B1"] },
-    { "source": "работать", "target": "to work", "tags": ["verbs", "B1"] },
-    { "source": "играть", "target": "to play", "tags": ["verbs", "B1"] },
-    { "source": "учиться", "target": "to learn", "tags": ["verbs", "B1"] },
-    { "source": "думать", "target": "to think", "tags": ["verbs", "B1"] },
-    { "source": "знать", "target": "to know", "tags": ["verbs", "B1"] },
-    { "source": "понимать", "target": "to understand", "tags": ["verbs", "B1"] },
-    { "source": "отвечать", "target": "to answer", "tags": ["verbs", "B1"] },
-    { "source": "спрашивать", "target": "to ask", "tags": ["verbs", "B1"] },
-    { "source": "помогать", "target": "to help", "tags": ["verbs", "B1"] },
-    { "source": "покупать", "target": "to buy", "tags": ["verbs", "B1"] },
-    { "source": "приходить", "target": "to come", "tags": ["verbs", "B1"] },
-    { "source": "уходить", "target": "to go", "tags": ["verbs", "B1"] },
-    { "source": "возвращаться", "target": "to return", "tags": ["verbs", "B1"] },
-    { "source": "забывать", "target": "to forget", "tags": ["verbs", "B1"] },
-    { "source": "помнить", "target": "to remember", "tags": ["verbs", "B1"] },
-    { "source": "открывать", "target": "to open", "tags": ["verbs", "B1"] },
-    { "source": "закрывать", "target": "to close", "tags": ["verbs", "B1"] },
-    { "source": "хороший", "target": "good", "tags": ["adjectives", "B1"] },
-    { "source": "плохой", "target": "bad", "tags": ["adjectives", "B1"] },
-    { "source": "большой", "target": "big", "tags": ["adjectives", "B1"] },
-    { "source": "маленький", "target": "small", "tags": ["adjectives", "B1"] },
-    { "source": "новый", "target": "new", "tags": ["adjectives", "B1"] },
-    { "source": "старый", "target": "old", "tags": ["adjectives", "B1"] },
-    { "source": "быстрый", "target": "fast", "tags": ["adjectives", "B1"] },
-    { "source": "медленный", "target": "slow", "tags": ["adjectives", "B1"] },
-    { "source": "горячий", "target": "hot", "tags": ["adjectives", "B1"] },
-    { "source": "холодный", "target": "cold", "tags": ["adjectives", "B1"] },
-    { "source": "красивый", "target": "beautiful", "tags": ["adjectives", "B1"] },
-    { "source": "некрасивый", "target": "ugly", "tags": ["adjectives", "B1"] },
-    { "source": "сильный", "target": "strong", "tags": ["adjectives", "B1"] },
-    { "source": "слабый", "target": "weak", "tags": ["adjectives", "B1"] },
-    { "source": "важный", "target": "important", "tags": ["adjectives", "B1"] },
-    { "source": "интересный", "target": "interesting", "tags": ["adjectives", "B1"] },
-    { "source": "трудный", "target": "difficult", "tags": ["adjectives", "B1"] },
-    { "source": "лёгкий", "target": "easy", "tags": ["adjectives", "B1"] },
-    { "source": "безопасный", "target": "safe", "tags": ["adjectives", "B1"] },
-    { "source": "чистый", "target": "clean", "tags": ["adjectives", "B1"] },
-    { "source": "грязный", "target": "dirty", "tags": ["adjectives", "B1"] },
-    { "source": "полный", "target": "full", "tags": ["adjectives", "B1"] },
-    { "source": "пустой", "target": "empty", "tags": ["adjectives", "B1"] },
-    { "source": "свободный", "target": "free", "tags": ["adjectives", "B1"] },
-    { "source": "телефон", "target": "phone", "tags": ["objects", "B1"] },
-    { "source": "компьютер", "target": "computer", "tags": ["objects", "B1"] },
-    { "source": "экран", "target": "screen", "tags": ["objects", "B1"] },
-    { "source": "клавиатура", "target": "keyboard", "tags": ["objects", "B1"] },
-    { "source": "мышь", "target": "mouse", "tags": ["objects", "B1"] },
-    { "source": "интернет", "target": "internet", "tags": ["objects", "B1"] },
-    { "source": "сумка", "target": "bag", "tags": ["objects", "B1"] },
-    { "source": "кошелёк", "target": "wallet", "tags": ["objects", "B1"] },
-    { "source": "часы", "target": "watch", "tags": ["objects", "B1"] },
-    { "source": "очки", "target": "glasses", "tags": ["objects", "B1"] },
-    { "source": "ключ", "target": "key", "tags": ["objects", "B1"] },
-    { "source": "ручка", "target": "pen", "tags": ["objects", "B1"] },
-    { "source": "бумага", "target": "paper", "tags": ["objects", "B1"] },
-    { "source": "деньги", "target": "money", "tags": ["objects", "B1"] },
-    { "source": "цена", "target": "price", "tags": ["objects", "B1"] },
-    { "source": "счёт", "target": "bill", "tags": ["objects", "B1"] },
-    { "source": "семья", "target": "family", "tags": ["social", "B1"] },
-    { "source": "друг", "target": "friend", "tags": ["social", "B1"] },
-    { "source": "сосед", "target": "neighbour", "tags": ["social", "B1"] },
-    { "source": "ребёнок", "target": "child", "tags": ["social", "B1"] },
-    { "source": "родители", "target": "parents", "tags": ["social", "B1"] },
-    { "source": "сестра", "target": "sister", "tags": ["social", "B1"] },
-    { "source": "брат", "target": "brother", "tags": ["social", "B1"] },
-    { "source": "муж", "target": "husband", "tags": ["social", "B1"] },
-    { "source": "жена", "target": "wife", "tags": ["social", "B1"] },
-    { "source": "учитель", "target": "teacher", "tags": ["social", "work", "B1"] },
-    { "source": "студент", "target": "student", "tags": ["social", "B1"] },
-    { "source": "врач", "target": "doctor", "tags": ["social", "work", "B1"] },
-    { "source": "больница", "target": "hospital", "tags": ["social", "B1"] },
-    { "source": "аптека", "target": "pharmacy", "tags": ["social", "B1"] },
-    { "source": "рынок", "target": "market", "tags": ["social", "B1"] },
-    { "source": "магазин", "target": "shop", "tags": ["social", "B1"] },
-    { "source": "банк", "target": "bank", "tags": ["social", "B1"] },
-    { "source": "школа", "target": "school", "tags": ["social", "B1"] },
-    { "source": "университет", "target": "university", "tags": ["social", "B1"] },
-    { "source": "музей", "target": "museum", "tags": ["social", "travel", "B1"] },
-    { "source": "библиотека", "target": "library", "tags": ["social", "B1"] },
-    { "source": "парк", "target": "park", "tags": ["social", "nature", "B1"] },
-    { "source": "кино", "target": "cinema", "tags": ["social", "B1"] },
-    { "source": "праздник", "target": "celebration", "tags": ["social", "B1"] },
-    { "source": "спорт", "target": "sport", "tags": ["social", "B1"] },
-    { "source": "здоровье", "target": "health", "tags": ["body", "B1"] },
-    { "source": "болезнь", "target": "illness", "tags": ["body", "B1"] },
-    { "source": "боль", "target": "pain", "tags": ["body", "B1"] },
-    { "source": "лекарство", "target": "medicine", "tags": ["body", "B1"] },
-    { "source": "дом", "target": "house", "tags": ["home", "B1"] },
-    { "source": "квартира", "target": "apartment", "tags": ["home", "B1"] }
+    {
+      "source": "масло",
+      "target": "butter",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "фрукт",
+      "target": "fruit",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "овощ",
+      "target": "vegetable",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "апельсин",
+      "target": "orange",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "помидор",
+      "target": "tomato",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "картофель",
+      "target": "potato",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "пиво",
+      "target": "beer",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "соль",
+      "target": "salt",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "суп",
+      "target": "soup",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "салат",
+      "target": "salad",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "обед",
+      "target": "lunch",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "ужин",
+      "target": "dinner",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "завтрак",
+      "target": "breakfast",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "ресторан",
+      "target": "restaurant",
+      "tags": ["food-drink", "travel", "B1"]
+    },
+    {
+      "source": "гостиница",
+      "target": "hotel",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "аэропорт",
+      "target": "airport",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "самолёт",
+      "target": "airplane",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "поезд",
+      "target": "train",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "билет",
+      "target": "ticket",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "паспорт",
+      "target": "passport",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "карта",
+      "target": "map",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "багаж",
+      "target": "luggage",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "работа",
+      "target": "work",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "офис",
+      "target": "office",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "встреча",
+      "target": "meeting",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "начальник",
+      "target": "boss",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "отпуск",
+      "target": "holiday",
+      "tags": ["work", "travel", "B1"]
+    },
+    {
+      "source": "радость",
+      "target": "joy",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "грусть",
+      "target": "sadness",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "страх",
+      "target": "fear",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "злость",
+      "target": "anger",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "удивление",
+      "target": "surprise",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "любовь",
+      "target": "love",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "волнение",
+      "target": "excitement",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "лес",
+      "target": "forest",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "море",
+      "target": "sea",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "озеро",
+      "target": "lake",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "река",
+      "target": "river",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "гора",
+      "target": "mountain",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "деревня",
+      "target": "countryside",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "луна",
+      "target": "moon",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "звезда",
+      "target": "star",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "ветер",
+      "target": "wind",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "облака",
+      "target": "clouds",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "зима",
+      "target": "winter",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "лето",
+      "target": "summer",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "весна",
+      "target": "spring",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "осень",
+      "target": "autumn",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "трава",
+      "target": "grass",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "кухня",
+      "target": "kitchen",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "спальня",
+      "target": "bedroom",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "ванная",
+      "target": "bathroom",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "гостиная",
+      "target": "living room",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "диван",
+      "target": "sofa",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "подушка",
+      "target": "pillow",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "одеяло",
+      "target": "blanket",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "зеркало",
+      "target": "mirror",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "лампа",
+      "target": "lamp",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "пол",
+      "target": "floor",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "потолок",
+      "target": "ceiling",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "стена",
+      "target": "wall",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "крыша",
+      "target": "roof",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "сад",
+      "target": "garden",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "лицо",
+      "target": "face",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "зубы",
+      "target": "teeth",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "шея",
+      "target": "neck",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "плечи",
+      "target": "shoulders",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "пальцы",
+      "target": "fingers",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "колено",
+      "target": "knee",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "стопа",
+      "target": "foot",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "час",
+      "target": "hour",
+      "tags": ["time", "B1"]
+    },
+    {
+      "source": "минута",
+      "target": "minute",
+      "tags": ["time", "B1"]
+    },
+    {
+      "source": "секунда",
+      "target": "second",
+      "tags": ["time", "B1"]
+    },
+    {
+      "source": "говорить",
+      "target": "to speak",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "слушать",
+      "target": "to listen",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "писать",
+      "target": "to write",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "идти",
+      "target": "to walk",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "бежать",
+      "target": "to run",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "учиться",
+      "target": "to learn",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "думать",
+      "target": "to think",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "знать",
+      "target": "to know",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "понимать",
+      "target": "to understand",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "помогать",
+      "target": "to help",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "покупать",
+      "target": "to buy",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "приходить",
+      "target": "to come",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "уходить",
+      "target": "to go",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "возвращаться",
+      "target": "to return",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "открывать",
+      "target": "to open",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "закрывать",
+      "target": "to close",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "быстрый",
+      "target": "fast",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "медленный",
+      "target": "slow",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "красивый",
+      "target": "beautiful",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "некрасивый",
+      "target": "ugly",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "сильный",
+      "target": "strong",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "слабый",
+      "target": "weak",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "важный",
+      "target": "important",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "безопасный",
+      "target": "safe",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "чистый",
+      "target": "clean",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "грязный",
+      "target": "dirty",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "полный",
+      "target": "full",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "пустой",
+      "target": "empty",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "свободный",
+      "target": "free",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "экран",
+      "target": "screen",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "клавиатура",
+      "target": "keyboard",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "мышь",
+      "target": "mouse",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "интернет",
+      "target": "internet",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "кошелёк",
+      "target": "wallet",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "часы",
+      "target": "watch",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "очки",
+      "target": "glasses",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "бумага",
+      "target": "paper",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "счёт",
+      "target": "bill",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "родители",
+      "target": "parents",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "рынок",
+      "target": "market",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "банк",
+      "target": "bank",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "университет",
+      "target": "university",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "музей",
+      "target": "museum",
+      "tags": ["social", "travel", "B1"]
+    },
+    {
+      "source": "библиотека",
+      "target": "library",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "парк",
+      "target": "park",
+      "tags": ["social", "nature", "B1"]
+    },
+    {
+      "source": "кино",
+      "target": "cinema",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "праздник",
+      "target": "celebration",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "спорт",
+      "target": "sport",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "здоровье",
+      "target": "health",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "болезнь",
+      "target": "illness",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "квартира",
+      "target": "apartment",
+      "tags": ["home", "B1"]
+    }
   ]
 }

--- a/public/starter-packs/ru-en-b2.json
+++ b/public/starter-packs/ru-en-b2.json
@@ -6,132 +6,610 @@
   "targetCode": "en",
   "level": "B2",
   "words": [
-    { "source": "путешествие", "target": "journey", "tags": ["travel", "B2"] },
-    { "source": "вино", "target": "wine", "tags": ["food-drink", "B2"] },
-    { "source": "граница", "target": "border", "tags": ["travel", "B2"] },
-    { "source": "валюта", "target": "currency", "tags": ["travel", "B2"] },
-    { "source": "бронирование", "target": "reservation", "tags": ["travel", "B2"] },
-    { "source": "зарплата", "target": "salary", "tags": ["work", "B2"] },
-    { "source": "проект", "target": "project", "tags": ["work", "B2"] },
-    { "source": "дедлайн", "target": "deadline", "tags": ["work", "B2"] },
-    { "source": "отчёт", "target": "report", "tags": ["work", "B2"] },
-    { "source": "презентация", "target": "presentation", "tags": ["work", "B2"] },
-    { "source": "компания", "target": "company", "tags": ["work", "B2"] },
-    { "source": "клиент", "target": "client", "tags": ["work", "B2"] },
-    { "source": "собеседование", "target": "job interview", "tags": ["work", "B2"] },
-    { "source": "карьера", "target": "career", "tags": ["work", "B2"] },
-    { "source": "ненависть", "target": "hatred", "tags": ["emotions", "B2"] },
-    { "source": "надежда", "target": "hope", "tags": ["emotions", "B2"] },
-    { "source": "разочарование", "target": "disappointment", "tags": ["emotions", "B2"] },
-    { "source": "облегчение", "target": "relief", "tags": ["emotions", "B2"] },
-    { "source": "стыд", "target": "shame", "tags": ["emotions", "B2"] },
-    { "source": "одиночество", "target": "loneliness", "tags": ["emotions", "B2"] },
-    { "source": "благодарность", "target": "gratitude", "tags": ["emotions", "B2"] },
-    { "source": "подвал", "target": "basement", "tags": ["home", "B2"] },
-    { "source": "лёгкие", "target": "lungs", "tags": ["body", "B2"] },
-    { "source": "давление", "target": "blood pressure", "tags": ["body", "B2"] },
-    { "source": "температура", "target": "temperature", "tags": ["body", "B2"] },
-    { "source": "прошлое", "target": "past", "tags": ["time", "B2"] },
-    { "source": "будущее", "target": "future", "tags": ["time", "B2"] },
-    { "source": "расписание", "target": "schedule", "tags": ["time", "work", "B2"] },
-    { "source": "продавать", "target": "to sell", "tags": ["verbs", "B2"] },
-    { "source": "менять", "target": "to change", "tags": ["verbs", "B2"] },
-    { "source": "решать", "target": "to decide", "tags": ["verbs", "B2"] },
-    { "source": "проверять", "target": "to check", "tags": ["verbs", "B2"] },
-    { "source": "планировать", "target": "to plan", "tags": ["verbs", "B2"] },
-    { "source": "организовывать", "target": "to organise", "tags": ["verbs", "B2"] },
-    { "source": "улучшать", "target": "to improve", "tags": ["verbs", "B2"] },
-    { "source": "достигать", "target": "to achieve", "tags": ["verbs", "B2"] },
-    { "source": "выбирать", "target": "to choose", "tags": ["verbs", "B2"] },
-    { "source": "обсуждать", "target": "to discuss", "tags": ["verbs", "B2"] },
-    { "source": "опасный", "target": "dangerous", "tags": ["adjectives", "B2"] },
-    { "source": "занятой", "target": "busy", "tags": ["adjectives", "B2"] },
-    { "source": "успешный", "target": "successful", "tags": ["adjectives", "B2"] },
-    { "source": "творческий", "target": "creative", "tags": ["adjectives", "B2"] },
-    { "source": "надёжный", "target": "reliable", "tags": ["adjectives", "B2"] },
-    { "source": "гибкий", "target": "flexible", "tags": ["adjectives", "B2"] },
-    { "source": "эффективный", "target": "effective", "tags": ["adjectives", "B2"] },
-    { "source": "программа", "target": "software", "tags": ["objects", "B2"] },
-    { "source": "приложение", "target": "application", "tags": ["objects", "B2"] },
-    { "source": "батарея", "target": "battery", "tags": ["objects", "B2"] },
-    { "source": "зарядное устройство", "target": "charger", "tags": ["objects", "B2"] },
-    { "source": "незнакомец", "target": "stranger", "tags": ["social", "B2"] },
-    { "source": "театр", "target": "theatre", "tags": ["social", "B2"] },
-    { "source": "лечение", "target": "treatment", "tags": ["body", "B2"] },
-    { "source": "операция", "target": "operation", "tags": ["body", "B2"] },
-    { "source": "аллергия", "target": "allergy", "tags": ["body", "B2"] },
-    { "source": "симптомы", "target": "symptoms", "tags": ["body", "B2"] },
-    { "source": "консультация", "target": "consultation", "tags": ["work", "B2"] },
-    { "source": "договор", "target": "contract", "tags": ["work", "B2"] },
-    { "source": "инвестиция", "target": "investment", "tags": ["work", "B2"] },
-    { "source": "бюджет", "target": "budget", "tags": ["work", "B2"] },
-    { "source": "налоги", "target": "taxes", "tags": ["work", "B2"] },
-    { "source": "страховка", "target": "insurance", "tags": ["work", "B2"] },
-    { "source": "адрес", "target": "address", "tags": ["social", "B2"] },
-    { "source": "почта", "target": "post office", "tags": ["social", "B2"] },
-    { "source": "письмо", "target": "letter", "tags": ["objects", "B2"] },
-    { "source": "посылка", "target": "package", "tags": ["objects", "B2"] },
-    { "source": "песня", "target": "song", "tags": ["social", "B2"] },
-    { "source": "музыка", "target": "music", "tags": ["social", "B2"] },
-    { "source": "танец", "target": "dance", "tags": ["social", "B2"] },
-    { "source": "фотография", "target": "photograph", "tags": ["objects", "B2"] },
-    { "source": "цвет", "target": "colour", "tags": ["objects", "B2"] },
-    { "source": "размер", "target": "size", "tags": ["objects", "B2"] },
-    { "source": "форма", "target": "shape", "tags": ["objects", "B2"] },
-    { "source": "звук", "target": "sound", "tags": ["objects", "B2"] },
-    { "source": "запах", "target": "smell", "tags": ["objects", "B2"] },
-    { "source": "вкус", "target": "taste", "tags": ["objects", "B2"] },
-    { "source": "язык", "target": "language", "tags": ["social", "B2"] },
-    { "source": "слово", "target": "word", "tags": ["social", "B2"] },
-    { "source": "предложение", "target": "sentence", "tags": ["social", "B2"] },
-    { "source": "вопрос", "target": "question", "tags": ["social", "B2"] },
-    { "source": "ответ", "target": "answer", "tags": ["social", "B2"] },
-    { "source": "проблема", "target": "problem", "tags": ["social", "B2"] },
-    { "source": "решение", "target": "solution", "tags": ["social", "B2"] },
-    { "source": "идея", "target": "idea", "tags": ["social", "B2"] },
-    { "source": "мнение", "target": "opinion", "tags": ["social", "B2"] },
-    { "source": "информация", "target": "information", "tags": ["social", "B2"] },
-    { "source": "новости", "target": "news", "tags": ["social", "B2"] },
-    { "source": "событие", "target": "event", "tags": ["social", "B2"] },
-    { "source": "возможность", "target": "opportunity", "tags": ["social", "B2"] },
-    { "source": "опыт", "target": "experience", "tags": ["social", "B2"] },
-    { "source": "знания", "target": "knowledge", "tags": ["social", "B2"] },
-    { "source": "образование", "target": "education", "tags": ["social", "B2"] },
-    { "source": "общество", "target": "society", "tags": ["social", "B2"] },
-    { "source": "культура", "target": "culture", "tags": ["social", "B2"] },
-    { "source": "окружающая среда", "target": "environment", "tags": ["nature", "B2"] },
-    { "source": "климат", "target": "climate", "tags": ["nature", "B2"] },
-    { "source": "энергия", "target": "energy", "tags": ["nature", "B2"] },
-    { "source": "ресурсы", "target": "resources", "tags": ["nature", "B2"] },
-    { "source": "загрязнение", "target": "pollution", "tags": ["nature", "B2"] },
-    { "source": "развитие", "target": "development", "tags": ["work", "B2"] },
-    { "source": "стратегия", "target": "strategy", "tags": ["work", "B2"] },
-    { "source": "цель", "target": "goal", "tags": ["work", "B2"] },
-    { "source": "результат", "target": "result", "tags": ["work", "B2"] },
-    { "source": "процесс", "target": "process", "tags": ["work", "B2"] },
-    { "source": "система", "target": "system", "tags": ["work", "B2"] },
-    { "source": "технология", "target": "technology", "tags": ["objects", "B2"] },
-    { "source": "устройство", "target": "device", "tags": ["objects", "B2"] },
-    { "source": "подключение", "target": "connection", "tags": ["objects", "B2"] },
-    { "source": "безопасность", "target": "security", "tags": ["objects", "B2"] },
-    { "source": "конфиденциальность", "target": "privacy", "tags": ["social", "B2"] },
-    { "source": "права", "target": "rights", "tags": ["social", "B2"] },
-    { "source": "обязанность", "target": "responsibility", "tags": ["social", "B2"] },
-    { "source": "решение", "target": "decision", "tags": ["social", "B2"] },
-    { "source": "соглашение", "target": "agreement", "tags": ["social", "B2"] },
-    { "source": "конфликт", "target": "conflict", "tags": ["social", "B2"] },
-    { "source": "сотрудничество", "target": "cooperation", "tags": ["social", "B2"] },
-    { "source": "критика", "target": "criticism", "tags": ["social", "B2"] },
-    { "source": "оценка", "target": "assessment", "tags": ["social", "B2"] },
-    { "source": "перспектива", "target": "perspective", "tags": ["social", "B2"] },
-    { "source": "вызов", "target": "challenge", "tags": ["social", "B2"] },
-    { "source": "риск", "target": "risk", "tags": ["work", "B2"] },
-    { "source": "качество", "target": "quality", "tags": ["work", "B2"] },
-    { "source": "стандарт", "target": "standard", "tags": ["work", "B2"] },
-    { "source": "достижение", "target": "achievement", "tags": ["work", "B2"] },
-    { "source": "влияние", "target": "impact", "tags": ["social", "B2"] },
-    { "source": "баланс", "target": "balance", "tags": ["social", "B2"] },
-    { "source": "приоритет", "target": "priority", "tags": ["work", "B2"] },
-    { "source": "инновация", "target": "innovation", "tags": ["work", "B2"] }
+    {
+      "source": "путешествие",
+      "target": "journey",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "вино",
+      "target": "wine",
+      "tags": ["food-drink", "B2"]
+    },
+    {
+      "source": "граница",
+      "target": "border",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "валюта",
+      "target": "currency",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "бронирование",
+      "target": "reservation",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "зарплата",
+      "target": "salary",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "проект",
+      "target": "project",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "дедлайн",
+      "target": "deadline",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "отчёт",
+      "target": "report",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "презентация",
+      "target": "presentation",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "компания",
+      "target": "company",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "клиент",
+      "target": "client",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "собеседование",
+      "target": "job interview",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "карьера",
+      "target": "career",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "ненависть",
+      "target": "hatred",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "надежда",
+      "target": "hope",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "разочарование",
+      "target": "disappointment",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "облегчение",
+      "target": "relief",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "стыд",
+      "target": "shame",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "одиночество",
+      "target": "loneliness",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "благодарность",
+      "target": "gratitude",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "подвал",
+      "target": "basement",
+      "tags": ["home", "B2"]
+    },
+    {
+      "source": "лёгкие",
+      "target": "lungs",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "давление",
+      "target": "blood pressure",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "температура",
+      "target": "temperature",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "прошлое",
+      "target": "past",
+      "tags": ["time", "B2"]
+    },
+    {
+      "source": "будущее",
+      "target": "future",
+      "tags": ["time", "B2"]
+    },
+    {
+      "source": "расписание",
+      "target": "schedule",
+      "tags": ["time", "work", "B2"]
+    },
+    {
+      "source": "продавать",
+      "target": "to sell",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "менять",
+      "target": "to change",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "решать",
+      "target": "to decide",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "проверять",
+      "target": "to check",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "планировать",
+      "target": "to plan",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "организовывать",
+      "target": "to organise",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "улучшать",
+      "target": "to improve",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "достигать",
+      "target": "to achieve",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "выбирать",
+      "target": "to choose",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "обсуждать",
+      "target": "to discuss",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "опасный",
+      "target": "dangerous",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "занятой",
+      "target": "busy",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "успешный",
+      "target": "successful",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "творческий",
+      "target": "creative",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "надёжный",
+      "target": "reliable",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "гибкий",
+      "target": "flexible",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "эффективный",
+      "target": "effective",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "программа",
+      "target": "software",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "приложение",
+      "target": "application",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "батарея",
+      "target": "battery",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "зарядное устройство",
+      "target": "charger",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "незнакомец",
+      "target": "stranger",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "театр",
+      "target": "theatre",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "лечение",
+      "target": "treatment",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "операция",
+      "target": "operation",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "аллергия",
+      "target": "allergy",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "симптомы",
+      "target": "symptoms",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "консультация",
+      "target": "consultation",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "договор",
+      "target": "contract",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "инвестиция",
+      "target": "investment",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "бюджет",
+      "target": "budget",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "налоги",
+      "target": "taxes",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "страховка",
+      "target": "insurance",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "почта",
+      "target": "post office",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "посылка",
+      "target": "package",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "песня",
+      "target": "song",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "танец",
+      "target": "dance",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "фотография",
+      "target": "photograph",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "цвет",
+      "target": "colour",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "форма",
+      "target": "shape",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "звук",
+      "target": "sound",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "запах",
+      "target": "smell",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "вкус",
+      "target": "taste",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "предложение",
+      "target": "sentence",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "вопрос",
+      "target": "question",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "ответ",
+      "target": "answer",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "проблема",
+      "target": "problem",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "решение",
+      "target": "solution",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "идея",
+      "target": "idea",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "мнение",
+      "target": "opinion",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "информация",
+      "target": "information",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "новости",
+      "target": "news",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "событие",
+      "target": "event",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "возможность",
+      "target": "opportunity",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "опыт",
+      "target": "experience",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "знания",
+      "target": "knowledge",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "образование",
+      "target": "education",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "общество",
+      "target": "society",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "культура",
+      "target": "culture",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "окружающая среда",
+      "target": "environment",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "климат",
+      "target": "climate",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "энергия",
+      "target": "energy",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "ресурсы",
+      "target": "resources",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "загрязнение",
+      "target": "pollution",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "развитие",
+      "target": "development",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "стратегия",
+      "target": "strategy",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "цель",
+      "target": "goal",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "результат",
+      "target": "result",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "процесс",
+      "target": "process",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "система",
+      "target": "system",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "технология",
+      "target": "technology",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "устройство",
+      "target": "device",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "подключение",
+      "target": "connection",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "безопасность",
+      "target": "security",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "конфиденциальность",
+      "target": "privacy",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "права",
+      "target": "rights",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "обязанность",
+      "target": "responsibility",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "решение",
+      "target": "decision",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "соглашение",
+      "target": "agreement",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "конфликт",
+      "target": "conflict",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "сотрудничество",
+      "target": "cooperation",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "критика",
+      "target": "criticism",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "оценка",
+      "target": "assessment",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "перспектива",
+      "target": "perspective",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "вызов",
+      "target": "challenge",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "риск",
+      "target": "risk",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "качество",
+      "target": "quality",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "стандарт",
+      "target": "standard",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "достижение",
+      "target": "achievement",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "влияние",
+      "target": "impact",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "баланс",
+      "target": "balance",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "приоритет",
+      "target": "priority",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "инновация",
+      "target": "innovation",
+      "tags": ["work", "B2"]
+    }
   ]
 }

--- a/public/starter-packs/ru-en-c1.json
+++ b/public/starter-packs/ru-en-c1.json
@@ -6,150 +6,710 @@
   "targetCode": "en",
   "level": "C1",
   "words": [
-    { "source": "абстрактный", "target": "abstract", "tags": ["academic", "C1"] },
-    { "source": "анализ", "target": "analysis", "tags": ["academic", "C1"] },
-    { "source": "синтез", "target": "synthesis", "tags": ["academic", "C1"] },
-    { "source": "гипотеза", "target": "hypothesis", "tags": ["academic", "C1"] },
-    { "source": "доказательство", "target": "evidence", "tags": ["academic", "C1"] },
-    { "source": "методология", "target": "methodology", "tags": ["academic", "C1"] },
-    { "source": "исследование", "target": "research", "tags": ["academic", "C1"] },
-    { "source": "теория", "target": "theory", "tags": ["academic", "C1"] },
-    { "source": "концепция", "target": "concept", "tags": ["academic", "C1"] },
-    { "source": "парадигма", "target": "paradigm", "tags": ["academic", "C1"] },
-    { "source": "дискурс", "target": "discourse", "tags": ["academic", "C1"] },
-    { "source": "аргументация", "target": "argumentation", "tags": ["academic", "C1"] },
-    { "source": "обоснование", "target": "justification", "tags": ["academic", "C1"] },
-    { "source": "вывод", "target": "conclusion", "tags": ["academic", "C1"] },
-    { "source": "утверждение", "target": "assertion", "tags": ["academic", "C1"] },
-    { "source": "опровержение", "target": "refutation", "tags": ["academic", "C1"] },
-    { "source": "критерий", "target": "criterion", "tags": ["academic", "C1"] },
-    { "source": "наблюдение", "target": "observation", "tags": ["academic", "C1"] },
-    { "source": "интерпретация", "target": "interpretation", "tags": ["academic", "C1"] },
-    { "source": "контекст", "target": "context", "tags": ["academic", "C1"] },
-    { "source": "правовая норма", "target": "legal provision", "tags": ["law", "C1"] },
-    { "source": "юрисдикция", "target": "jurisdiction", "tags": ["law", "C1"] },
-    { "source": "суд", "target": "court", "tags": ["law", "C1"] },
-    { "source": "приговор", "target": "verdict", "tags": ["law", "C1"] },
-    { "source": "обвинение", "target": "prosecution", "tags": ["law", "C1"] },
-    { "source": "защита", "target": "defence", "tags": ["law", "C1"] },
-    { "source": "доказать", "target": "to prove", "tags": ["law", "C1"] },
-    { "source": "правоохранительные органы", "target": "law enforcement", "tags": ["law", "C1"] },
-    { "source": "регулировать", "target": "to regulate", "tags": ["law", "C1"] },
+    {
+      "source": "абстрактный",
+      "target": "abstract",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "анализ",
+      "target": "analysis",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "синтез",
+      "target": "synthesis",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "гипотеза",
+      "target": "hypothesis",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "доказательство",
+      "target": "evidence",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "методология",
+      "target": "methodology",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "исследование",
+      "target": "research",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "теория",
+      "target": "theory",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "концепция",
+      "target": "concept",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "парадигма",
+      "target": "paradigm",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "дискурс",
+      "target": "discourse",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "аргументация",
+      "target": "argumentation",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "обоснование",
+      "target": "justification",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "вывод",
+      "target": "conclusion",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "утверждение",
+      "target": "assertion",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "опровержение",
+      "target": "refutation",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "критерий",
+      "target": "criterion",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "наблюдение",
+      "target": "observation",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "интерпретация",
+      "target": "interpretation",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "контекст",
+      "target": "context",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "правовая норма",
+      "target": "legal provision",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "юрисдикция",
+      "target": "jurisdiction",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "суд",
+      "target": "court",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "приговор",
+      "target": "verdict",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "обвинение",
+      "target": "prosecution",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "защита",
+      "target": "defence",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "доказать",
+      "target": "to prove",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "правоохранительные органы",
+      "target": "law enforcement",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "регулировать",
+      "target": "to regulate",
+      "tags": ["law", "C1"]
+    },
     {
       "source": "привлекать к ответственности",
       "target": "to hold accountable",
       "tags": ["law", "C1"]
     },
-    { "source": "диагностировать", "target": "to diagnose", "tags": ["medicine", "C1"] },
-    { "source": "симптом", "target": "symptom", "tags": ["medicine", "C1"] },
-    { "source": "диагноз", "target": "diagnosis", "tags": ["medicine", "C1"] },
-    { "source": "терапия", "target": "therapy", "tags": ["medicine", "C1"] },
-    { "source": "рецепт", "target": "prescription", "tags": ["medicine", "C1"] },
-    { "source": "клинический", "target": "clinical", "tags": ["medicine", "C1"] },
-    { "source": "профилактический", "target": "preventive", "tags": ["medicine", "C1"] },
-    { "source": "хронический", "target": "chronic", "tags": ["medicine", "C1"] },
-    { "source": "острый", "target": "acute", "tags": ["medicine", "C1"] },
-    { "source": "иммунная система", "target": "immune system", "tags": ["medicine", "C1"] },
-    { "source": "выручка", "target": "revenue", "tags": ["business", "C1"] },
-    { "source": "прибыль", "target": "profit", "tags": ["business", "C1"] },
-    { "source": "расходы", "target": "expenditure", "tags": ["business", "C1"] },
-    { "source": "портфель", "target": "portfolio", "tags": ["business", "C1"] },
-    { "source": "доля рынка", "target": "market share", "tags": ["business", "C1"] },
-    { "source": "конкуренция", "target": "competition", "tags": ["business", "C1"] },
-    { "source": "цепочка поставок", "target": "supply chain", "tags": ["business", "C1"] },
-    { "source": "расширение", "target": "expansion", "tags": ["business", "C1"] },
-    { "source": "предпринимательство", "target": "entrepreneurship", "tags": ["business", "C1"] },
-    { "source": "корпоративный", "target": "corporate", "tags": ["business", "C1"] },
-    { "source": "точный", "target": "precise", "tags": ["adjectives", "C1"] },
-    { "source": "исчерпывающий", "target": "comprehensive", "tags": ["adjectives", "C1"] },
-    { "source": "систематический", "target": "systematic", "tags": ["adjectives", "C1"] },
-    { "source": "критический", "target": "critical", "tags": ["adjectives", "C1"] },
-    { "source": "аналитический", "target": "analytical", "tags": ["adjectives", "C1"] },
-    { "source": "объективный", "target": "objective", "tags": ["adjectives", "C1"] },
-    { "source": "субъективный", "target": "subjective", "tags": ["adjectives", "C1"] },
-    { "source": "логичный", "target": "logical", "tags": ["adjectives", "C1"] },
-    { "source": "рациональный", "target": "rational", "tags": ["adjectives", "C1"] },
-    { "source": "иррациональный", "target": "irrational", "tags": ["adjectives", "C1"] },
-    { "source": "недооценивать", "target": "to underestimate", "tags": ["verbs", "C1"] },
-    { "source": "переоценивать", "target": "to overestimate", "tags": ["verbs", "C1"] },
-    { "source": "формулировать", "target": "to formulate", "tags": ["verbs", "C1"] },
-    { "source": "анализировать", "target": "to analyse", "tags": ["verbs", "C1"] },
-    { "source": "расследовать", "target": "to investigate", "tags": ["verbs", "C1"] },
-    { "source": "применять", "target": "to apply", "tags": ["verbs", "C1"] },
-    { "source": "оценивать", "target": "to evaluate", "tags": ["verbs", "C1"] },
-    { "source": "иллюстрировать", "target": "to illustrate", "tags": ["verbs", "C1"] },
-    { "source": "обосновывать", "target": "to substantiate", "tags": ["verbs", "C1"] },
-    { "source": "консолидировать", "target": "to consolidate", "tags": ["verbs", "C1"] },
-    { "source": "преподаватель", "target": "faculty member", "tags": ["academic", "C1"] },
-    { "source": "диссертация", "target": "dissertation", "tags": ["academic", "C1"] },
-    { "source": "статья", "target": "paper", "tags": ["academic", "C1"] },
-    { "source": "семинар", "target": "seminar", "tags": ["academic", "C1"] },
-    { "source": "симпозиум", "target": "symposium", "tags": ["academic", "C1"] },
-    { "source": "лекция", "target": "lecture", "tags": ["academic", "C1"] },
-    { "source": "бакалавр", "target": "bachelor", "tags": ["academic", "C1"] },
-    { "source": "магистр", "target": "master", "tags": ["academic", "C1"] },
-    { "source": "аспирант", "target": "doctoral student", "tags": ["academic", "C1"] },
-    { "source": "профессор", "target": "professor", "tags": ["academic", "C1"] },
-    { "source": "официальный", "target": "formal", "tags": ["register", "C1"] },
-    { "source": "неофициальный", "target": "informal", "tags": ["register", "C1"] },
-    { "source": "профессиональный", "target": "professional", "tags": ["register", "C1"] },
-    { "source": "вежливый", "target": "polite", "tags": ["register", "C1"] },
-    { "source": "сдержанный", "target": "reserved", "tags": ["register", "C1"] },
-    { "source": "выражение", "target": "expression", "tags": ["register", "C1"] },
-    { "source": "поговорка", "target": "saying", "tags": ["register", "C1"] },
-    { "source": "идиома", "target": "idiom", "tags": ["register", "C1"] },
-    { "source": "словарный запас", "target": "vocabulary", "tags": ["register", "C1"] },
-    { "source": "терминология", "target": "terminology", "tags": ["register", "C1"] },
-    { "source": "инфраструктура", "target": "infrastructure", "tags": ["social", "C1"] },
-    { "source": "институт", "target": "institution", "tags": ["social", "C1"] },
-    { "source": "бюрократия", "target": "bureaucracy", "tags": ["social", "C1"] },
-    { "source": "политика", "target": "policy", "tags": ["social", "C1"] },
-    { "source": "дипломатия", "target": "diplomacy", "tags": ["social", "C1"] },
-    { "source": "международный", "target": "international", "tags": ["social", "C1"] },
-    { "source": "правительство", "target": "government", "tags": ["social", "C1"] },
-    { "source": "парламентский", "target": "parliamentary", "tags": ["social", "C1"] },
-    { "source": "референдум", "target": "referendum", "tags": ["social", "C1"] },
-    { "source": "демократия", "target": "democracy", "tags": ["social", "C1"] },
-    { "source": "неумолимый", "target": "relentless", "tags": ["adjectives", "C1"] },
-    { "source": "неизбежный", "target": "inevitable", "tags": ["adjectives", "C1"] },
-    { "source": "значительный", "target": "significant", "tags": ["adjectives", "C1"] },
-    { "source": "существенный", "target": "essential", "tags": ["adjectives", "C1"] },
-    { "source": "подходящий", "target": "appropriate", "tags": ["adjectives", "C1"] },
-    { "source": "необоснованный", "target": "unjustified", "tags": ["adjectives", "C1"] },
-    { "source": "устойчивый", "target": "sustainable", "tags": ["adjectives", "C1"] },
-    { "source": "сложный", "target": "complex", "tags": ["adjectives", "C1"] },
-    { "source": "своеобразный", "target": "peculiar", "tags": ["adjectives", "C1"] },
-    { "source": "мимолётный", "target": "transient", "tags": ["adjectives", "C1"] },
-    { "source": "последствия", "target": "consequences", "tags": ["social", "C1"] },
-    { "source": "сравнительный", "target": "comparative", "tags": ["academic", "C1"] },
-    { "source": "количественный", "target": "quantitative", "tags": ["academic", "C1"] },
-    { "source": "качественный", "target": "qualitative", "tags": ["academic", "C1"] },
-    { "source": "эмпирический", "target": "empirical", "tags": ["academic", "C1"] },
-    { "source": "теоретический", "target": "theoretical", "tags": ["academic", "C1"] },
-    { "source": "интегрировать", "target": "to integrate", "tags": ["verbs", "C1"] },
-    { "source": "координировать", "target": "to coordinate", "tags": ["verbs", "C1"] },
-    { "source": "контролировать", "target": "to oversee", "tags": ["verbs", "C1"] },
-    { "source": "реализовывать", "target": "to implement", "tags": ["verbs", "C1"] },
-    { "source": "делегировать", "target": "to delegate", "tags": ["verbs", "C1"] },
-    { "source": "управлять", "target": "to manage", "tags": ["verbs", "C1"] },
-    { "source": "мониторить", "target": "to monitor", "tags": ["verbs", "C1"] },
-    { "source": "оптимизировать", "target": "to optimise", "tags": ["verbs", "C1"] },
-    { "source": "преодолевать", "target": "to overcome", "tags": ["verbs", "C1"] },
-    { "source": "обеспечивать", "target": "to ensure", "tags": ["verbs", "C1"] },
-    { "source": "стремиться", "target": "to strive", "tags": ["verbs", "C1"] },
-    { "source": "ценить", "target": "to appreciate", "tags": ["verbs", "C1"] },
-    { "source": "пересматривать", "target": "to revise", "tags": ["verbs", "C1"] },
-    { "source": "систематизировать", "target": "to systematise", "tags": ["verbs", "C1"] },
-    { "source": "дифференцировать", "target": "to differentiate", "tags": ["verbs", "C1"] },
-    { "source": "подтверждать", "target": "to confirm", "tags": ["verbs", "C1"] },
-    { "source": "оспаривать", "target": "to dispute", "tags": ["verbs", "C1"] },
-    { "source": "поддерживать", "target": "to support", "tags": ["verbs", "C1"] },
-    { "source": "объединять", "target": "to unite", "tags": ["verbs", "C1"] },
-    { "source": "адаптировать", "target": "to adapt", "tags": ["verbs", "C1"] },
-    { "source": "ускорять", "target": "to accelerate", "tags": ["verbs", "C1"] },
-    { "source": "предлагать", "target": "to propose", "tags": ["verbs", "C1"] },
-    { "source": "убеждать", "target": "to persuade", "tags": ["verbs", "C1"] },
-    { "source": "приобретать", "target": "to acquire", "tags": ["verbs", "C1"] },
-    { "source": "расширять", "target": "to expand", "tags": ["verbs", "C1"] }
+    {
+      "source": "диагностировать",
+      "target": "to diagnose",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "симптом",
+      "target": "symptom",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "диагноз",
+      "target": "diagnosis",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "терапия",
+      "target": "therapy",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "рецепт",
+      "target": "prescription",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "клинический",
+      "target": "clinical",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "профилактический",
+      "target": "preventive",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "хронический",
+      "target": "chronic",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "острый",
+      "target": "acute",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "иммунная система",
+      "target": "immune system",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "выручка",
+      "target": "revenue",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "прибыль",
+      "target": "profit",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "расходы",
+      "target": "expenditure",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "портфель",
+      "target": "portfolio",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "доля рынка",
+      "target": "market share",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "конкуренция",
+      "target": "competition",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "цепочка поставок",
+      "target": "supply chain",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "расширение",
+      "target": "expansion",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "предпринимательство",
+      "target": "entrepreneurship",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "корпоративный",
+      "target": "corporate",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "точный",
+      "target": "precise",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "исчерпывающий",
+      "target": "comprehensive",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "систематический",
+      "target": "systematic",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "критический",
+      "target": "critical",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "аналитический",
+      "target": "analytical",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "объективный",
+      "target": "objective",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "субъективный",
+      "target": "subjective",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "логичный",
+      "target": "logical",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "рациональный",
+      "target": "rational",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "иррациональный",
+      "target": "irrational",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "недооценивать",
+      "target": "to underestimate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "переоценивать",
+      "target": "to overestimate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "формулировать",
+      "target": "to formulate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "анализировать",
+      "target": "to analyse",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "расследовать",
+      "target": "to investigate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "применять",
+      "target": "to apply",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "оценивать",
+      "target": "to evaluate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "иллюстрировать",
+      "target": "to illustrate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "обосновывать",
+      "target": "to substantiate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "консолидировать",
+      "target": "to consolidate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "преподаватель",
+      "target": "faculty member",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "диссертация",
+      "target": "dissertation",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "статья",
+      "target": "paper",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "семинар",
+      "target": "seminar",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "симпозиум",
+      "target": "symposium",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "лекция",
+      "target": "lecture",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "бакалавр",
+      "target": "bachelor",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "магистр",
+      "target": "master",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "аспирант",
+      "target": "doctoral student",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "профессор",
+      "target": "professor",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "официальный",
+      "target": "formal",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "неофициальный",
+      "target": "informal",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "профессиональный",
+      "target": "professional",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "вежливый",
+      "target": "polite",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "сдержанный",
+      "target": "reserved",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "выражение",
+      "target": "expression",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "поговорка",
+      "target": "saying",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "идиома",
+      "target": "idiom",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "словарный запас",
+      "target": "vocabulary",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "терминология",
+      "target": "terminology",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "инфраструктура",
+      "target": "infrastructure",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "институт",
+      "target": "institution",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "бюрократия",
+      "target": "bureaucracy",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "политика",
+      "target": "policy",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "дипломатия",
+      "target": "diplomacy",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "международный",
+      "target": "international",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "правительство",
+      "target": "government",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "парламентский",
+      "target": "parliamentary",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "референдум",
+      "target": "referendum",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "демократия",
+      "target": "democracy",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "неумолимый",
+      "target": "relentless",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "неизбежный",
+      "target": "inevitable",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "значительный",
+      "target": "significant",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "существенный",
+      "target": "essential",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "подходящий",
+      "target": "appropriate",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "необоснованный",
+      "target": "unjustified",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "устойчивый",
+      "target": "sustainable",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "сложный",
+      "target": "complex",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "своеобразный",
+      "target": "peculiar",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "мимолётный",
+      "target": "transient",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "последствия",
+      "target": "consequences",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "сравнительный",
+      "target": "comparative",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "количественный",
+      "target": "quantitative",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "качественный",
+      "target": "qualitative",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "эмпирический",
+      "target": "empirical",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "теоретический",
+      "target": "theoretical",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "интегрировать",
+      "target": "to integrate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "координировать",
+      "target": "to coordinate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "контролировать",
+      "target": "to oversee",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "реализовывать",
+      "target": "to implement",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "делегировать",
+      "target": "to delegate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "управлять",
+      "target": "to manage",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "мониторить",
+      "target": "to monitor",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "оптимизировать",
+      "target": "to optimise",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "преодолевать",
+      "target": "to overcome",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "обеспечивать",
+      "target": "to ensure",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "стремиться",
+      "target": "to strive",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "ценить",
+      "target": "to appreciate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "пересматривать",
+      "target": "to revise",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "систематизировать",
+      "target": "to systematise",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "дифференцировать",
+      "target": "to differentiate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "подтверждать",
+      "target": "to confirm",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "оспаривать",
+      "target": "to dispute",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "поддерживать",
+      "target": "to support",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "объединять",
+      "target": "to unite",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "адаптировать",
+      "target": "to adapt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "ускорять",
+      "target": "to accelerate",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "предлагать",
+      "target": "to propose",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "убеждать",
+      "target": "to persuade",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "приобретать",
+      "target": "to acquire",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "расширять",
+      "target": "to expand",
+      "tags": ["verbs", "C1"]
+    }
   ]
 }

--- a/public/starter-packs/ru-en-c2.json
+++ b/public/starter-packs/ru-en-c2.json
@@ -6,124 +6,600 @@
   "targetCode": "en",
   "level": "C2",
   "words": [
-    { "source": "меланхолия", "target": "melancholy", "tags": ["emotions", "C2"] },
-    { "source": "ностальгия", "target": "nostalgia", "tags": ["emotions", "C2"] },
-    { "source": "эйфория", "target": "euphoria", "tags": ["emotions", "C2"] },
-    { "source": "апатия", "target": "apathy", "tags": ["emotions", "C2"] },
-    { "source": "амбивалентность", "target": "ambivalence", "tags": ["emotions", "C2"] },
-    { "source": "тревога", "target": "unease", "tags": ["emotions", "C2"] },
-    { "source": "наивность", "target": "naivety", "tags": ["emotions", "C2"] },
-    { "source": "ирония", "target": "irony", "tags": ["emotions", "C2"] },
-    { "source": "сарказм", "target": "sarcasm", "tags": ["emotions", "C2"] },
-    { "source": "презрение", "target": "contempt", "tags": ["emotions", "C2"] },
-    { "source": "честолюбие", "target": "ambition", "tags": ["emotions", "C2"] },
-    { "source": "невинность", "target": "innocence", "tags": ["emotions", "C2"] },
-    { "source": "восхищение", "target": "admiration", "tags": ["emotions", "C2"] },
-    { "source": "благоговение", "target": "awe", "tags": ["emotions", "C2"] },
-    { "source": "недоверие", "target": "distrust", "tags": ["emotions", "C2"] },
-    { "source": "энтузиазм", "target": "enthusiasm", "tags": ["emotions", "C2"] },
-    { "source": "отчуждение", "target": "alienation", "tags": ["emotions", "C2"] },
-    { "source": "эмпатия", "target": "empathy", "tags": ["emotions", "C2"] },
-    { "source": "смирение", "target": "humility", "tags": ["emotions", "C2"] },
-    { "source": "гордость", "target": "pride", "tags": ["emotions", "C2"] },
-    { "source": "коренное население", "target": "indigenous people", "tags": ["social", "C2"] },
-    { "source": "колониализм", "target": "colonialism", "tags": ["social", "C2"] },
-    { "source": "ассимиляция", "target": "assimilation", "tags": ["social", "C2"] },
-    { "source": "аккультурация", "target": "acculturation", "tags": ["social", "C2"] },
-    { "source": "этноцентризм", "target": "ethnocentrism", "tags": ["social", "C2"] },
-    { "source": "плюрализм", "target": "pluralism", "tags": ["social", "C2"] },
-    { "source": "гегемония", "target": "hegemony", "tags": ["social", "C2"] },
-    { "source": "дискриминация", "target": "discrimination", "tags": ["social", "C2"] },
-    { "source": "эмансипация", "target": "emancipation", "tags": ["social", "C2"] },
-    { "source": "сегрегация", "target": "segregation", "tags": ["social", "C2"] },
-    { "source": "афоризм", "target": "aphorism", "tags": ["literary", "C2"] },
-    { "source": "метафора", "target": "metaphor", "tags": ["literary", "C2"] },
-    { "source": "аллегория", "target": "allegory", "tags": ["literary", "C2"] },
-    { "source": "эпитет", "target": "epithet", "tags": ["literary", "C2"] },
-    { "source": "олицетворение", "target": "personification", "tags": ["literary", "C2"] },
-    { "source": "иронизировать", "target": "to ironise", "tags": ["literary", "C2"] },
-    { "source": "возникать", "target": "to emerge", "tags": ["literary", "C2"] },
-    { "source": "исчезать", "target": "to vanish", "tags": ["literary", "C2"] },
-    { "source": "мерцать", "target": "to glimmer", "tags": ["literary", "C2"] },
-    { "source": "дрожать", "target": "to tremble", "tags": ["literary", "C2"] },
-    { "source": "квинтэссенция", "target": "quintessence", "tags": ["academic", "C2"] },
-    { "source": "аксиома", "target": "axiom", "tags": ["academic", "C2"] },
-    { "source": "тавтология", "target": "tautology", "tags": ["academic", "C2"] },
-    { "source": "парадокс", "target": "paradox", "tags": ["academic", "C2"] },
-    { "source": "эпистемический", "target": "epistemic", "tags": ["academic", "C2"] },
-    { "source": "онтологический", "target": "ontological", "tags": ["academic", "C2"] },
-    { "source": "феноменология", "target": "phenomenology", "tags": ["academic", "C2"] },
-    { "source": "герменевтика", "target": "hermeneutics", "tags": ["academic", "C2"] },
-    { "source": "диалектика", "target": "dialectics", "tags": ["academic", "C2"] },
-    { "source": "прагматизм", "target": "pragmatism", "tags": ["academic", "C2"] },
-    { "source": "великодушный", "target": "magnanimous", "tags": ["archaic", "C2"] },
-    { "source": "великолепие", "target": "splendour", "tags": ["archaic", "C2"] },
-    { "source": "блеск", "target": "brilliance", "tags": ["archaic", "C2"] },
-    { "source": "осязаемый", "target": "tangible", "tags": ["archaic", "C2"] },
-    { "source": "неосязаемый", "target": "intangible", "tags": ["archaic", "C2"] },
-    { "source": "двусмысленный", "target": "ambiguous", "tags": ["register", "C2"] },
-    { "source": "нейтральный", "target": "neutral", "tags": ["register", "C2"] },
-    { "source": "тонкий", "target": "subtle", "tags": ["register", "C2"] },
-    { "source": "утончённый", "target": "refined", "tags": ["register", "C2"] },
-    { "source": "экспрессивный", "target": "expressive", "tags": ["register", "C2"] },
-    { "source": "суггестивный", "target": "suggestive", "tags": ["register", "C2"] },
-    { "source": "благозвучный", "target": "euphonious", "tags": ["register", "C2"] },
-    { "source": "ассонанс", "target": "assonance", "tags": ["register", "C2"] },
-    { "source": "аллитерация", "target": "alliteration", "tags": ["register", "C2"] },
-    { "source": "неоднозначность", "target": "ambiguity", "tags": ["register", "C2"] },
-    { "source": "художественный", "target": "artistic", "tags": ["register", "C2"] },
-    { "source": "эстетический", "target": "aesthetic", "tags": ["register", "C2"] },
-    { "source": "романтический", "target": "romantic", "tags": ["register", "C2"] },
-    { "source": "символический", "target": "symbolic", "tags": ["register", "C2"] },
-    { "source": "мистический", "target": "mystical", "tags": ["register", "C2"] },
-    { "source": "эклектический", "target": "eclectic", "tags": ["academic", "C2"] },
-    { "source": "синергия", "target": "synergy", "tags": ["academic", "C2"] },
-    { "source": "холистический", "target": "holistic", "tags": ["academic", "C2"] },
-    { "source": "редукционизм", "target": "reductionism", "tags": ["academic", "C2"] },
-    { "source": "детерминизм", "target": "determinism", "tags": ["academic", "C2"] },
-    { "source": "релятивизм", "target": "relativism", "tags": ["academic", "C2"] },
-    { "source": "нигилизм", "target": "nihilism", "tags": ["academic", "C2"] },
-    { "source": "скептицизм", "target": "scepticism", "tags": ["academic", "C2"] },
-    { "source": "эмпиризм", "target": "empiricism", "tags": ["academic", "C2"] },
-    { "source": "рационализм", "target": "rationalism", "tags": ["academic", "C2"] },
-    { "source": "в переносном смысле", "target": "figuratively", "tags": ["literary", "C2"] },
-    { "source": "в буквальном смысле", "target": "literally", "tags": ["literary", "C2"] },
-    { "source": "риторика", "target": "rhetoric", "tags": ["literary", "C2"] },
-    { "source": "полемика", "target": "polemic", "tags": ["literary", "C2"] },
-    { "source": "эпиграмма", "target": "epigram", "tags": ["literary", "C2"] },
-    { "source": "сатира", "target": "satire", "tags": ["literary", "C2"] },
-    { "source": "пародия", "target": "parody", "tags": ["literary", "C2"] },
-    { "source": "аналогия", "target": "analogy", "tags": ["literary", "C2"] },
-    { "source": "метонимия", "target": "metonymy", "tags": ["literary", "C2"] },
-    { "source": "экзистенциальный", "target": "existential", "tags": ["academic", "C2"] },
-    { "source": "трансцендентный", "target": "transcendent", "tags": ["academic", "C2"] },
-    { "source": "метафизический", "target": "metaphysical", "tags": ["academic", "C2"] },
-    { "source": "эпистемология", "target": "epistemology", "tags": ["academic", "C2"] },
-    { "source": "телеологический", "target": "teleological", "tags": ["academic", "C2"] },
-    { "source": "деонтологический", "target": "deontological", "tags": ["academic", "C2"] },
-    { "source": "консеквенциализм", "target": "consequentialism", "tags": ["academic", "C2"] },
-    { "source": "утилитаризм", "target": "utilitarianism", "tags": ["academic", "C2"] },
-    { "source": "морализаторство", "target": "moralism", "tags": ["academic", "C2"] },
-    { "source": "непоправимый", "target": "irremediable", "tags": ["archaic", "C2"] },
-    { "source": "необратимый", "target": "irreversible", "tags": ["archaic", "C2"] },
-    { "source": "печаль", "target": "sorrow", "tags": ["archaic", "C2"] },
-    { "source": "томиться", "target": "to languish", "tags": ["archaic", "C2"] },
-    { "source": "лелеять", "target": "to cherish", "tags": ["archaic", "C2"] },
-    { "source": "вздыхать", "target": "to sigh", "tags": ["archaic", "C2"] },
-    { "source": "прослеживать", "target": "to trace", "tags": ["verbs", "C2"] },
-    { "source": "вспоминать", "target": "to reminisce", "tags": ["verbs", "C2"] },
-    { "source": "воплощать", "target": "to embody", "tags": ["verbs", "C2"] },
-    { "source": "проявляться", "target": "to manifest", "tags": ["verbs", "C2"] },
-    { "source": "искоренять", "target": "to eradicate", "tags": ["verbs", "C2"] },
-    { "source": "укореняться", "target": "to take root", "tags": ["verbs", "C2"] },
-    { "source": "преодолевать", "target": "to transcend", "tags": ["verbs", "C2"] },
-    { "source": "нормативный", "target": "normative", "tags": ["academic", "C2"] },
-    { "source": "дескриптивный", "target": "descriptive", "tags": ["academic", "C2"] },
-    { "source": "прескриптивный", "target": "prescriptive", "tags": ["academic", "C2"] },
-    { "source": "символика", "target": "symbolism", "tags": ["literary", "C2"] },
-    { "source": "гипербола", "target": "hyperbole", "tags": ["literary", "C2"] },
-    { "source": "литота", "target": "litotes", "tags": ["literary", "C2"] },
-    { "source": "общественное мнение", "target": "public opinion", "tags": ["social", "C2"] },
-    { "source": "приток", "target": "influx", "tags": ["social", "C2"] }
+    {
+      "source": "меланхолия",
+      "target": "melancholy",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "ностальгия",
+      "target": "nostalgia",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "эйфория",
+      "target": "euphoria",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "апатия",
+      "target": "apathy",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "амбивалентность",
+      "target": "ambivalence",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "тревога",
+      "target": "unease",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "наивность",
+      "target": "naivety",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "ирония",
+      "target": "irony",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "сарказм",
+      "target": "sarcasm",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "презрение",
+      "target": "contempt",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "честолюбие",
+      "target": "ambition",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "невинность",
+      "target": "innocence",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "восхищение",
+      "target": "admiration",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "благоговение",
+      "target": "awe",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "недоверие",
+      "target": "distrust",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "энтузиазм",
+      "target": "enthusiasm",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "отчуждение",
+      "target": "alienation",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "эмпатия",
+      "target": "empathy",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "смирение",
+      "target": "humility",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "гордость",
+      "target": "pride",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "коренное население",
+      "target": "indigenous people",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "колониализм",
+      "target": "colonialism",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "ассимиляция",
+      "target": "assimilation",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "аккультурация",
+      "target": "acculturation",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "этноцентризм",
+      "target": "ethnocentrism",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "плюрализм",
+      "target": "pluralism",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "гегемония",
+      "target": "hegemony",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "дискриминация",
+      "target": "discrimination",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "эмансипация",
+      "target": "emancipation",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "сегрегация",
+      "target": "segregation",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "афоризм",
+      "target": "aphorism",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "метафора",
+      "target": "metaphor",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "аллегория",
+      "target": "allegory",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "эпитет",
+      "target": "epithet",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "олицетворение",
+      "target": "personification",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "иронизировать",
+      "target": "to ironise",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "возникать",
+      "target": "to emerge",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "исчезать",
+      "target": "to vanish",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "мерцать",
+      "target": "to glimmer",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "дрожать",
+      "target": "to tremble",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "квинтэссенция",
+      "target": "quintessence",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "аксиома",
+      "target": "axiom",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "тавтология",
+      "target": "tautology",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "парадокс",
+      "target": "paradox",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "эпистемический",
+      "target": "epistemic",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "онтологический",
+      "target": "ontological",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "феноменология",
+      "target": "phenomenology",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "герменевтика",
+      "target": "hermeneutics",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "диалектика",
+      "target": "dialectics",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "прагматизм",
+      "target": "pragmatism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "великодушный",
+      "target": "magnanimous",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "великолепие",
+      "target": "splendour",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "блеск",
+      "target": "brilliance",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "осязаемый",
+      "target": "tangible",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "неосязаемый",
+      "target": "intangible",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "двусмысленный",
+      "target": "ambiguous",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "нейтральный",
+      "target": "neutral",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "тонкий",
+      "target": "subtle",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "утончённый",
+      "target": "refined",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "экспрессивный",
+      "target": "expressive",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "суггестивный",
+      "target": "suggestive",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "благозвучный",
+      "target": "euphonious",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "ассонанс",
+      "target": "assonance",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "аллитерация",
+      "target": "alliteration",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "неоднозначность",
+      "target": "ambiguity",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "художественный",
+      "target": "artistic",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "эстетический",
+      "target": "aesthetic",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "романтический",
+      "target": "romantic",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "символический",
+      "target": "symbolic",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "мистический",
+      "target": "mystical",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "эклектический",
+      "target": "eclectic",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "синергия",
+      "target": "synergy",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "холистический",
+      "target": "holistic",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "редукционизм",
+      "target": "reductionism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "детерминизм",
+      "target": "determinism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "релятивизм",
+      "target": "relativism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "нигилизм",
+      "target": "nihilism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "скептицизм",
+      "target": "scepticism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "эмпиризм",
+      "target": "empiricism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "рационализм",
+      "target": "rationalism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "в переносном смысле",
+      "target": "figuratively",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "в буквальном смысле",
+      "target": "literally",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "риторика",
+      "target": "rhetoric",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "полемика",
+      "target": "polemic",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "эпиграмма",
+      "target": "epigram",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "сатира",
+      "target": "satire",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "пародия",
+      "target": "parody",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "аналогия",
+      "target": "analogy",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "метонимия",
+      "target": "metonymy",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "экзистенциальный",
+      "target": "existential",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "трансцендентный",
+      "target": "transcendent",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "метафизический",
+      "target": "metaphysical",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "эпистемология",
+      "target": "epistemology",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "телеологический",
+      "target": "teleological",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "деонтологический",
+      "target": "deontological",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "консеквенциализм",
+      "target": "consequentialism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "утилитаризм",
+      "target": "utilitarianism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "морализаторство",
+      "target": "moralism",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "непоправимый",
+      "target": "irremediable",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "необратимый",
+      "target": "irreversible",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "печаль",
+      "target": "sorrow",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "томиться",
+      "target": "to languish",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "лелеять",
+      "target": "to cherish",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "вздыхать",
+      "target": "to sigh",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "прослеживать",
+      "target": "to trace",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "вспоминать",
+      "target": "to reminisce",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "воплощать",
+      "target": "to embody",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "проявляться",
+      "target": "to manifest",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "искоренять",
+      "target": "to eradicate",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "укореняться",
+      "target": "to take root",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "преодолевать",
+      "target": "to transcend",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "нормативный",
+      "target": "normative",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "дескриптивный",
+      "target": "descriptive",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "прескриптивный",
+      "target": "prescriptive",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "символика",
+      "target": "symbolism",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "гипербола",
+      "target": "hyperbole",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "литота",
+      "target": "litotes",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "общественное мнение",
+      "target": "public opinion",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "приток",
+      "target": "influx",
+      "tags": ["social", "C2"]
+    }
   ]
 }

--- a/public/starter-packs/ru-lv-a1.json
+++ b/public/starter-packs/ru-lv-a1.json
@@ -6,191 +6,935 @@
   "targetCode": "lv",
   "level": "A1",
   "words": [
-    { "source": "привет", "target": "sveiki", "tags": ["greetings", "A1"] },
-    { "source": "пока", "target": "čau", "tags": ["greetings", "A1"] },
-    { "source": "до свидания", "target": "ardievu", "tags": ["greetings", "A1"] },
-    { "source": "пожалуйста", "target": "lūdzu", "tags": ["greetings", "A1"] },
-    { "source": "спасибо", "target": "paldies", "tags": ["greetings", "A1"] },
-    { "source": "да", "target": "jā", "tags": ["greetings", "A1"] },
-    { "source": "нет", "target": "nē", "tags": ["greetings", "A1"] },
-    { "source": "извините", "target": "piedodiet", "tags": ["greetings", "A1"] },
-    { "source": "доброе утро", "target": "labrīt", "tags": ["greetings", "A1"] },
-    { "source": "добрый день", "target": "labdien", "tags": ["greetings", "A1"] },
-    { "source": "добрый вечер", "target": "labvakar", "tags": ["greetings", "A1"] },
-    { "source": "до встречи", "target": "uz redzēšanos", "tags": ["greetings", "A1"] },
-    { "source": "один", "target": "viens", "tags": ["numbers", "A1"] },
-    { "source": "два", "target": "divi", "tags": ["numbers", "A1"] },
-    { "source": "три", "target": "trīs", "tags": ["numbers", "A1"] },
-    { "source": "четыре", "target": "četri", "tags": ["numbers", "A1"] },
-    { "source": "пять", "target": "pieci", "tags": ["numbers", "A1"] },
-    { "source": "шесть", "target": "seši", "tags": ["numbers", "A1"] },
-    { "source": "семь", "target": "septiņi", "tags": ["numbers", "A1"] },
-    { "source": "восемь", "target": "astoņi", "tags": ["numbers", "A1"] },
-    { "source": "девять", "target": "deviņi", "tags": ["numbers", "A1"] },
-    { "source": "десять", "target": "desmit", "tags": ["numbers", "A1"] },
-    { "source": "одиннадцать", "target": "vienpadsmit", "tags": ["numbers", "A1"] },
-    { "source": "двенадцать", "target": "divpadsmit", "tags": ["numbers", "A1"] },
-    { "source": "тринадцать", "target": "trīspadsmit", "tags": ["numbers", "A1"] },
-    { "source": "четырнадцать", "target": "četrpadsmit", "tags": ["numbers", "A1"] },
-    { "source": "пятнадцать", "target": "piecpadsmit", "tags": ["numbers", "A1"] },
-    { "source": "шестнадцать", "target": "sešpadsmit", "tags": ["numbers", "A1"] },
-    { "source": "семнадцать", "target": "septiņpadsmit", "tags": ["numbers", "A1"] },
-    { "source": "восемнадцать", "target": "astoņpadsmit", "tags": ["numbers", "A1"] },
-    { "source": "девятнадцать", "target": "deviņpadsmit", "tags": ["numbers", "A1"] },
-    { "source": "двадцать", "target": "divdesmit", "tags": ["numbers", "A1"] },
-    { "source": "красный", "target": "sarkans", "tags": ["colours", "A1"] },
-    { "source": "синий", "target": "zils", "tags": ["colours", "A1"] },
-    { "source": "зелёный", "target": "zaļš", "tags": ["colours", "A1"] },
-    { "source": "жёлтый", "target": "dzeltens", "tags": ["colours", "A1"] },
-    { "source": "белый", "target": "balts", "tags": ["colours", "A1"] },
-    { "source": "чёрный", "target": "melns", "tags": ["colours", "A1"] },
-    { "source": "оранжевый", "target": "oranžs", "tags": ["colours", "A1"] },
-    { "source": "розовый", "target": "rozā", "tags": ["colours", "A1"] },
-    { "source": "фиолетовый", "target": "violets", "tags": ["colours", "A1"] },
-    { "source": "коричневый", "target": "brūns", "tags": ["colours", "A1"] },
-    { "source": "серый", "target": "pelēks", "tags": ["colours", "A1"] },
-    { "source": "мама", "target": "māte", "tags": ["family", "A1"] },
-    { "source": "папа", "target": "tēvs", "tags": ["family", "A1"] },
-    { "source": "сестра", "target": "māsa", "tags": ["family", "A1"] },
-    { "source": "брат", "target": "brālis", "tags": ["family", "A1"] },
-    { "source": "бабушка", "target": "vecāmāte", "tags": ["family", "A1"] },
-    { "source": "дедушка", "target": "vectēvs", "tags": ["family", "A1"] },
-    { "source": "ребёнок", "target": "bērns", "tags": ["family", "A1"] },
-    { "source": "сын", "target": "dēls", "tags": ["family", "A1"] },
-    { "source": "дочь", "target": "meita", "tags": ["family", "A1"] },
-    { "source": "муж", "target": "vīrs", "tags": ["family", "A1"] },
-    { "source": "жена", "target": "sieva", "tags": ["family", "A1"] },
-    { "source": "семья", "target": "ģimene", "tags": ["family", "A1"] },
-    { "source": "вода", "target": "ūdens", "tags": ["food-drink", "A1"] },
-    { "source": "молоко", "target": "piens", "tags": ["food-drink", "A1"] },
-    { "source": "хлеб", "target": "maize", "tags": ["food-drink", "A1"] },
-    { "source": "яйцо", "target": "ola", "tags": ["food-drink", "A1"] },
-    { "source": "яблоко", "target": "ābols", "tags": ["food-drink", "A1"] },
-    { "source": "банан", "target": "banāns", "tags": ["food-drink", "A1"] },
-    { "source": "кофе", "target": "kafija", "tags": ["food-drink", "A1"] },
-    { "source": "чай", "target": "tēja", "tags": ["food-drink", "A1"] },
-    { "source": "сыр", "target": "siers", "tags": ["food-drink", "A1"] },
-    { "source": "мясо", "target": "gaļa", "tags": ["food-drink", "A1"] },
-    { "source": "рис", "target": "rīsi", "tags": ["food-drink", "A1"] },
-    { "source": "сахар", "target": "cukurs", "tags": ["food-drink", "A1"] },
-    { "source": "понедельник", "target": "pirmdiena", "tags": ["days", "A1"] },
-    { "source": "вторник", "target": "otrdiena", "tags": ["days", "A1"] },
-    { "source": "среда", "target": "trešdiena", "tags": ["days", "A1"] },
-    { "source": "четверг", "target": "ceturtdiena", "tags": ["days", "A1"] },
-    { "source": "пятница", "target": "piektdiena", "tags": ["days", "A1"] },
-    { "source": "суббота", "target": "sestdiena", "tags": ["days", "A1"] },
-    { "source": "воскресенье", "target": "svētdiena", "tags": ["days", "A1"] },
-    { "source": "январь", "target": "janvāris", "tags": ["months", "A1"] },
-    { "source": "февраль", "target": "februāris", "tags": ["months", "A1"] },
-    { "source": "март", "target": "marts", "tags": ["months", "A1"] },
-    { "source": "апрель", "target": "aprīlis", "tags": ["months", "A1"] },
-    { "source": "май", "target": "maijs", "tags": ["months", "A1"] },
-    { "source": "июнь", "target": "jūnijs", "tags": ["months", "A1"] },
-    { "source": "июль", "target": "jūlijs", "tags": ["months", "A1"] },
-    { "source": "август", "target": "augusts", "tags": ["months", "A1"] },
-    { "source": "сентябрь", "target": "septembris", "tags": ["months", "A1"] },
-    { "source": "октябрь", "target": "oktobris", "tags": ["months", "A1"] },
-    { "source": "ноябрь", "target": "novembris", "tags": ["months", "A1"] },
-    { "source": "декабрь", "target": "decembris", "tags": ["months", "A1"] },
-    { "source": "быть", "target": "būt", "tags": ["verbs", "A1"] },
-    { "source": "иметь", "target": "piederēt", "tags": ["verbs", "A1"] },
-    { "source": "идти", "target": "iet", "tags": ["verbs", "A1"] },
-    { "source": "хотеть", "target": "gribēt", "tags": ["verbs", "A1"] },
-    { "source": "любить", "target": "patikt", "tags": ["verbs", "A1"] },
-    { "source": "прийти", "target": "nākt", "tags": ["verbs", "A1"] },
-    { "source": "видеть", "target": "redzēt", "tags": ["verbs", "A1"] },
-    { "source": "слышать", "target": "dzirdēt", "tags": ["verbs", "A1"] },
-    { "source": "есть", "target": "ēst", "tags": ["verbs", "A1"] },
-    { "source": "пить", "target": "dzert", "tags": ["verbs", "A1"] },
-    { "source": "спать", "target": "gulēt", "tags": ["verbs", "A1"] },
-    { "source": "сидеть", "target": "sēdēt", "tags": ["verbs", "A1"] },
-    { "source": "стоять", "target": "stāvēt", "tags": ["verbs", "A1"] },
-    { "source": "говорить", "target": "runāt", "tags": ["verbs", "A1"] },
-    { "source": "дать", "target": "dot", "tags": ["verbs", "A1"] },
-    { "source": "взять", "target": "ņemt", "tags": ["verbs", "A1"] },
-    { "source": "смотреть", "target": "skatīties", "tags": ["verbs", "A1"] },
-    { "source": "хороший", "target": "labs", "tags": ["adjectives", "A1"] },
-    { "source": "плохой", "target": "slikts", "tags": ["adjectives", "A1"] },
-    { "source": "большой", "target": "liels", "tags": ["adjectives", "A1"] },
-    { "source": "маленький", "target": "mazs", "tags": ["adjectives", "A1"] },
-    { "source": "горячий", "target": "karsts", "tags": ["adjectives", "A1"] },
-    { "source": "холодный", "target": "auksts", "tags": ["adjectives", "A1"] },
-    { "source": "новый", "target": "jauns", "tags": ["adjectives", "A1"] },
-    { "source": "старый", "target": "vecs", "tags": ["adjectives", "A1"] },
-    { "source": "длинный", "target": "garš", "tags": ["adjectives", "A1"] },
-    { "source": "короткий", "target": "īss", "tags": ["adjectives", "A1"] },
-    { "source": "высокий", "target": "augsts", "tags": ["adjectives", "A1"] },
-    { "source": "низкий", "target": "zems", "tags": ["adjectives", "A1"] },
-    { "source": "я", "target": "es", "tags": ["pronouns", "A1"] },
-    { "source": "ты", "target": "tu", "tags": ["pronouns", "A1"] },
-    { "source": "он", "target": "viņš", "tags": ["pronouns", "A1"] },
-    { "source": "она", "target": "viņa", "tags": ["pronouns", "A1"] },
-    { "source": "мы", "target": "mēs", "tags": ["pronouns", "A1"] },
-    { "source": "они", "target": "viņi", "tags": ["pronouns", "A1"] },
-    { "source": "оно", "target": "tas", "tags": ["pronouns", "A1"] },
-    { "source": "дом", "target": "māja", "tags": ["home", "A1"] },
-    { "source": "комната", "target": "istaba", "tags": ["home", "A1"] },
-    { "source": "дверь", "target": "durvis", "tags": ["home", "A1"] },
-    { "source": "окно", "target": "logs", "tags": ["home", "A1"] },
-    { "source": "стол", "target": "galds", "tags": ["home", "A1"] },
-    { "source": "стул", "target": "krēsls", "tags": ["home", "A1"] },
-    { "source": "кровать", "target": "gulta", "tags": ["home", "A1"] },
-    { "source": "человек", "target": "cilvēks", "tags": ["social", "A1"] },
-    { "source": "мужчина", "target": "vīrietis", "tags": ["social", "A1"] },
-    { "source": "женщина", "target": "sieviete", "tags": ["social", "A1"] },
-    { "source": "мальчик", "target": "zēns", "tags": ["social", "A1"] },
-    { "source": "девочка", "target": "meitene", "tags": ["social", "A1"] },
-    { "source": "друг", "target": "draugs", "tags": ["social", "A1"] },
-    { "source": "имя", "target": "vārds", "tags": ["social", "A1"] },
-    { "source": "возраст", "target": "vecums", "tags": ["social", "A1"] },
-    { "source": "животное", "target": "dzīvnieks", "tags": ["nature", "A1"] },
-    { "source": "собака", "target": "suns", "tags": ["nature", "A1"] },
-    { "source": "кошка", "target": "kaķis", "tags": ["nature", "A1"] },
-    { "source": "птица", "target": "putns", "tags": ["nature", "A1"] },
-    { "source": "рыба", "target": "zivs", "tags": ["nature", "A1"] },
-    { "source": "дерево", "target": "koks", "tags": ["nature", "A1"] },
-    { "source": "цветок", "target": "puķe", "tags": ["nature", "A1"] },
-    { "source": "солнце", "target": "saule", "tags": ["nature", "A1"] },
-    { "source": "дождь", "target": "lietus", "tags": ["nature", "A1"] },
-    { "source": "снег", "target": "sniegs", "tags": ["nature", "A1"] },
-    { "source": "телефон", "target": "telefons", "tags": ["objects", "A1"] },
-    { "source": "книга", "target": "grāmata", "tags": ["objects", "A1"] },
-    { "source": "ручка", "target": "pildspalva", "tags": ["objects", "A1"] },
-    { "source": "сумка", "target": "soma", "tags": ["objects", "A1"] },
-    { "source": "ключ", "target": "atslēga", "tags": ["objects", "A1"] },
-    { "source": "деньги", "target": "nauda", "tags": ["objects", "A1"] },
-    { "source": "магазин", "target": "veikals", "tags": ["social", "A1"] },
-    { "source": "школа", "target": "skola", "tags": ["social", "A1"] },
-    { "source": "машина", "target": "auto", "tags": ["travel", "A1"] },
-    { "source": "автобус", "target": "autobuss", "tags": ["travel", "A1"] },
-    { "source": "улица", "target": "iela", "tags": ["travel", "A1"] },
-    { "source": "город", "target": "pilsēta", "tags": ["travel", "A1"] },
-    { "source": "страна", "target": "valsts", "tags": ["travel", "A1"] },
-    { "source": "здесь", "target": "šeit", "tags": ["directions", "A1"] },
-    { "source": "там", "target": "tur", "tags": ["directions", "A1"] },
-    { "source": "направо", "target": "pa labi", "tags": ["directions", "A1"] },
-    { "source": "налево", "target": "pa kreisi", "tags": ["directions", "A1"] },
-    { "source": "прямо", "target": "taisni", "tags": ["directions", "A1"] },
-    { "source": "вверх", "target": "augšā", "tags": ["directions", "A1"] },
-    { "source": "вниз", "target": "lejā", "tags": ["directions", "A1"] },
-    { "source": "день", "target": "diena", "tags": ["time", "A1"] },
-    { "source": "ночь", "target": "nakts", "tags": ["time", "A1"] },
-    { "source": "утро", "target": "rīts", "tags": ["time", "A1"] },
-    { "source": "вечер", "target": "vakars", "tags": ["time", "A1"] },
-    { "source": "сейчас", "target": "tagad", "tags": ["time", "A1"] },
-    { "source": "вчера", "target": "vakar", "tags": ["time", "A1"] },
-    { "source": "завтра", "target": "rīt", "tags": ["time", "A1"] },
-    { "source": "сегодня", "target": "šodien", "tags": ["time", "A1"] },
-    { "source": "неделя", "target": "nedēļa", "tags": ["time", "A1"] },
-    { "source": "месяц", "target": "mēnesis", "tags": ["time", "A1"] },
-    { "source": "год", "target": "gads", "tags": ["time", "A1"] },
-    { "source": "голова", "target": "galva", "tags": ["body", "A1"] },
-    { "source": "рука", "target": "roka", "tags": ["body", "A1"] },
-    { "source": "нога", "target": "kāja", "tags": ["body", "A1"] },
-    { "source": "глаза", "target": "acis", "tags": ["body", "A1"] },
-    { "source": "уши", "target": "ausis", "tags": ["body", "A1"] },
-    { "source": "нос", "target": "deguns", "tags": ["body", "A1"] },
-    { "source": "рот", "target": "mute", "tags": ["body", "A1"] },
-    { "source": "сердце", "target": "sirds", "tags": ["body", "A1"] }
+    {
+      "source": "привет",
+      "target": "sveiki",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "пока",
+      "target": "čau",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "до свидания",
+      "target": "ardievu",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "пожалуйста",
+      "target": "lūdzu",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "спасибо",
+      "target": "paldies",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "да",
+      "target": "jā",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "нет",
+      "target": "nē",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "извините",
+      "target": "piedodiet",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "доброе утро",
+      "target": "labrīt",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "добрый день",
+      "target": "labdien",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "добрый вечер",
+      "target": "labvakar",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "до встречи",
+      "target": "uz redzēšanos",
+      "tags": ["greetings", "A1"]
+    },
+    {
+      "source": "один",
+      "target": "viens",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "два",
+      "target": "divi",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "три",
+      "target": "trīs",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "четыре",
+      "target": "četri",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "пять",
+      "target": "pieci",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "шесть",
+      "target": "seši",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "семь",
+      "target": "septiņi",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "восемь",
+      "target": "astoņi",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "девять",
+      "target": "deviņi",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "десять",
+      "target": "desmit",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "одиннадцать",
+      "target": "vienpadsmit",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "двенадцать",
+      "target": "divpadsmit",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "тринадцать",
+      "target": "trīspadsmit",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "четырнадцать",
+      "target": "četrpadsmit",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "пятнадцать",
+      "target": "piecpadsmit",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "шестнадцать",
+      "target": "sešpadsmit",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "семнадцать",
+      "target": "septiņpadsmit",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "восемнадцать",
+      "target": "astoņpadsmit",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "девятнадцать",
+      "target": "deviņpadsmit",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "двадцать",
+      "target": "divdesmit",
+      "tags": ["numbers", "A1"]
+    },
+    {
+      "source": "красный",
+      "target": "sarkans",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "синий",
+      "target": "zils",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "зелёный",
+      "target": "zaļš",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "жёлтый",
+      "target": "dzeltens",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "белый",
+      "target": "balts",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "чёрный",
+      "target": "melns",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "оранжевый",
+      "target": "oranžs",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "розовый",
+      "target": "rozā",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "фиолетовый",
+      "target": "violets",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "коричневый",
+      "target": "brūns",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "серый",
+      "target": "pelēks",
+      "tags": ["colours", "A1"]
+    },
+    {
+      "source": "мама",
+      "target": "māte",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "папа",
+      "target": "tēvs",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "сестра",
+      "target": "māsa",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "брат",
+      "target": "brālis",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "бабушка",
+      "target": "vecāmāte",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "дедушка",
+      "target": "vectēvs",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "ребёнок",
+      "target": "bērns",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "сын",
+      "target": "dēls",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "дочь",
+      "target": "meita",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "муж",
+      "target": "vīrs",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "жена",
+      "target": "sieva",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "семья",
+      "target": "ģimene",
+      "tags": ["family", "A1"]
+    },
+    {
+      "source": "вода",
+      "target": "ūdens",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "молоко",
+      "target": "piens",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "хлеб",
+      "target": "maize",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "яйцо",
+      "target": "ola",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "яблоко",
+      "target": "ābols",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "банан",
+      "target": "banāns",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "кофе",
+      "target": "kafija",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "чай",
+      "target": "tēja",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "сыр",
+      "target": "siers",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "мясо",
+      "target": "gaļa",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "рис",
+      "target": "rīsi",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "сахар",
+      "target": "cukurs",
+      "tags": ["food-drink", "A1"]
+    },
+    {
+      "source": "понедельник",
+      "target": "pirmdiena",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "вторник",
+      "target": "otrdiena",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "среда",
+      "target": "trešdiena",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "четверг",
+      "target": "ceturtdiena",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "пятница",
+      "target": "piektdiena",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "суббота",
+      "target": "sestdiena",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "воскресенье",
+      "target": "svētdiena",
+      "tags": ["days", "A1"]
+    },
+    {
+      "source": "январь",
+      "target": "janvāris",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "февраль",
+      "target": "februāris",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "март",
+      "target": "marts",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "апрель",
+      "target": "aprīlis",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "май",
+      "target": "maijs",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "июнь",
+      "target": "jūnijs",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "июль",
+      "target": "jūlijs",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "август",
+      "target": "augusts",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "сентябрь",
+      "target": "septembris",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "октябрь",
+      "target": "oktobris",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "ноябрь",
+      "target": "novembris",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "декабрь",
+      "target": "decembris",
+      "tags": ["months", "A1"]
+    },
+    {
+      "source": "быть",
+      "target": "būt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "иметь",
+      "target": "piederēt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "идти",
+      "target": "iet",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "хотеть",
+      "target": "gribēt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "любить",
+      "target": "patikt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "прийти",
+      "target": "nākt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "видеть",
+      "target": "redzēt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "слышать",
+      "target": "dzirdēt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "есть",
+      "target": "ēst",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "пить",
+      "target": "dzert",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "спать",
+      "target": "gulēt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "сидеть",
+      "target": "sēdēt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "стоять",
+      "target": "stāvēt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "говорить",
+      "target": "runāt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "дать",
+      "target": "dot",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "взять",
+      "target": "ņemt",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "смотреть",
+      "target": "skatīties",
+      "tags": ["verbs", "A1"]
+    },
+    {
+      "source": "хороший",
+      "target": "labs",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "плохой",
+      "target": "slikts",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "большой",
+      "target": "liels",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "маленький",
+      "target": "mazs",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "горячий",
+      "target": "karsts",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "холодный",
+      "target": "auksts",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "новый",
+      "target": "jauns",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "старый",
+      "target": "vecs",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "длинный",
+      "target": "garš",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "короткий",
+      "target": "īss",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "высокий",
+      "target": "augsts",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "низкий",
+      "target": "zems",
+      "tags": ["adjectives", "A1"]
+    },
+    {
+      "source": "я",
+      "target": "es",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "ты",
+      "target": "tu",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "он",
+      "target": "viņš",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "она",
+      "target": "viņa",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "мы",
+      "target": "mēs",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "они",
+      "target": "viņi",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "оно",
+      "target": "tas",
+      "tags": ["pronouns", "A1"]
+    },
+    {
+      "source": "дом",
+      "target": "māja",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "комната",
+      "target": "istaba",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "дверь",
+      "target": "durvis",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "окно",
+      "target": "logs",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "стол",
+      "target": "galds",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "стул",
+      "target": "krēsls",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "кровать",
+      "target": "gulta",
+      "tags": ["home", "A1"]
+    },
+    {
+      "source": "человек",
+      "target": "cilvēks",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "мужчина",
+      "target": "vīrietis",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "женщина",
+      "target": "sieviete",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "мальчик",
+      "target": "zēns",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "девочка",
+      "target": "meitene",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "друг",
+      "target": "draugs",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "имя",
+      "target": "vārds",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "возраст",
+      "target": "vecums",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "животное",
+      "target": "dzīvnieks",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "собака",
+      "target": "suns",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "кошка",
+      "target": "kaķis",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "птица",
+      "target": "putns",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "рыба",
+      "target": "zivs",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "дерево",
+      "target": "koks",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "цветок",
+      "target": "puķe",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "солнце",
+      "target": "saule",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "дождь",
+      "target": "lietus",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "снег",
+      "target": "sniegs",
+      "tags": ["nature", "A1"]
+    },
+    {
+      "source": "телефон",
+      "target": "telefons",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "книга",
+      "target": "grāmata",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "ручка",
+      "target": "pildspalva",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "сумка",
+      "target": "soma",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "ключ",
+      "target": "atslēga",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "деньги",
+      "target": "nauda",
+      "tags": ["objects", "A1"]
+    },
+    {
+      "source": "магазин",
+      "target": "veikals",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "школа",
+      "target": "skola",
+      "tags": ["social", "A1"]
+    },
+    {
+      "source": "машина",
+      "target": "auto",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "автобус",
+      "target": "autobuss",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "улица",
+      "target": "iela",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "город",
+      "target": "pilsēta",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "страна",
+      "target": "valsts",
+      "tags": ["travel", "A1"]
+    },
+    {
+      "source": "здесь",
+      "target": "šeit",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "там",
+      "target": "tur",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "направо",
+      "target": "pa labi",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "налево",
+      "target": "pa kreisi",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "прямо",
+      "target": "taisni",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "вверх",
+      "target": "augšā",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "вниз",
+      "target": "lejā",
+      "tags": ["directions", "A1"]
+    },
+    {
+      "source": "день",
+      "target": "diena",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "ночь",
+      "target": "nakts",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "утро",
+      "target": "rīts",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "вечер",
+      "target": "vakars",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "сейчас",
+      "target": "tagad",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "вчера",
+      "target": "vakar",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "завтра",
+      "target": "rīt",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "сегодня",
+      "target": "šodien",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "неделя",
+      "target": "nedēļa",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "месяц",
+      "target": "mēnesis",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "год",
+      "target": "gads",
+      "tags": ["time", "A1"]
+    },
+    {
+      "source": "голова",
+      "target": "galva",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "рука",
+      "target": "roka",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "нога",
+      "target": "kāja",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "глаза",
+      "target": "acis",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "уши",
+      "target": "ausis",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "нос",
+      "target": "deguns",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "рот",
+      "target": "mute",
+      "tags": ["body", "A1"]
+    },
+    {
+      "source": "сердце",
+      "target": "sirds",
+      "tags": ["body", "A1"]
+    }
   ]
 }

--- a/public/starter-packs/ru-lv-a2.json
+++ b/public/starter-packs/ru-lv-a2.json
@@ -6,149 +6,690 @@
   "targetCode": "lv",
   "level": "A2",
   "words": [
-    { "source": "покупки", "target": "iepirkšanās", "tags": ["shopping", "A2"] },
-    { "source": "магазин", "target": "veikals", "tags": ["shopping", "A2"] },
-    { "source": "цена", "target": "cena", "tags": ["shopping", "A2"] },
-    { "source": "дешёвый", "target": "lēts", "tags": ["shopping", "A2"] },
-    { "source": "дорогой", "target": "dārgs", "tags": ["shopping", "A2"] },
-    { "source": "деньги", "target": "nauda", "tags": ["shopping", "A2"] },
-    { "source": "чек", "target": "čeks", "tags": ["shopping", "A2"] },
-    { "source": "скидка", "target": "atlaide", "tags": ["shopping", "A2"] },
-    { "source": "размер", "target": "izmērs", "tags": ["shopping", "A2"] },
-    { "source": "коробка", "target": "kaste", "tags": ["shopping", "A2"] },
-    { "source": "пакет", "target": "maiss", "tags": ["shopping", "A2"] },
-    { "source": "очередь", "target": "rinda", "tags": ["shopping", "A2"] },
-    { "source": "дорога", "target": "ceļš", "tags": ["directions", "A2"] },
-    { "source": "угол", "target": "stūris", "tags": ["directions", "A2"] },
-    { "source": "перекрёсток", "target": "krustojums", "tags": ["directions", "A2"] },
-    { "source": "мост", "target": "tilts", "tags": ["directions", "A2"] },
-    { "source": "вокзал", "target": "stacija", "tags": ["directions", "A2"] },
-    { "source": "остановка", "target": "pietura", "tags": ["directions", "A2"] },
-    { "source": "рядом", "target": "netālu", "tags": ["directions", "A2"] },
-    { "source": "далеко", "target": "tālu", "tags": ["directions", "A2"] },
-    { "source": "за", "target": "aiz", "tags": ["directions", "A2"] },
-    { "source": "перед", "target": "priekšā", "tags": ["directions", "A2"] },
-    { "source": "рядом с", "target": "blakus", "tags": ["directions", "A2"] },
-    { "source": "погода", "target": "laiks", "tags": ["weather", "A2"] },
-    { "source": "солнечный", "target": "saulains", "tags": ["weather", "A2"] },
-    { "source": "облачный", "target": "mākoņains", "tags": ["weather", "A2"] },
-    { "source": "дождливый", "target": "lietains", "tags": ["weather", "A2"] },
-    { "source": "ветреный", "target": "vējaini", "tags": ["weather", "A2"] },
-    { "source": "снежный", "target": "sniegains", "tags": ["weather", "A2"] },
-    { "source": "тёплый", "target": "silts", "tags": ["weather", "A2"] },
-    { "source": "холодный", "target": "auksts", "tags": ["weather", "A2"] },
-    { "source": "гром", "target": "pērkons", "tags": ["weather", "A2"] },
-    { "source": "молния", "target": "zibens", "tags": ["weather", "A2"] },
-    { "source": "больной", "target": "slims", "tags": ["health", "A2"] },
-    { "source": "головная боль", "target": "galvassāpes", "tags": ["health", "A2"] },
-    { "source": "жар", "target": "drudzis", "tags": ["health", "A2"] },
-    { "source": "кашель", "target": "klepus", "tags": ["health", "A2"] },
-    { "source": "насморк", "target": "iesnas", "tags": ["health", "A2"] },
-    { "source": "боль", "target": "sāpes", "tags": ["health", "A2"] },
-    { "source": "врач", "target": "ārsts", "tags": ["health", "A2"] },
-    { "source": "лекарство", "target": "zāles", "tags": ["health", "A2"] },
-    { "source": "больница", "target": "slimnīca", "tags": ["health", "A2"] },
-    { "source": "аптека", "target": "aptieka", "tags": ["health", "A2"] },
-    { "source": "здоровый", "target": "vesels", "tags": ["health", "A2"] },
-    { "source": "заниматься спортом", "target": "sportot", "tags": ["hobbies", "A2"] },
-    { "source": "читать", "target": "lasīt", "tags": ["hobbies", "A2"] },
-    { "source": "слушать музыку", "target": "klausīties mūziku", "tags": ["hobbies", "A2"] },
-    { "source": "смотреть телевизор", "target": "skatīties televizoru", "tags": ["hobbies", "A2"] },
-    { "source": "путешествовать", "target": "ceļot", "tags": ["hobbies", "A2"] },
-    { "source": "готовить", "target": "gatavot", "tags": ["hobbies", "A2"] },
-    { "source": "рисовать", "target": "zīmēt", "tags": ["hobbies", "A2"] },
-    { "source": "фотографировать", "target": "fotografēt", "tags": ["hobbies", "A2"] },
-    { "source": "играть", "target": "spēlēt", "tags": ["hobbies", "A2"] },
-    { "source": "танцевать", "target": "dejot", "tags": ["hobbies", "A2"] },
-    { "source": "петь", "target": "dziedāt", "tags": ["hobbies", "A2"] },
-    { "source": "плавать", "target": "peldēties", "tags": ["hobbies", "A2"] },
+    {
+      "source": "покупки",
+      "target": "iepirkšanās",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "цена",
+      "target": "cena",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "дешёвый",
+      "target": "lēts",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "дорогой",
+      "target": "dārgs",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "чек",
+      "target": "čeks",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "скидка",
+      "target": "atlaide",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "размер",
+      "target": "izmērs",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "коробка",
+      "target": "kaste",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "пакет",
+      "target": "maiss",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "очередь",
+      "target": "rinda",
+      "tags": ["shopping", "A2"]
+    },
+    {
+      "source": "дорога",
+      "target": "ceļš",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "угол",
+      "target": "stūris",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "перекрёсток",
+      "target": "krustojums",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "мост",
+      "target": "tilts",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "вокзал",
+      "target": "stacija",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "остановка",
+      "target": "pietura",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "рядом",
+      "target": "netālu",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "далеко",
+      "target": "tālu",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "за",
+      "target": "aiz",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "перед",
+      "target": "priekšā",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "рядом с",
+      "target": "blakus",
+      "tags": ["directions", "A2"]
+    },
+    {
+      "source": "погода",
+      "target": "laiks",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "солнечный",
+      "target": "saulains",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "облачный",
+      "target": "mākoņains",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "дождливый",
+      "target": "lietains",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "ветреный",
+      "target": "vējaini",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "снежный",
+      "target": "sniegains",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "тёплый",
+      "target": "silts",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "гром",
+      "target": "pērkons",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "молния",
+      "target": "zibens",
+      "tags": ["weather", "A2"]
+    },
+    {
+      "source": "больной",
+      "target": "slims",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "головная боль",
+      "target": "galvassāpes",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "жар",
+      "target": "drudzis",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "кашель",
+      "target": "klepus",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "насморк",
+      "target": "iesnas",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "боль",
+      "target": "sāpes",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "врач",
+      "target": "ārsts",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "лекарство",
+      "target": "zāles",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "больница",
+      "target": "slimnīca",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "аптека",
+      "target": "aptieka",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "здоровый",
+      "target": "vesels",
+      "tags": ["health", "A2"]
+    },
+    {
+      "source": "заниматься спортом",
+      "target": "sportot",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "читать",
+      "target": "lasīt",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "слушать музыку",
+      "target": "klausīties mūziku",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "смотреть телевизор",
+      "target": "skatīties televizoru",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "путешествовать",
+      "target": "ceļot",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "готовить",
+      "target": "gatavot",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "рисовать",
+      "target": "zīmēt",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "фотографировать",
+      "target": "fotografēt",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "играть",
+      "target": "spēlēt",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "танцевать",
+      "target": "dejot",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "петь",
+      "target": "dziedāt",
+      "tags": ["hobbies", "A2"]
+    },
+    {
+      "source": "плавать",
+      "target": "peldēties",
+      "tags": ["hobbies", "A2"]
+    },
     {
       "source": "ездить на велосипеде",
       "target": "braukt ar velosipēdu",
       "tags": ["hobbies", "A2"]
     },
-    { "source": "интересный", "target": "interesants", "tags": ["adjectives", "A2"] },
-    { "source": "скучный", "target": "garlaicīgs", "tags": ["adjectives", "A2"] },
-    { "source": "весёлый", "target": "jautrs", "tags": ["adjectives", "A2"] },
-    { "source": "захватывающий", "target": "aizraujošs", "tags": ["adjectives", "A2"] },
-    { "source": "трудный", "target": "grūts", "tags": ["adjectives", "A2"] },
-    { "source": "лёгкий", "target": "viegls", "tags": ["adjectives", "A2"] },
-    { "source": "дружелюбный", "target": "draudzīgs", "tags": ["adjectives", "A2"] },
-    { "source": "умный", "target": "gudrs", "tags": ["adjectives", "A2"] },
-    { "source": "глупый", "target": "muļķīgs", "tags": ["adjectives", "A2"] },
-    { "source": "добрый", "target": "laipns", "tags": ["adjectives", "A2"] },
-    { "source": "честный", "target": "godīgs", "tags": ["adjectives", "A2"] },
-    { "source": "счастливый", "target": "laimīgs", "tags": ["adjectives", "A2"] },
-    { "source": "грустный", "target": "skumīgs", "tags": ["adjectives", "A2"] },
-    { "source": "усталый", "target": "noguris", "tags": ["adjectives", "A2"] },
-    { "source": "голодный", "target": "izsalcis", "tags": ["adjectives", "A2"] },
-    { "source": "жаждущий", "target": "izslāpis", "tags": ["adjectives", "A2"] },
-    { "source": "испуганный", "target": "nobijies", "tags": ["adjectives", "A2"] },
-    { "source": "удивлённый", "target": "pārsteigts", "tags": ["adjectives", "A2"] },
-    { "source": "одежда", "target": "apģērbs", "tags": ["clothing", "A2"] },
-    { "source": "рубашка", "target": "krekls", "tags": ["clothing", "A2"] },
-    { "source": "брюки", "target": "bikses", "tags": ["clothing", "A2"] },
-    { "source": "платье", "target": "kleita", "tags": ["clothing", "A2"] },
-    { "source": "куртка", "target": "jaka", "tags": ["clothing", "A2"] },
-    { "source": "туфли", "target": "kurpes", "tags": ["clothing", "A2"] },
-    { "source": "шляпа", "target": "cepure", "tags": ["clothing", "A2"] },
-    { "source": "носки", "target": "zeķes", "tags": ["clothing", "A2"] },
-    { "source": "свитер", "target": "džemperis", "tags": ["clothing", "A2"] },
-    { "source": "пальто", "target": "mētelis", "tags": ["clothing", "A2"] },
-    { "source": "кафе", "target": "kafejnīca", "tags": ["food-drink", "A2"] },
-    { "source": "меню", "target": "ēdienkarte", "tags": ["food-drink", "A2"] },
-    { "source": "заказать", "target": "pasūtīt", "tags": ["food-drink", "A2"] },
-    { "source": "варёный", "target": "vārīts", "tags": ["food-drink", "A2"] },
-    { "source": "жареный", "target": "cepts", "tags": ["food-drink", "A2"] },
-    { "source": "свежий", "target": "svaigs", "tags": ["food-drink", "A2"] },
-    { "source": "сладкий", "target": "salds", "tags": ["food-drink", "A2"] },
-    { "source": "кислый", "target": "skābs", "tags": ["food-drink", "A2"] },
-    { "source": "солёный", "target": "sāļš", "tags": ["food-drink", "A2"] },
-    { "source": "острый", "target": "ass", "tags": ["food-drink", "A2"] },
-    { "source": "сок", "target": "sula", "tags": ["food-drink", "A2"] },
-    { "source": "основное блюдо", "target": "otrais ēdiens", "tags": ["food-drink", "A2"] },
-    { "source": "десерт", "target": "deserts", "tags": ["food-drink", "A2"] },
-    { "source": "раньше", "target": "agrāk", "tags": ["time", "A2"] },
-    { "source": "позже", "target": "vēlāk", "tags": ["time", "A2"] },
-    { "source": "часто", "target": "bieži", "tags": ["time", "A2"] },
-    { "source": "иногда", "target": "dažreiz", "tags": ["time", "A2"] },
-    { "source": "никогда", "target": "nekad", "tags": ["time", "A2"] },
-    { "source": "всегда", "target": "vienmēr", "tags": ["time", "A2"] },
-    { "source": "скоро", "target": "drīz", "tags": ["time", "A2"] },
-    { "source": "ещё", "target": "vēl", "tags": ["time", "A2"] },
-    { "source": "уже", "target": "jau", "tags": ["time", "A2"] },
-    { "source": "сосед", "target": "kaimiņš", "tags": ["social", "A2"] },
-    { "source": "одноклассник", "target": "klasesbiedrs", "tags": ["social", "A2"] },
-    { "source": "знакомый", "target": "paziņa", "tags": ["social", "A2"] },
-    { "source": "коллега", "target": "kolēģis", "tags": ["social", "A2"] },
-    { "source": "учитель", "target": "skolotājs", "tags": ["social", "A2"] },
-    { "source": "студент", "target": "students", "tags": ["social", "A2"] },
-    { "source": "иностранный язык", "target": "svešvaloda", "tags": ["social", "A2"] },
-    { "source": "слово", "target": "vārds", "tags": ["social", "A2"] },
-    { "source": "язык", "target": "valoda", "tags": ["social", "A2"] },
-    { "source": "число", "target": "skaitlis", "tags": ["social", "A2"] },
-    { "source": "письмо", "target": "vēstule", "tags": ["social", "A2"] },
-    { "source": "адрес", "target": "adrese", "tags": ["social", "A2"] },
-    { "source": "телефон", "target": "tālrunis", "tags": ["objects", "A2"] },
-    { "source": "компьютер", "target": "dators", "tags": ["objects", "A2"] },
-    { "source": "часы", "target": "pulkstenis", "tags": ["objects", "A2"] },
-    { "source": "картина", "target": "bilde", "tags": ["objects", "A2"] },
-    { "source": "музыка", "target": "mūzika", "tags": ["objects", "A2"] },
-    { "source": "фильм", "target": "filma", "tags": ["objects", "A2"] },
-    { "source": "ехать", "target": "braukt", "tags": ["verbs", "A2"] },
-    { "source": "работать", "target": "strādāt", "tags": ["verbs", "A2"] },
-    { "source": "учиться", "target": "mācīties", "tags": ["verbs", "A2"] },
-    { "source": "спрашивать", "target": "jautāt", "tags": ["verbs", "A2"] },
-    { "source": "отвечать", "target": "atbildēt", "tags": ["verbs", "A2"] },
-    { "source": "обещать", "target": "apsolīt", "tags": ["verbs", "A2"] },
-    { "source": "забывать", "target": "aizmirst", "tags": ["verbs", "A2"] },
-    { "source": "помнить", "target": "atcerēties", "tags": ["verbs", "A2"] },
-    { "source": "ждать", "target": "gaidīt", "tags": ["verbs", "A2"] },
-    { "source": "найти", "target": "atrast", "tags": ["verbs", "A2"] },
-    { "source": "потерять", "target": "pazaudēt", "tags": ["verbs", "A2"] },
-    { "source": "изменить", "target": "mainīt", "tags": ["verbs", "A2"] },
-    { "source": "вернуться", "target": "atgriezties", "tags": ["verbs", "A2"] },
-    { "source": "начать", "target": "sākt", "tags": ["verbs", "A2"] },
-    { "source": "закончить", "target": "beigt", "tags": ["verbs", "A2"] }
+    {
+      "source": "интересный",
+      "target": "interesants",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "скучный",
+      "target": "garlaicīgs",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "весёлый",
+      "target": "jautrs",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "захватывающий",
+      "target": "aizraujošs",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "трудный",
+      "target": "grūts",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "лёгкий",
+      "target": "viegls",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "дружелюбный",
+      "target": "draudzīgs",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "умный",
+      "target": "gudrs",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "глупый",
+      "target": "muļķīgs",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "добрый",
+      "target": "laipns",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "честный",
+      "target": "godīgs",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "счастливый",
+      "target": "laimīgs",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "грустный",
+      "target": "skumīgs",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "усталый",
+      "target": "noguris",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "голодный",
+      "target": "izsalcis",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "жаждущий",
+      "target": "izslāpis",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "испуганный",
+      "target": "nobijies",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "удивлённый",
+      "target": "pārsteigts",
+      "tags": ["adjectives", "A2"]
+    },
+    {
+      "source": "одежда",
+      "target": "apģērbs",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "рубашка",
+      "target": "krekls",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "брюки",
+      "target": "bikses",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "платье",
+      "target": "kleita",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "куртка",
+      "target": "jaka",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "туфли",
+      "target": "kurpes",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "шляпа",
+      "target": "cepure",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "носки",
+      "target": "zeķes",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "свитер",
+      "target": "džemperis",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "пальто",
+      "target": "mētelis",
+      "tags": ["clothing", "A2"]
+    },
+    {
+      "source": "кафе",
+      "target": "kafejnīca",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "меню",
+      "target": "ēdienkarte",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "заказать",
+      "target": "pasūtīt",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "варёный",
+      "target": "vārīts",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "жареный",
+      "target": "cepts",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "свежий",
+      "target": "svaigs",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "сладкий",
+      "target": "salds",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "кислый",
+      "target": "skābs",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "солёный",
+      "target": "sāļš",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "острый",
+      "target": "ass",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "сок",
+      "target": "sula",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "основное блюдо",
+      "target": "otrais ēdiens",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "десерт",
+      "target": "deserts",
+      "tags": ["food-drink", "A2"]
+    },
+    {
+      "source": "раньше",
+      "target": "agrāk",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "позже",
+      "target": "vēlāk",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "часто",
+      "target": "bieži",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "иногда",
+      "target": "dažreiz",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "никогда",
+      "target": "nekad",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "всегда",
+      "target": "vienmēr",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "скоро",
+      "target": "drīz",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "ещё",
+      "target": "vēl",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "уже",
+      "target": "jau",
+      "tags": ["time", "A2"]
+    },
+    {
+      "source": "сосед",
+      "target": "kaimiņš",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "одноклассник",
+      "target": "klasesbiedrs",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "знакомый",
+      "target": "paziņa",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "коллега",
+      "target": "kolēģis",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "учитель",
+      "target": "skolotājs",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "студент",
+      "target": "students",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "иностранный язык",
+      "target": "svešvaloda",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "слово",
+      "target": "vārds",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "язык",
+      "target": "valoda",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "число",
+      "target": "skaitlis",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "письмо",
+      "target": "vēstule",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "адрес",
+      "target": "adrese",
+      "tags": ["social", "A2"]
+    },
+    {
+      "source": "телефон",
+      "target": "tālrunis",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "компьютер",
+      "target": "dators",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "часы",
+      "target": "pulkstenis",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "картина",
+      "target": "bilde",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "музыка",
+      "target": "mūzika",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "фильм",
+      "target": "filma",
+      "tags": ["objects", "A2"]
+    },
+    {
+      "source": "ехать",
+      "target": "braukt",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "работать",
+      "target": "strādāt",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "учиться",
+      "target": "mācīties",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "спрашивать",
+      "target": "jautāt",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "отвечать",
+      "target": "atbildēt",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "обещать",
+      "target": "apsolīt",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "забывать",
+      "target": "aizmirst",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "помнить",
+      "target": "atcerēties",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "ждать",
+      "target": "gaidīt",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "найти",
+      "target": "atrast",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "потерять",
+      "target": "pazaudēt",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "изменить",
+      "target": "mainīt",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "вернуться",
+      "target": "atgriezties",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "начать",
+      "target": "sākt",
+      "tags": ["verbs", "A2"]
+    },
+    {
+      "source": "закончить",
+      "target": "beigt",
+      "tags": ["verbs", "A2"]
+    }
   ]
 }

--- a/public/starter-packs/ru-lv-b1.json
+++ b/public/starter-packs/ru-lv-b1.json
@@ -6,223 +6,610 @@
   "targetCode": "lv",
   "level": "B1",
   "words": [
-    { "source": "книга", "target": "grāmata", "tags": ["objects", "B1"] },
-    { "source": "вода", "target": "ūdens", "tags": ["food-drink", "B1"] },
-    { "source": "хлеб", "target": "maize", "tags": ["food-drink", "B1"] },
-    { "source": "мясо", "target": "gaļa", "tags": ["food-drink", "B1"] },
-    { "source": "молоко", "target": "piens", "tags": ["food-drink", "B1"] },
-    { "source": "яйцо", "target": "ola", "tags": ["food-drink", "B1"] },
-    { "source": "сыр", "target": "siers", "tags": ["food-drink", "B1"] },
-    { "source": "масло", "target": "sviests", "tags": ["food-drink", "B1"] },
-    { "source": "фрукт", "target": "auglis", "tags": ["food-drink", "B1"] },
-    { "source": "овощ", "target": "dārzenis", "tags": ["food-drink", "B1"] },
-    { "source": "яблоко", "target": "ābols", "tags": ["food-drink", "B1"] },
-    { "source": "банан", "target": "banāns", "tags": ["food-drink", "B1"] },
-    { "source": "апельсин", "target": "apelsīns", "tags": ["food-drink", "B1"] },
-    { "source": "помидор", "target": "tomāts", "tags": ["food-drink", "B1"] },
-    { "source": "картофель", "target": "kartupelis", "tags": ["food-drink", "B1"] },
-    { "source": "кофе", "target": "kafija", "tags": ["food-drink", "B1"] },
-    { "source": "чай", "target": "tēja", "tags": ["food-drink", "B1"] },
-    { "source": "пиво", "target": "alus", "tags": ["food-drink", "B1"] },
-    { "source": "сахар", "target": "cukurs", "tags": ["food-drink", "B1"] },
-    { "source": "соль", "target": "sāls", "tags": ["food-drink", "B1"] },
-    { "source": "рис", "target": "rīsi", "tags": ["food-drink", "B1"] },
-    { "source": "суп", "target": "zupa", "tags": ["food-drink", "B1"] },
-    { "source": "салат", "target": "salāti", "tags": ["food-drink", "B1"] },
-    { "source": "обед", "target": "pusdienas", "tags": ["food-drink", "B1"] },
-    { "source": "ужин", "target": "vakariņas", "tags": ["food-drink", "B1"] },
-    { "source": "завтрак", "target": "brokastis", "tags": ["food-drink", "B1"] },
-    { "source": "ресторан", "target": "restorāns", "tags": ["food-drink", "travel", "B1"] },
-    { "source": "гостиница", "target": "viesnīca", "tags": ["travel", "B1"] },
-    { "source": "аэропорт", "target": "lidosta", "tags": ["travel", "B1"] },
-    { "source": "самолёт", "target": "lidmašīna", "tags": ["travel", "B1"] },
-    { "source": "поезд", "target": "vilciens", "tags": ["travel", "B1"] },
-    { "source": "автобус", "target": "autobuss", "tags": ["travel", "B1"] },
-    { "source": "машина", "target": "auto", "tags": ["travel", "B1"] },
-    { "source": "билет", "target": "biļete", "tags": ["travel", "B1"] },
-    { "source": "паспорт", "target": "pase", "tags": ["travel", "B1"] },
-    { "source": "карта", "target": "karte", "tags": ["travel", "B1"] },
-    { "source": "улица", "target": "iela", "tags": ["travel", "B1"] },
-    { "source": "город", "target": "pilsēta", "tags": ["travel", "B1"] },
-    { "source": "страна", "target": "valsts", "tags": ["travel", "B1"] },
-    { "source": "багаж", "target": "bagāža", "tags": ["travel", "B1"] },
-    { "source": "работа", "target": "darbs", "tags": ["work", "B1"] },
-    { "source": "офис", "target": "birojs", "tags": ["work", "B1"] },
-    { "source": "встреча", "target": "sanāksme", "tags": ["work", "B1"] },
-    { "source": "коллега", "target": "kolēģis", "tags": ["work", "B1"] },
-    { "source": "начальник", "target": "priekšnieks", "tags": ["work", "B1"] },
-    { "source": "отпуск", "target": "atvaļinājums", "tags": ["work", "travel", "B1"] },
-    { "source": "радость", "target": "prieks", "tags": ["emotions", "B1"] },
-    { "source": "грусть", "target": "skumjas", "tags": ["emotions", "B1"] },
-    { "source": "страх", "target": "bailes", "tags": ["emotions", "B1"] },
-    { "source": "злость", "target": "dusmas", "tags": ["emotions", "B1"] },
-    { "source": "удивление", "target": "pārsteigums", "tags": ["emotions", "B1"] },
-    { "source": "любовь", "target": "mīlestība", "tags": ["emotions", "B1"] },
-    { "source": "волнение", "target": "uztraukums", "tags": ["emotions", "B1"] },
-    { "source": "лес", "target": "mežs", "tags": ["nature", "B1"] },
-    { "source": "море", "target": "jūra", "tags": ["nature", "B1"] },
-    { "source": "озеро", "target": "ezers", "tags": ["nature", "B1"] },
-    { "source": "река", "target": "upe", "tags": ["nature", "B1"] },
-    { "source": "гора", "target": "kalns", "tags": ["nature", "B1"] },
-    { "source": "деревня", "target": "lauki", "tags": ["nature", "B1"] },
-    { "source": "солнце", "target": "saule", "tags": ["nature", "B1"] },
-    { "source": "луна", "target": "mēness", "tags": ["nature", "B1"] },
-    { "source": "звезда", "target": "zvaigzne", "tags": ["nature", "B1"] },
-    { "source": "дождь", "target": "lietus", "tags": ["nature", "B1"] },
-    { "source": "снег", "target": "sniegs", "tags": ["nature", "B1"] },
-    { "source": "ветер", "target": "vējš", "tags": ["nature", "B1"] },
-    { "source": "облака", "target": "mākoņi", "tags": ["nature", "B1"] },
-    { "source": "зима", "target": "ziema", "tags": ["nature", "B1"] },
-    { "source": "лето", "target": "vasara", "tags": ["nature", "B1"] },
-    { "source": "весна", "target": "pavasaris", "tags": ["nature", "B1"] },
-    { "source": "осень", "target": "rudens", "tags": ["nature", "B1"] },
-    { "source": "дерево", "target": "koks", "tags": ["nature", "B1"] },
-    { "source": "цветок", "target": "puķe", "tags": ["nature", "B1"] },
-    { "source": "трава", "target": "zāle", "tags": ["nature", "B1"] },
-    { "source": "комната", "target": "istaba", "tags": ["home", "B1"] },
-    { "source": "кухня", "target": "virtuve", "tags": ["home", "B1"] },
-    { "source": "спальня", "target": "guļamistaba", "tags": ["home", "B1"] },
-    { "source": "ванная", "target": "vannas istaba", "tags": ["home", "B1"] },
-    { "source": "гостиная", "target": "viesistaba", "tags": ["home", "B1"] },
-    { "source": "дверь", "target": "durvis", "tags": ["home", "B1"] },
-    { "source": "окно", "target": "logs", "tags": ["home", "B1"] },
-    { "source": "стол", "target": "galds", "tags": ["home", "B1"] },
-    { "source": "стул", "target": "krēsls", "tags": ["home", "B1"] },
-    { "source": "диван", "target": "dīvāns", "tags": ["home", "B1"] },
-    { "source": "кровать", "target": "gulta", "tags": ["home", "B1"] },
-    { "source": "подушка", "target": "spilvens", "tags": ["home", "B1"] },
-    { "source": "одеяло", "target": "sega", "tags": ["home", "B1"] },
-    { "source": "зеркало", "target": "spogulis", "tags": ["home", "B1"] },
-    { "source": "лампа", "target": "lampa", "tags": ["home", "B1"] },
-    { "source": "пол", "target": "grīda", "tags": ["home", "B1"] },
-    { "source": "потолок", "target": "griesti", "tags": ["home", "B1"] },
-    { "source": "стена", "target": "siena", "tags": ["home", "B1"] },
-    { "source": "крыша", "target": "jumts", "tags": ["home", "B1"] },
-    { "source": "сад", "target": "dārzs", "tags": ["home", "B1"] },
-    { "source": "голова", "target": "galva", "tags": ["body", "B1"] },
-    { "source": "лицо", "target": "seja", "tags": ["body", "B1"] },
-    { "source": "глаза", "target": "acis", "tags": ["body", "B1"] },
-    { "source": "уши", "target": "ausis", "tags": ["body", "B1"] },
-    { "source": "нос", "target": "deguns", "tags": ["body", "B1"] },
-    { "source": "рот", "target": "mute", "tags": ["body", "B1"] },
-    { "source": "зубы", "target": "zobi", "tags": ["body", "B1"] },
-    { "source": "шея", "target": "kakls", "tags": ["body", "B1"] },
-    { "source": "плечи", "target": "pleci", "tags": ["body", "B1"] },
-    { "source": "рука", "target": "roka", "tags": ["body", "B1"] },
-    { "source": "пальцы", "target": "pirksti", "tags": ["body", "B1"] },
-    { "source": "нога", "target": "kāja", "tags": ["body", "B1"] },
-    { "source": "колено", "target": "celis", "tags": ["body", "B1"] },
-    { "source": "стопа", "target": "pēda", "tags": ["body", "B1"] },
-    { "source": "сердце", "target": "sirds", "tags": ["body", "B1"] },
-    { "source": "день", "target": "diena", "tags": ["time", "B1"] },
-    { "source": "ночь", "target": "nakts", "tags": ["time", "B1"] },
-    { "source": "утро", "target": "rīts", "tags": ["time", "B1"] },
-    { "source": "вечер", "target": "vakars", "tags": ["time", "B1"] },
-    { "source": "неделя", "target": "nedēļa", "tags": ["time", "B1"] },
-    { "source": "месяц", "target": "mēnesis", "tags": ["time", "B1"] },
-    { "source": "год", "target": "gads", "tags": ["time", "B1"] },
-    { "source": "час", "target": "stunda", "tags": ["time", "B1"] },
-    { "source": "минута", "target": "minūte", "tags": ["time", "B1"] },
-    { "source": "секунда", "target": "sekunde", "tags": ["time", "B1"] },
-    { "source": "сейчас", "target": "tagad", "tags": ["time", "B1"] },
-    { "source": "вчера", "target": "vakar", "tags": ["time", "B1"] },
-    { "source": "завтра", "target": "rīt", "tags": ["time", "B1"] },
-    { "source": "говорить", "target": "runāt", "tags": ["verbs", "B1"] },
-    { "source": "слушать", "target": "klausīties", "tags": ["verbs", "B1"] },
-    { "source": "читать", "target": "lasīt", "tags": ["verbs", "B1"] },
-    { "source": "писать", "target": "rakstīt", "tags": ["verbs", "B1"] },
-    { "source": "есть", "target": "ēst", "tags": ["verbs", "B1"] },
-    { "source": "пить", "target": "dzert", "tags": ["verbs", "B1"] },
-    { "source": "спать", "target": "gulēt", "tags": ["verbs", "B1"] },
-    { "source": "идти", "target": "staigāt", "tags": ["verbs", "B1"] },
-    { "source": "бежать", "target": "skriet", "tags": ["verbs", "B1"] },
-    { "source": "работать", "target": "strādāt", "tags": ["verbs", "B1"] },
-    { "source": "играть", "target": "spēlēt", "tags": ["verbs", "B1"] },
-    { "source": "учиться", "target": "mācīties", "tags": ["verbs", "B1"] },
-    { "source": "думать", "target": "domāt", "tags": ["verbs", "B1"] },
-    { "source": "знать", "target": "zināt", "tags": ["verbs", "B1"] },
-    { "source": "понимать", "target": "saprast", "tags": ["verbs", "B1"] },
-    { "source": "отвечать", "target": "atbildēt", "tags": ["verbs", "B1"] },
-    { "source": "спрашивать", "target": "jautāt", "tags": ["verbs", "B1"] },
-    { "source": "помогать", "target": "palīdzēt", "tags": ["verbs", "B1"] },
-    { "source": "покупать", "target": "pirkt", "tags": ["verbs", "B1"] },
-    { "source": "приходить", "target": "nākt", "tags": ["verbs", "B1"] },
-    { "source": "уходить", "target": "iet", "tags": ["verbs", "B1"] },
-    { "source": "возвращаться", "target": "atgriezties", "tags": ["verbs", "B1"] },
-    { "source": "забывать", "target": "aizmirst", "tags": ["verbs", "B1"] },
-    { "source": "помнить", "target": "atcerēties", "tags": ["verbs", "B1"] },
-    { "source": "открывать", "target": "atvērt", "tags": ["verbs", "B1"] },
-    { "source": "закрывать", "target": "aizvērt", "tags": ["verbs", "B1"] },
-    { "source": "хороший", "target": "labs", "tags": ["adjectives", "B1"] },
-    { "source": "плохой", "target": "slikts", "tags": ["adjectives", "B1"] },
-    { "source": "большой", "target": "liels", "tags": ["adjectives", "B1"] },
-    { "source": "маленький", "target": "mazs", "tags": ["adjectives", "B1"] },
-    { "source": "новый", "target": "jauns", "tags": ["adjectives", "B1"] },
-    { "source": "старый", "target": "vecs", "tags": ["adjectives", "B1"] },
-    { "source": "быстрый", "target": "ātrs", "tags": ["adjectives", "B1"] },
-    { "source": "медленный", "target": "lēns", "tags": ["adjectives", "B1"] },
-    { "source": "горячий", "target": "karsts", "tags": ["adjectives", "B1"] },
-    { "source": "холодный", "target": "auksts", "tags": ["adjectives", "B1"] },
-    { "source": "красивый", "target": "skaists", "tags": ["adjectives", "B1"] },
-    { "source": "некрасивый", "target": "neglīts", "tags": ["adjectives", "B1"] },
-    { "source": "сильный", "target": "stiprs", "tags": ["adjectives", "B1"] },
-    { "source": "слабый", "target": "vājš", "tags": ["adjectives", "B1"] },
-    { "source": "важный", "target": "svarīgs", "tags": ["adjectives", "B1"] },
-    { "source": "интересный", "target": "interesants", "tags": ["adjectives", "B1"] },
-    { "source": "трудный", "target": "grūts", "tags": ["adjectives", "B1"] },
-    { "source": "лёгкий", "target": "viegls", "tags": ["adjectives", "B1"] },
-    { "source": "безопасный", "target": "drošs", "tags": ["adjectives", "B1"] },
-    { "source": "чистый", "target": "tīrs", "tags": ["adjectives", "B1"] },
-    { "source": "грязный", "target": "netīrs", "tags": ["adjectives", "B1"] },
-    { "source": "полный", "target": "pilns", "tags": ["adjectives", "B1"] },
-    { "source": "пустой", "target": "tukšs", "tags": ["adjectives", "B1"] },
-    { "source": "свободный", "target": "brīvs", "tags": ["adjectives", "B1"] },
-    { "source": "телефон", "target": "telefons", "tags": ["objects", "B1"] },
-    { "source": "компьютер", "target": "dators", "tags": ["objects", "B1"] },
-    { "source": "экран", "target": "ekrāns", "tags": ["objects", "B1"] },
-    { "source": "клавиатура", "target": "klaviatūra", "tags": ["objects", "B1"] },
-    { "source": "мышь", "target": "pele", "tags": ["objects", "B1"] },
-    { "source": "интернет", "target": "internets", "tags": ["objects", "B1"] },
-    { "source": "сумка", "target": "soma", "tags": ["objects", "B1"] },
-    { "source": "кошелёк", "target": "maks", "tags": ["objects", "B1"] },
-    { "source": "часы", "target": "pulkstenis", "tags": ["objects", "B1"] },
-    { "source": "очки", "target": "brilles", "tags": ["objects", "B1"] },
-    { "source": "ключ", "target": "atslēga", "tags": ["objects", "B1"] },
-    { "source": "ручка", "target": "pildspalva", "tags": ["objects", "B1"] },
-    { "source": "бумага", "target": "papīrs", "tags": ["objects", "B1"] },
-    { "source": "деньги", "target": "nauda", "tags": ["objects", "B1"] },
-    { "source": "цена", "target": "cena", "tags": ["objects", "B1"] },
-    { "source": "счёт", "target": "rēķins", "tags": ["objects", "B1"] },
-    { "source": "семья", "target": "ģimene", "tags": ["social", "B1"] },
-    { "source": "друг", "target": "draugs", "tags": ["social", "B1"] },
-    { "source": "сосед", "target": "kaimiņš", "tags": ["social", "B1"] },
-    { "source": "ребёнок", "target": "bērns", "tags": ["social", "B1"] },
-    { "source": "родители", "target": "vecāki", "tags": ["social", "B1"] },
-    { "source": "сестра", "target": "māsa", "tags": ["social", "B1"] },
-    { "source": "брат", "target": "brālis", "tags": ["social", "B1"] },
-    { "source": "муж", "target": "vīrs", "tags": ["social", "B1"] },
-    { "source": "жена", "target": "sieva", "tags": ["social", "B1"] },
-    { "source": "учитель", "target": "skolotājs", "tags": ["social", "work", "B1"] },
-    { "source": "студент", "target": "students", "tags": ["social", "B1"] },
-    { "source": "врач", "target": "ārsts", "tags": ["social", "work", "B1"] },
-    { "source": "больница", "target": "slimnīca", "tags": ["social", "B1"] },
-    { "source": "аптека", "target": "aptieka", "tags": ["social", "B1"] },
-    { "source": "рынок", "target": "tirgus", "tags": ["social", "B1"] },
-    { "source": "магазин", "target": "veikals", "tags": ["social", "B1"] },
-    { "source": "банк", "target": "banka", "tags": ["social", "B1"] },
-    { "source": "школа", "target": "skola", "tags": ["social", "B1"] },
-    { "source": "университет", "target": "universitāte", "tags": ["social", "B1"] },
-    { "source": "музей", "target": "muzejs", "tags": ["social", "travel", "B1"] },
-    { "source": "библиотека", "target": "bibliotēka", "tags": ["social", "B1"] },
-    { "source": "парк", "target": "parks", "tags": ["social", "nature", "B1"] },
-    { "source": "кино", "target": "kino", "tags": ["social", "B1"] },
-    { "source": "праздник", "target": "svētki", "tags": ["social", "B1"] },
-    { "source": "спорт", "target": "sports", "tags": ["social", "B1"] },
-    { "source": "здоровье", "target": "veselība", "tags": ["body", "B1"] },
-    { "source": "болезнь", "target": "slimība", "tags": ["body", "B1"] },
-    { "source": "боль", "target": "sāpes", "tags": ["body", "B1"] },
-    { "source": "лекарство", "target": "zāles", "tags": ["body", "B1"] },
-    { "source": "дом", "target": "māja", "tags": ["home", "B1"] },
-    { "source": "квартира", "target": "dzīvoklis", "tags": ["home", "B1"] }
+    {
+      "source": "масло",
+      "target": "sviests",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "фрукт",
+      "target": "auglis",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "овощ",
+      "target": "dārzenis",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "апельсин",
+      "target": "apelsīns",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "помидор",
+      "target": "tomāts",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "картофель",
+      "target": "kartupelis",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "пиво",
+      "target": "alus",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "соль",
+      "target": "sāls",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "суп",
+      "target": "zupa",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "салат",
+      "target": "salāti",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "обед",
+      "target": "pusdienas",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "ужин",
+      "target": "vakariņas",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "завтрак",
+      "target": "brokastis",
+      "tags": ["food-drink", "B1"]
+    },
+    {
+      "source": "ресторан",
+      "target": "restorāns",
+      "tags": ["food-drink", "travel", "B1"]
+    },
+    {
+      "source": "гостиница",
+      "target": "viesnīca",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "аэропорт",
+      "target": "lidosta",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "самолёт",
+      "target": "lidmašīna",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "поезд",
+      "target": "vilciens",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "билет",
+      "target": "biļete",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "паспорт",
+      "target": "pase",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "карта",
+      "target": "karte",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "багаж",
+      "target": "bagāža",
+      "tags": ["travel", "B1"]
+    },
+    {
+      "source": "работа",
+      "target": "darbs",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "офис",
+      "target": "birojs",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "встреча",
+      "target": "sanāksme",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "начальник",
+      "target": "priekšnieks",
+      "tags": ["work", "B1"]
+    },
+    {
+      "source": "отпуск",
+      "target": "atvaļinājums",
+      "tags": ["work", "travel", "B1"]
+    },
+    {
+      "source": "радость",
+      "target": "prieks",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "грусть",
+      "target": "skumjas",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "страх",
+      "target": "bailes",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "злость",
+      "target": "dusmas",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "удивление",
+      "target": "pārsteigums",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "любовь",
+      "target": "mīlestība",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "волнение",
+      "target": "uztraukums",
+      "tags": ["emotions", "B1"]
+    },
+    {
+      "source": "лес",
+      "target": "mežs",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "море",
+      "target": "jūra",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "озеро",
+      "target": "ezers",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "река",
+      "target": "upe",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "гора",
+      "target": "kalns",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "деревня",
+      "target": "lauki",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "луна",
+      "target": "mēness",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "звезда",
+      "target": "zvaigzne",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "ветер",
+      "target": "vējš",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "облака",
+      "target": "mākoņi",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "зима",
+      "target": "ziema",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "лето",
+      "target": "vasara",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "весна",
+      "target": "pavasaris",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "осень",
+      "target": "rudens",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "трава",
+      "target": "zāle",
+      "tags": ["nature", "B1"]
+    },
+    {
+      "source": "кухня",
+      "target": "virtuve",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "спальня",
+      "target": "guļamistaba",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "ванная",
+      "target": "vannas istaba",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "гостиная",
+      "target": "viesistaba",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "диван",
+      "target": "dīvāns",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "подушка",
+      "target": "spilvens",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "одеяло",
+      "target": "sega",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "зеркало",
+      "target": "spogulis",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "лампа",
+      "target": "lampa",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "пол",
+      "target": "grīda",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "потолок",
+      "target": "griesti",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "стена",
+      "target": "siena",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "крыша",
+      "target": "jumts",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "сад",
+      "target": "dārzs",
+      "tags": ["home", "B1"]
+    },
+    {
+      "source": "лицо",
+      "target": "seja",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "зубы",
+      "target": "zobi",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "шея",
+      "target": "kakls",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "плечи",
+      "target": "pleci",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "пальцы",
+      "target": "pirksti",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "колено",
+      "target": "celis",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "стопа",
+      "target": "pēda",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "час",
+      "target": "stunda",
+      "tags": ["time", "B1"]
+    },
+    {
+      "source": "минута",
+      "target": "minūte",
+      "tags": ["time", "B1"]
+    },
+    {
+      "source": "секунда",
+      "target": "sekunde",
+      "tags": ["time", "B1"]
+    },
+    {
+      "source": "слушать",
+      "target": "klausīties",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "писать",
+      "target": "rakstīt",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "идти",
+      "target": "staigāt",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "бежать",
+      "target": "skriet",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "думать",
+      "target": "domāt",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "знать",
+      "target": "zināt",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "понимать",
+      "target": "saprast",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "помогать",
+      "target": "palīdzēt",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "покупать",
+      "target": "pirkt",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "приходить",
+      "target": "nākt",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "уходить",
+      "target": "iet",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "возвращаться",
+      "target": "atgriezties",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "открывать",
+      "target": "atvērt",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "закрывать",
+      "target": "aizvērt",
+      "tags": ["verbs", "B1"]
+    },
+    {
+      "source": "быстрый",
+      "target": "ātrs",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "медленный",
+      "target": "lēns",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "красивый",
+      "target": "skaists",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "некрасивый",
+      "target": "neglīts",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "сильный",
+      "target": "stiprs",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "слабый",
+      "target": "vājš",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "важный",
+      "target": "svarīgs",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "безопасный",
+      "target": "drošs",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "чистый",
+      "target": "tīrs",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "грязный",
+      "target": "netīrs",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "полный",
+      "target": "pilns",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "пустой",
+      "target": "tukšs",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "свободный",
+      "target": "brīvs",
+      "tags": ["adjectives", "B1"]
+    },
+    {
+      "source": "экран",
+      "target": "ekrāns",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "клавиатура",
+      "target": "klaviatūra",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "мышь",
+      "target": "pele",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "интернет",
+      "target": "internets",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "кошелёк",
+      "target": "maks",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "очки",
+      "target": "brilles",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "бумага",
+      "target": "papīrs",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "счёт",
+      "target": "rēķins",
+      "tags": ["objects", "B1"]
+    },
+    {
+      "source": "родители",
+      "target": "vecāki",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "рынок",
+      "target": "tirgus",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "банк",
+      "target": "banka",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "университет",
+      "target": "universitāte",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "музей",
+      "target": "muzejs",
+      "tags": ["social", "travel", "B1"]
+    },
+    {
+      "source": "библиотека",
+      "target": "bibliotēka",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "парк",
+      "target": "parks",
+      "tags": ["social", "nature", "B1"]
+    },
+    {
+      "source": "кино",
+      "target": "kino",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "праздник",
+      "target": "svētki",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "спорт",
+      "target": "sports",
+      "tags": ["social", "B1"]
+    },
+    {
+      "source": "здоровье",
+      "target": "veselība",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "болезнь",
+      "target": "slimība",
+      "tags": ["body", "B1"]
+    },
+    {
+      "source": "квартира",
+      "target": "dzīvoklis",
+      "tags": ["home", "B1"]
+    }
   ]
 }

--- a/public/starter-packs/ru-lv-b2.json
+++ b/public/starter-packs/ru-lv-b2.json
@@ -6,131 +6,605 @@
   "targetCode": "lv",
   "level": "B2",
   "words": [
-    { "source": "путешествие", "target": "ceļojums", "tags": ["travel", "B2"] },
-    { "source": "вино", "target": "vīns", "tags": ["food-drink", "B2"] },
-    { "source": "граница", "target": "robeža", "tags": ["travel", "B2"] },
-    { "source": "валюта", "target": "valūta", "tags": ["travel", "B2"] },
-    { "source": "бронирование", "target": "rezervācija", "tags": ["travel", "B2"] },
-    { "source": "зарплата", "target": "alga", "tags": ["work", "B2"] },
-    { "source": "проект", "target": "projekts", "tags": ["work", "B2"] },
-    { "source": "дедлайн", "target": "termiņš", "tags": ["work", "B2"] },
-    { "source": "отчёт", "target": "ziņojums", "tags": ["work", "B2"] },
-    { "source": "презентация", "target": "prezentācija", "tags": ["work", "B2"] },
-    { "source": "компания", "target": "uzņēmums", "tags": ["work", "B2"] },
-    { "source": "клиент", "target": "klients", "tags": ["work", "B2"] },
-    { "source": "собеседование", "target": "darba intervija", "tags": ["work", "B2"] },
-    { "source": "карьера", "target": "karjera", "tags": ["work", "B2"] },
-    { "source": "ненависть", "target": "naids", "tags": ["emotions", "B2"] },
-    { "source": "надежда", "target": "cerība", "tags": ["emotions", "B2"] },
-    { "source": "разочарование", "target": "vilšanās", "tags": ["emotions", "B2"] },
-    { "source": "облегчение", "target": "atvieglojums", "tags": ["emotions", "B2"] },
-    { "source": "стыд", "target": "kauns", "tags": ["emotions", "B2"] },
-    { "source": "одиночество", "target": "vientulība", "tags": ["emotions", "B2"] },
-    { "source": "благодарность", "target": "pateicība", "tags": ["emotions", "B2"] },
-    { "source": "подвал", "target": "pagrabstāvs", "tags": ["home", "B2"] },
-    { "source": "лёгкие", "target": "plaušas", "tags": ["body", "B2"] },
-    { "source": "давление", "target": "asinsspiediens", "tags": ["body", "B2"] },
-    { "source": "температура", "target": "temperatūra", "tags": ["body", "B2"] },
-    { "source": "прошлое", "target": "pagātne", "tags": ["time", "B2"] },
-    { "source": "будущее", "target": "nākotne", "tags": ["time", "B2"] },
-    { "source": "расписание", "target": "grafiks", "tags": ["time", "work", "B2"] },
-    { "source": "продавать", "target": "pārdot", "tags": ["verbs", "B2"] },
-    { "source": "менять", "target": "mainīt", "tags": ["verbs", "B2"] },
-    { "source": "решать", "target": "lemt", "tags": ["verbs", "B2"] },
-    { "source": "проверять", "target": "pārbaudīt", "tags": ["verbs", "B2"] },
-    { "source": "планировать", "target": "plānot", "tags": ["verbs", "B2"] },
-    { "source": "организовывать", "target": "organizēt", "tags": ["verbs", "B2"] },
-    { "source": "улучшать", "target": "uzlabot", "tags": ["verbs", "B2"] },
-    { "source": "достигать", "target": "sasniegt", "tags": ["verbs", "B2"] },
-    { "source": "выбирать", "target": "izvēlēties", "tags": ["verbs", "B2"] },
-    { "source": "обсуждать", "target": "apspriest", "tags": ["verbs", "B2"] },
-    { "source": "опасный", "target": "bīstams", "tags": ["adjectives", "B2"] },
-    { "source": "занятой", "target": "aizņemts", "tags": ["adjectives", "B2"] },
-    { "source": "успешный", "target": "veiksmīgs", "tags": ["adjectives", "B2"] },
-    { "source": "творческий", "target": "radošs", "tags": ["adjectives", "B2"] },
-    { "source": "надёжный", "target": "uzticams", "tags": ["adjectives", "B2"] },
-    { "source": "гибкий", "target": "elastīgs", "tags": ["adjectives", "B2"] },
-    { "source": "эффективный", "target": "efektīvs", "tags": ["adjectives", "B2"] },
-    { "source": "программа", "target": "programma", "tags": ["objects", "B2"] },
-    { "source": "приложение", "target": "aplikācija", "tags": ["objects", "B2"] },
-    { "source": "батарея", "target": "baterija", "tags": ["objects", "B2"] },
-    { "source": "зарядное устройство", "target": "lādētājs", "tags": ["objects", "B2"] },
-    { "source": "незнакомец", "target": "svešinieks", "tags": ["social", "B2"] },
-    { "source": "театр", "target": "teātris", "tags": ["social", "B2"] },
-    { "source": "лечение", "target": "ārstēšana", "tags": ["body", "B2"] },
-    { "source": "операция", "target": "operācija", "tags": ["body", "B2"] },
-    { "source": "аллергия", "target": "alerģija", "tags": ["body", "B2"] },
-    { "source": "симптомы", "target": "simptomi", "tags": ["body", "B2"] },
-    { "source": "консультация", "target": "konsultācija", "tags": ["work", "B2"] },
-    { "source": "договор", "target": "līgums", "tags": ["work", "B2"] },
-    { "source": "инвестиция", "target": "investīcija", "tags": ["work", "B2"] },
-    { "source": "бюджет", "target": "budžets", "tags": ["work", "B2"] },
-    { "source": "налоги", "target": "nodokļi", "tags": ["work", "B2"] },
-    { "source": "страховка", "target": "apdrošināšana", "tags": ["work", "B2"] },
-    { "source": "адрес", "target": "adrese", "tags": ["social", "B2"] },
-    { "source": "почта", "target": "pasts", "tags": ["social", "B2"] },
-    { "source": "письмо", "target": "vēstule", "tags": ["objects", "B2"] },
-    { "source": "посылка", "target": "sūtījums", "tags": ["objects", "B2"] },
-    { "source": "песня", "target": "dziesma", "tags": ["social", "B2"] },
-    { "source": "музыка", "target": "mūzika", "tags": ["social", "B2"] },
-    { "source": "танец", "target": "deja", "tags": ["social", "B2"] },
-    { "source": "фотография", "target": "fotogrāfija", "tags": ["objects", "B2"] },
-    { "source": "цвет", "target": "krāsa", "tags": ["objects", "B2"] },
-    { "source": "размер", "target": "izmērs", "tags": ["objects", "B2"] },
-    { "source": "форма", "target": "forma", "tags": ["objects", "B2"] },
-    { "source": "звук", "target": "skaņa", "tags": ["objects", "B2"] },
-    { "source": "запах", "target": "smarža", "tags": ["objects", "B2"] },
-    { "source": "вкус", "target": "garša", "tags": ["objects", "B2"] },
-    { "source": "язык", "target": "valoda", "tags": ["social", "B2"] },
-    { "source": "слово", "target": "vārds", "tags": ["social", "B2"] },
-    { "source": "предложение", "target": "teikums", "tags": ["social", "B2"] },
-    { "source": "вопрос", "target": "jautājums", "tags": ["social", "B2"] },
-    { "source": "ответ", "target": "atbilde", "tags": ["social", "B2"] },
-    { "source": "проблема", "target": "problēma", "tags": ["social", "B2"] },
-    { "source": "решение", "target": "risinājums", "tags": ["social", "B2"] },
-    { "source": "идея", "target": "ideja", "tags": ["social", "B2"] },
-    { "source": "мнение", "target": "viedoklis", "tags": ["social", "B2"] },
-    { "source": "информация", "target": "informācija", "tags": ["social", "B2"] },
-    { "source": "новости", "target": "ziņas", "tags": ["social", "B2"] },
-    { "source": "событие", "target": "notikums", "tags": ["social", "B2"] },
-    { "source": "возможность", "target": "iespēja", "tags": ["social", "B2"] },
-    { "source": "опыт", "target": "pieredze", "tags": ["social", "B2"] },
-    { "source": "знания", "target": "zināšanas", "tags": ["social", "B2"] },
-    { "source": "образование", "target": "izglītība", "tags": ["social", "B2"] },
-    { "source": "общество", "target": "sabiedrība", "tags": ["social", "B2"] },
-    { "source": "культура", "target": "kultūra", "tags": ["social", "B2"] },
-    { "source": "окружающая среда", "target": "vide", "tags": ["nature", "B2"] },
-    { "source": "климат", "target": "klimats", "tags": ["nature", "B2"] },
-    { "source": "энергия", "target": "enerģija", "tags": ["nature", "B2"] },
-    { "source": "ресурсы", "target": "resursi", "tags": ["nature", "B2"] },
-    { "source": "загрязнение", "target": "piesārņojums", "tags": ["nature", "B2"] },
-    { "source": "развитие", "target": "attīstība", "tags": ["work", "B2"] },
-    { "source": "стратегия", "target": "stratēģija", "tags": ["work", "B2"] },
-    { "source": "цель", "target": "mērķis", "tags": ["work", "B2"] },
-    { "source": "результат", "target": "rezultāts", "tags": ["work", "B2"] },
-    { "source": "процесс", "target": "process", "tags": ["work", "B2"] },
-    { "source": "система", "target": "sistēma", "tags": ["work", "B2"] },
-    { "source": "технология", "target": "tehnoloģija", "tags": ["objects", "B2"] },
-    { "source": "устройство", "target": "ierīce", "tags": ["objects", "B2"] },
-    { "source": "подключение", "target": "savienojums", "tags": ["objects", "B2"] },
-    { "source": "безопасность", "target": "drošība", "tags": ["objects", "B2"] },
-    { "source": "конфиденциальность", "target": "privātums", "tags": ["social", "B2"] },
-    { "source": "права", "target": "tiesības", "tags": ["social", "B2"] },
-    { "source": "обязанность", "target": "pienākums", "tags": ["social", "B2"] },
-    { "source": "соглашение", "target": "vienošanās", "tags": ["social", "B2"] },
-    { "source": "конфликт", "target": "konflikts", "tags": ["social", "B2"] },
-    { "source": "сотрудничество", "target": "sadarbība", "tags": ["social", "B2"] },
-    { "source": "критика", "target": "kritika", "tags": ["social", "B2"] },
-    { "source": "оценка", "target": "novērtējums", "tags": ["social", "B2"] },
-    { "source": "перспектива", "target": "perspektīva", "tags": ["social", "B2"] },
-    { "source": "вызов", "target": "izaicinājums", "tags": ["social", "B2"] },
-    { "source": "риск", "target": "riski", "tags": ["work", "B2"] },
-    { "source": "качество", "target": "kvalitāte", "tags": ["work", "B2"] },
-    { "source": "стандарт", "target": "standarts", "tags": ["work", "B2"] },
-    { "source": "достижение", "target": "sasniegums", "tags": ["work", "B2"] },
-    { "source": "влияние", "target": "ietekme", "tags": ["social", "B2"] },
-    { "source": "баланс", "target": "līdzsvars", "tags": ["social", "B2"] },
-    { "source": "приоритет", "target": "prioritāte", "tags": ["work", "B2"] },
-    { "source": "инновация", "target": "inovācija", "tags": ["work", "B2"] }
+    {
+      "source": "путешествие",
+      "target": "ceļojums",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "вино",
+      "target": "vīns",
+      "tags": ["food-drink", "B2"]
+    },
+    {
+      "source": "граница",
+      "target": "robeža",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "валюта",
+      "target": "valūta",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "бронирование",
+      "target": "rezervācija",
+      "tags": ["travel", "B2"]
+    },
+    {
+      "source": "зарплата",
+      "target": "alga",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "проект",
+      "target": "projekts",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "дедлайн",
+      "target": "termiņš",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "отчёт",
+      "target": "ziņojums",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "презентация",
+      "target": "prezentācija",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "компания",
+      "target": "uzņēmums",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "клиент",
+      "target": "klients",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "собеседование",
+      "target": "darba intervija",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "карьера",
+      "target": "karjera",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "ненависть",
+      "target": "naids",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "надежда",
+      "target": "cerība",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "разочарование",
+      "target": "vilšanās",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "облегчение",
+      "target": "atvieglojums",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "стыд",
+      "target": "kauns",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "одиночество",
+      "target": "vientulība",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "благодарность",
+      "target": "pateicība",
+      "tags": ["emotions", "B2"]
+    },
+    {
+      "source": "подвал",
+      "target": "pagrabstāvs",
+      "tags": ["home", "B2"]
+    },
+    {
+      "source": "лёгкие",
+      "target": "plaušas",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "давление",
+      "target": "asinsspiediens",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "температура",
+      "target": "temperatūra",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "прошлое",
+      "target": "pagātne",
+      "tags": ["time", "B2"]
+    },
+    {
+      "source": "будущее",
+      "target": "nākotne",
+      "tags": ["time", "B2"]
+    },
+    {
+      "source": "расписание",
+      "target": "grafiks",
+      "tags": ["time", "work", "B2"]
+    },
+    {
+      "source": "продавать",
+      "target": "pārdot",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "менять",
+      "target": "mainīt",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "решать",
+      "target": "lemt",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "проверять",
+      "target": "pārbaudīt",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "планировать",
+      "target": "plānot",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "организовывать",
+      "target": "organizēt",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "улучшать",
+      "target": "uzlabot",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "достигать",
+      "target": "sasniegt",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "выбирать",
+      "target": "izvēlēties",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "обсуждать",
+      "target": "apspriest",
+      "tags": ["verbs", "B2"]
+    },
+    {
+      "source": "опасный",
+      "target": "bīstams",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "занятой",
+      "target": "aizņemts",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "успешный",
+      "target": "veiksmīgs",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "творческий",
+      "target": "radošs",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "надёжный",
+      "target": "uzticams",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "гибкий",
+      "target": "elastīgs",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "эффективный",
+      "target": "efektīvs",
+      "tags": ["adjectives", "B2"]
+    },
+    {
+      "source": "программа",
+      "target": "programma",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "приложение",
+      "target": "aplikācija",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "батарея",
+      "target": "baterija",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "зарядное устройство",
+      "target": "lādētājs",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "незнакомец",
+      "target": "svešinieks",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "театр",
+      "target": "teātris",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "лечение",
+      "target": "ārstēšana",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "операция",
+      "target": "operācija",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "аллергия",
+      "target": "alerģija",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "симптомы",
+      "target": "simptomi",
+      "tags": ["body", "B2"]
+    },
+    {
+      "source": "консультация",
+      "target": "konsultācija",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "договор",
+      "target": "līgums",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "инвестиция",
+      "target": "investīcija",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "бюджет",
+      "target": "budžets",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "налоги",
+      "target": "nodokļi",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "страховка",
+      "target": "apdrošināšana",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "почта",
+      "target": "pasts",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "посылка",
+      "target": "sūtījums",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "песня",
+      "target": "dziesma",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "танец",
+      "target": "deja",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "фотография",
+      "target": "fotogrāfija",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "цвет",
+      "target": "krāsa",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "форма",
+      "target": "forma",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "звук",
+      "target": "skaņa",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "запах",
+      "target": "smarža",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "вкус",
+      "target": "garša",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "предложение",
+      "target": "teikums",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "вопрос",
+      "target": "jautājums",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "ответ",
+      "target": "atbilde",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "проблема",
+      "target": "problēma",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "решение",
+      "target": "risinājums",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "идея",
+      "target": "ideja",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "мнение",
+      "target": "viedoklis",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "информация",
+      "target": "informācija",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "новости",
+      "target": "ziņas",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "событие",
+      "target": "notikums",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "возможность",
+      "target": "iespēja",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "опыт",
+      "target": "pieredze",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "знания",
+      "target": "zināšanas",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "образование",
+      "target": "izglītība",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "общество",
+      "target": "sabiedrība",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "культура",
+      "target": "kultūra",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "окружающая среда",
+      "target": "vide",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "климат",
+      "target": "klimats",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "энергия",
+      "target": "enerģija",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "ресурсы",
+      "target": "resursi",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "загрязнение",
+      "target": "piesārņojums",
+      "tags": ["nature", "B2"]
+    },
+    {
+      "source": "развитие",
+      "target": "attīstība",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "стратегия",
+      "target": "stratēģija",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "цель",
+      "target": "mērķis",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "результат",
+      "target": "rezultāts",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "процесс",
+      "target": "process",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "система",
+      "target": "sistēma",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "технология",
+      "target": "tehnoloģija",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "устройство",
+      "target": "ierīce",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "подключение",
+      "target": "savienojums",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "безопасность",
+      "target": "drošība",
+      "tags": ["objects", "B2"]
+    },
+    {
+      "source": "конфиденциальность",
+      "target": "privātums",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "права",
+      "target": "tiesības",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "обязанность",
+      "target": "pienākums",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "соглашение",
+      "target": "vienošanās",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "конфликт",
+      "target": "konflikts",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "сотрудничество",
+      "target": "sadarbība",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "критика",
+      "target": "kritika",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "оценка",
+      "target": "novērtējums",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "перспектива",
+      "target": "perspektīva",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "вызов",
+      "target": "izaicinājums",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "риск",
+      "target": "riski",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "качество",
+      "target": "kvalitāte",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "стандарт",
+      "target": "standarts",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "достижение",
+      "target": "sasniegums",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "влияние",
+      "target": "ietekme",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "баланс",
+      "target": "līdzsvars",
+      "tags": ["social", "B2"]
+    },
+    {
+      "source": "приоритет",
+      "target": "prioritāte",
+      "tags": ["work", "B2"]
+    },
+    {
+      "source": "инновация",
+      "target": "inovācija",
+      "tags": ["work", "B2"]
+    }
   ]
 }

--- a/public/starter-packs/ru-lv-c1.json
+++ b/public/starter-packs/ru-lv-c1.json
@@ -6,137 +6,665 @@
   "targetCode": "lv",
   "level": "C1",
   "words": [
-    { "source": "абстрактный", "target": "abstrakts", "tags": ["academic", "C1"] },
-    { "source": "анализ", "target": "analīze", "tags": ["academic", "C1"] },
-    { "source": "синтез", "target": "sintēze", "tags": ["academic", "C1"] },
-    { "source": "гипотеза", "target": "hipotēze", "tags": ["academic", "C1"] },
-    { "source": "доказательство", "target": "pierādījums", "tags": ["academic", "C1"] },
-    { "source": "методология", "target": "metodoloģija", "tags": ["academic", "C1"] },
-    { "source": "исследование", "target": "pētījums", "tags": ["academic", "C1"] },
-    { "source": "теория", "target": "teorija", "tags": ["academic", "C1"] },
-    { "source": "концепция", "target": "koncepcija", "tags": ["academic", "C1"] },
-    { "source": "парадигма", "target": "paradigma", "tags": ["academic", "C1"] },
-    { "source": "дискурс", "target": "diskurss", "tags": ["academic", "C1"] },
-    { "source": "аргументация", "target": "argumentācija", "tags": ["academic", "C1"] },
-    { "source": "обоснование", "target": "pamatojums", "tags": ["academic", "C1"] },
-    { "source": "вывод", "target": "secinājums", "tags": ["academic", "C1"] },
-    { "source": "утверждение", "target": "apgalvojums", "tags": ["academic", "C1"] },
-    { "source": "опровержение", "target": "atspēkojums", "tags": ["academic", "C1"] },
-    { "source": "критерий", "target": "kritērijs", "tags": ["academic", "C1"] },
-    { "source": "наблюдение", "target": "novērojums", "tags": ["academic", "C1"] },
-    { "source": "интерпретация", "target": "interpretācija", "tags": ["academic", "C1"] },
-    { "source": "контекст", "target": "konteksts", "tags": ["academic", "C1"] },
-    { "source": "правовая норма", "target": "likuma norma", "tags": ["law", "C1"] },
-    { "source": "юрисдикция", "target": "jurisdikcija", "tags": ["law", "C1"] },
-    { "source": "суд", "target": "tiesa", "tags": ["law", "C1"] },
-    { "source": "приговор", "target": "spriedums", "tags": ["law", "C1"] },
-    { "source": "обвинение", "target": "apsūdzība", "tags": ["law", "C1"] },
-    { "source": "защита", "target": "aizstāvība", "tags": ["law", "C1"] },
-    { "source": "доказать", "target": "pierādīt", "tags": ["law", "C1"] },
-    { "source": "регулировать", "target": "regulēt", "tags": ["law", "C1"] },
-    { "source": "диагностировать", "target": "diagnosticēt", "tags": ["medicine", "C1"] },
-    { "source": "симптом", "target": "simptoms", "tags": ["medicine", "C1"] },
-    { "source": "диагноз", "target": "diagnoze", "tags": ["medicine", "C1"] },
-    { "source": "терапия", "target": "terapija", "tags": ["medicine", "C1"] },
-    { "source": "рецепт", "target": "recepte", "tags": ["medicine", "C1"] },
-    { "source": "клинический", "target": "klīnisks", "tags": ["medicine", "C1"] },
-    { "source": "профилактический", "target": "profilaktisks", "tags": ["medicine", "C1"] },
-    { "source": "хронический", "target": "hronisks", "tags": ["medicine", "C1"] },
-    { "source": "острый", "target": "akūts", "tags": ["medicine", "C1"] },
-    { "source": "иммунная система", "target": "imūnsistēma", "tags": ["medicine", "C1"] },
-    { "source": "выручка", "target": "ieņēmumi", "tags": ["business", "C1"] },
-    { "source": "прибыль", "target": "peļņa", "tags": ["business", "C1"] },
-    { "source": "расходы", "target": "izdevumi", "tags": ["business", "C1"] },
-    { "source": "доля рынка", "target": "tirgus daļa", "tags": ["business", "C1"] },
-    { "source": "конкуренция", "target": "konkurence", "tags": ["business", "C1"] },
-    { "source": "цепочка поставок", "target": "piegādes ķēde", "tags": ["business", "C1"] },
-    { "source": "расширение", "target": "paplašināšanās", "tags": ["business", "C1"] },
-    { "source": "предпринимательство", "target": "uzņēmējdarbība", "tags": ["business", "C1"] },
-    { "source": "корпоративный", "target": "korporatīvs", "tags": ["business", "C1"] },
-    { "source": "точный", "target": "precīzs", "tags": ["adjectives", "C1"] },
-    { "source": "исчерпывающий", "target": "izsmeļošs", "tags": ["adjectives", "C1"] },
-    { "source": "систематический", "target": "sistemātisks", "tags": ["adjectives", "C1"] },
-    { "source": "критический", "target": "kritisks", "tags": ["adjectives", "C1"] },
-    { "source": "аналитический", "target": "analītisks", "tags": ["adjectives", "C1"] },
-    { "source": "объективный", "target": "objektīvs", "tags": ["adjectives", "C1"] },
-    { "source": "субъективный", "target": "subjektīvs", "tags": ["adjectives", "C1"] },
-    { "source": "логичный", "target": "loģisks", "tags": ["adjectives", "C1"] },
-    { "source": "рациональный", "target": "racionāls", "tags": ["adjectives", "C1"] },
-    { "source": "иррациональный", "target": "iracionāls", "tags": ["adjectives", "C1"] },
-    { "source": "недооценивать", "target": "nenovērtēt", "tags": ["verbs", "C1"] },
-    { "source": "переоценивать", "target": "pārvērtēt", "tags": ["verbs", "C1"] },
-    { "source": "формулировать", "target": "formulēt", "tags": ["verbs", "C1"] },
-    { "source": "анализировать", "target": "analizēt", "tags": ["verbs", "C1"] },
-    { "source": "расследовать", "target": "izzināt", "tags": ["verbs", "C1"] },
-    { "source": "применять", "target": "piemērot", "tags": ["verbs", "C1"] },
-    { "source": "оценивать", "target": "izvērtēt", "tags": ["verbs", "C1"] },
-    { "source": "иллюстрировать", "target": "ilustrēt", "tags": ["verbs", "C1"] },
-    { "source": "обосновывать", "target": "pamatot", "tags": ["verbs", "C1"] },
-    { "source": "консолидировать", "target": "nostiprināt", "tags": ["verbs", "C1"] },
-    { "source": "преподаватель", "target": "mācībspēks", "tags": ["academic", "C1"] },
-    { "source": "диссертация", "target": "disertācija", "tags": ["academic", "C1"] },
-    { "source": "статья", "target": "referāts", "tags": ["academic", "C1"] },
-    { "source": "семинар", "target": "seminārs", "tags": ["academic", "C1"] },
-    { "source": "симпозиум", "target": "simpozijs", "tags": ["academic", "C1"] },
-    { "source": "лекция", "target": "lekcija", "tags": ["academic", "C1"] },
-    { "source": "бакалавр", "target": "bakalaurs", "tags": ["academic", "C1"] },
-    { "source": "магистр", "target": "maģistrs", "tags": ["academic", "C1"] },
-    { "source": "аспирант", "target": "doktorants", "tags": ["academic", "C1"] },
-    { "source": "профессор", "target": "profesors", "tags": ["academic", "C1"] },
-    { "source": "официальный", "target": "formāls", "tags": ["register", "C1"] },
-    { "source": "неофициальный", "target": "neformāls", "tags": ["register", "C1"] },
-    { "source": "профессиональный", "target": "lietišķs", "tags": ["register", "C1"] },
-    { "source": "вежливый", "target": "pieklājīgs", "tags": ["register", "C1"] },
-    { "source": "сдержанный", "target": "atturīgs", "tags": ["register", "C1"] },
-    { "source": "выражение", "target": "izteiciens", "tags": ["register", "C1"] },
-    { "source": "поговорка", "target": "teiciens", "tags": ["register", "C1"] },
-    { "source": "идиома", "target": "idioma", "tags": ["register", "C1"] },
-    { "source": "словарный запас", "target": "vārdu krājums", "tags": ["register", "C1"] },
-    { "source": "терминология", "target": "terminoloģija", "tags": ["register", "C1"] },
-    { "source": "инфраструктура", "target": "infrastruktūra", "tags": ["social", "C1"] },
-    { "source": "институт", "target": "institūcija", "tags": ["social", "C1"] },
-    { "source": "бюрократия", "target": "birokrātija", "tags": ["social", "C1"] },
-    { "source": "политика", "target": "politika", "tags": ["social", "C1"] },
-    { "source": "дипломатия", "target": "diplomātija", "tags": ["social", "C1"] },
-    { "source": "международный", "target": "starptautisks", "tags": ["social", "C1"] },
-    { "source": "правительство", "target": "valdība", "tags": ["social", "C1"] },
-    { "source": "референдум", "target": "referendums", "tags": ["social", "C1"] },
-    { "source": "демократия", "target": "demokrātija", "tags": ["social", "C1"] },
-    { "source": "неумолимый", "target": "nepielūdzams", "tags": ["adjectives", "C1"] },
-    { "source": "неизбежный", "target": "nenovēršams", "tags": ["adjectives", "C1"] },
-    { "source": "значительный", "target": "nozīmīgs", "tags": ["adjectives", "C1"] },
-    { "source": "существенный", "target": "būtisks", "tags": ["adjectives", "C1"] },
-    { "source": "подходящий", "target": "atbilstošs", "tags": ["adjectives", "C1"] },
-    { "source": "устойчивый", "target": "ilgtspējīgs", "tags": ["adjectives", "C1"] },
-    { "source": "сложный", "target": "sarežģīts", "tags": ["adjectives", "C1"] },
-    { "source": "своеобразный", "target": "savdabīgs", "tags": ["adjectives", "C1"] },
-    { "source": "последствия", "target": "sekas", "tags": ["social", "C1"] },
-    { "source": "сравнительный", "target": "salīdzinošs", "tags": ["academic", "C1"] },
-    { "source": "количественный", "target": "kvantitatīvs", "tags": ["academic", "C1"] },
-    { "source": "качественный", "target": "kvalitatīvs", "tags": ["academic", "C1"] },
-    { "source": "эмпирический", "target": "empīrisks", "tags": ["academic", "C1"] },
-    { "source": "теоретический", "target": "teorētisks", "tags": ["academic", "C1"] },
-    { "source": "интегрировать", "target": "integrēt", "tags": ["verbs", "C1"] },
-    { "source": "координировать", "target": "koordinēt", "tags": ["verbs", "C1"] },
-    { "source": "реализовывать", "target": "īstenot", "tags": ["verbs", "C1"] },
-    { "source": "делегировать", "target": "delegēt", "tags": ["verbs", "C1"] },
-    { "source": "управлять", "target": "pārvaldīt", "tags": ["verbs", "C1"] },
-    { "source": "мониторить", "target": "uzraudzīt", "tags": ["verbs", "C1"] },
-    { "source": "оптимизировать", "target": "optimizēt", "tags": ["verbs", "C1"] },
-    { "source": "преодолевать", "target": "pārvarēt", "tags": ["verbs", "C1"] },
-    { "source": "обеспечивать", "target": "nodrošināt", "tags": ["verbs", "C1"] },
-    { "source": "стремиться", "target": "censties", "tags": ["verbs", "C1"] },
-    { "source": "ценить", "target": "novērtēt", "tags": ["verbs", "C1"] },
-    { "source": "пересматривать", "target": "pārskatīt", "tags": ["verbs", "C1"] },
-    { "source": "подтверждать", "target": "apstiprināt", "tags": ["verbs", "C1"] },
-    { "source": "оспаривать", "target": "apstrīdēt", "tags": ["verbs", "C1"] },
-    { "source": "поддерживать", "target": "atbalstīt", "tags": ["verbs", "C1"] },
-    { "source": "объединять", "target": "apvienot", "tags": ["verbs", "C1"] },
-    { "source": "адаптировать", "target": "adaptēt", "tags": ["verbs", "C1"] },
-    { "source": "ускорять", "target": "paātrināt", "tags": ["verbs", "C1"] },
-    { "source": "предлагать", "target": "ierosināt", "tags": ["verbs", "C1"] },
-    { "source": "убеждать", "target": "pārliecināt", "tags": ["verbs", "C1"] },
-    { "source": "приобретать", "target": "iegūt", "tags": ["verbs", "C1"] },
-    { "source": "расширять", "target": "paplašināt", "tags": ["verbs", "C1"] }
+    {
+      "source": "абстрактный",
+      "target": "abstrakts",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "анализ",
+      "target": "analīze",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "синтез",
+      "target": "sintēze",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "гипотеза",
+      "target": "hipotēze",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "доказательство",
+      "target": "pierādījums",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "методология",
+      "target": "metodoloģija",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "исследование",
+      "target": "pētījums",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "теория",
+      "target": "teorija",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "концепция",
+      "target": "koncepcija",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "парадигма",
+      "target": "paradigma",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "дискурс",
+      "target": "diskurss",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "аргументация",
+      "target": "argumentācija",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "обоснование",
+      "target": "pamatojums",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "вывод",
+      "target": "secinājums",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "утверждение",
+      "target": "apgalvojums",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "опровержение",
+      "target": "atspēkojums",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "критерий",
+      "target": "kritērijs",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "наблюдение",
+      "target": "novērojums",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "интерпретация",
+      "target": "interpretācija",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "контекст",
+      "target": "konteksts",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "правовая норма",
+      "target": "likuma norma",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "юрисдикция",
+      "target": "jurisdikcija",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "суд",
+      "target": "tiesa",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "приговор",
+      "target": "spriedums",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "обвинение",
+      "target": "apsūdzība",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "защита",
+      "target": "aizstāvība",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "доказать",
+      "target": "pierādīt",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "регулировать",
+      "target": "regulēt",
+      "tags": ["law", "C1"]
+    },
+    {
+      "source": "диагностировать",
+      "target": "diagnosticēt",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "симптом",
+      "target": "simptoms",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "диагноз",
+      "target": "diagnoze",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "терапия",
+      "target": "terapija",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "рецепт",
+      "target": "recepte",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "клинический",
+      "target": "klīnisks",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "профилактический",
+      "target": "profilaktisks",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "хронический",
+      "target": "hronisks",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "острый",
+      "target": "akūts",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "иммунная система",
+      "target": "imūnsistēma",
+      "tags": ["medicine", "C1"]
+    },
+    {
+      "source": "выручка",
+      "target": "ieņēmumi",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "прибыль",
+      "target": "peļņa",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "расходы",
+      "target": "izdevumi",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "доля рынка",
+      "target": "tirgus daļa",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "конкуренция",
+      "target": "konkurence",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "цепочка поставок",
+      "target": "piegādes ķēde",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "расширение",
+      "target": "paplašināšanās",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "предпринимательство",
+      "target": "uzņēmējdarbība",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "корпоративный",
+      "target": "korporatīvs",
+      "tags": ["business", "C1"]
+    },
+    {
+      "source": "точный",
+      "target": "precīzs",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "исчерпывающий",
+      "target": "izsmeļošs",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "систематический",
+      "target": "sistemātisks",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "критический",
+      "target": "kritisks",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "аналитический",
+      "target": "analītisks",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "объективный",
+      "target": "objektīvs",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "субъективный",
+      "target": "subjektīvs",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "логичный",
+      "target": "loģisks",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "рациональный",
+      "target": "racionāls",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "иррациональный",
+      "target": "iracionāls",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "недооценивать",
+      "target": "nenovērtēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "переоценивать",
+      "target": "pārvērtēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "формулировать",
+      "target": "formulēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "анализировать",
+      "target": "analizēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "расследовать",
+      "target": "izzināt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "применять",
+      "target": "piemērot",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "оценивать",
+      "target": "izvērtēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "иллюстрировать",
+      "target": "ilustrēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "обосновывать",
+      "target": "pamatot",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "консолидировать",
+      "target": "nostiprināt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "преподаватель",
+      "target": "mācībspēks",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "диссертация",
+      "target": "disertācija",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "статья",
+      "target": "referāts",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "семинар",
+      "target": "seminārs",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "симпозиум",
+      "target": "simpozijs",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "лекция",
+      "target": "lekcija",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "бакалавр",
+      "target": "bakalaurs",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "магистр",
+      "target": "maģistrs",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "аспирант",
+      "target": "doktorants",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "профессор",
+      "target": "profesors",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "официальный",
+      "target": "formāls",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "неофициальный",
+      "target": "neformāls",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "профессиональный",
+      "target": "lietišķs",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "вежливый",
+      "target": "pieklājīgs",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "сдержанный",
+      "target": "atturīgs",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "выражение",
+      "target": "izteiciens",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "поговорка",
+      "target": "teiciens",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "идиома",
+      "target": "idioma",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "словарный запас",
+      "target": "vārdu krājums",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "терминология",
+      "target": "terminoloģija",
+      "tags": ["register", "C1"]
+    },
+    {
+      "source": "инфраструктура",
+      "target": "infrastruktūra",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "институт",
+      "target": "institūcija",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "бюрократия",
+      "target": "birokrātija",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "политика",
+      "target": "politika",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "дипломатия",
+      "target": "diplomātija",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "международный",
+      "target": "starptautisks",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "правительство",
+      "target": "valdība",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "референдум",
+      "target": "referendums",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "демократия",
+      "target": "demokrātija",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "неумолимый",
+      "target": "nepielūdzams",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "неизбежный",
+      "target": "nenovēršams",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "значительный",
+      "target": "nozīmīgs",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "существенный",
+      "target": "būtisks",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "подходящий",
+      "target": "atbilstošs",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "устойчивый",
+      "target": "ilgtspējīgs",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "сложный",
+      "target": "sarežģīts",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "своеобразный",
+      "target": "savdabīgs",
+      "tags": ["adjectives", "C1"]
+    },
+    {
+      "source": "последствия",
+      "target": "sekas",
+      "tags": ["social", "C1"]
+    },
+    {
+      "source": "сравнительный",
+      "target": "salīdzinošs",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "количественный",
+      "target": "kvantitatīvs",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "качественный",
+      "target": "kvalitatīvs",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "эмпирический",
+      "target": "empīrisks",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "теоретический",
+      "target": "teorētisks",
+      "tags": ["academic", "C1"]
+    },
+    {
+      "source": "интегрировать",
+      "target": "integrēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "координировать",
+      "target": "koordinēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "реализовывать",
+      "target": "īstenot",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "делегировать",
+      "target": "delegēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "управлять",
+      "target": "pārvaldīt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "мониторить",
+      "target": "uzraudzīt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "оптимизировать",
+      "target": "optimizēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "преодолевать",
+      "target": "pārvarēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "обеспечивать",
+      "target": "nodrošināt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "стремиться",
+      "target": "censties",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "ценить",
+      "target": "novērtēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "пересматривать",
+      "target": "pārskatīt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "подтверждать",
+      "target": "apstiprināt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "оспаривать",
+      "target": "apstrīdēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "поддерживать",
+      "target": "atbalstīt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "объединять",
+      "target": "apvienot",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "адаптировать",
+      "target": "adaptēt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "ускорять",
+      "target": "paātrināt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "предлагать",
+      "target": "ierosināt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "убеждать",
+      "target": "pārliecināt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "приобретать",
+      "target": "iegūt",
+      "tags": ["verbs", "C1"]
+    },
+    {
+      "source": "расширять",
+      "target": "paplašināt",
+      "tags": ["verbs", "C1"]
+    }
   ]
 }

--- a/public/starter-packs/ru-lv-c2.json
+++ b/public/starter-packs/ru-lv-c2.json
@@ -6,116 +6,560 @@
   "targetCode": "lv",
   "level": "C2",
   "words": [
-    { "source": "меланхолия", "target": "melanholija", "tags": ["emotions", "C2"] },
-    { "source": "ностальгия", "target": "nostalģija", "tags": ["emotions", "C2"] },
-    { "source": "эйфория", "target": "eiforija", "tags": ["emotions", "C2"] },
-    { "source": "апатия", "target": "apatija", "tags": ["emotions", "C2"] },
-    { "source": "амбивалентность", "target": "ambivalence", "tags": ["emotions", "C2"] },
-    { "source": "тревога", "target": "nemiers", "tags": ["emotions", "C2"] },
-    { "source": "наивность", "target": "naivums", "tags": ["emotions", "C2"] },
-    { "source": "ирония", "target": "ironija", "tags": ["emotions", "C2"] },
-    { "source": "сарказм", "target": "sarkasms", "tags": ["emotions", "C2"] },
-    { "source": "презрение", "target": "nicinājums", "tags": ["emotions", "C2"] },
-    { "source": "честолюбие", "target": "godkārība", "tags": ["emotions", "C2"] },
-    { "source": "невинность", "target": "nevainīgums", "tags": ["emotions", "C2"] },
-    { "source": "восхищение", "target": "apbrīna", "tags": ["emotions", "C2"] },
-    { "source": "благоговение", "target": "bijāšana", "tags": ["emotions", "C2"] },
-    { "source": "недоверие", "target": "neuzticēšanās", "tags": ["emotions", "C2"] },
-    { "source": "энтузиазм", "target": "entuziasms", "tags": ["emotions", "C2"] },
-    { "source": "отчуждение", "target": "atsvešinātība", "tags": ["emotions", "C2"] },
-    { "source": "эмпатия", "target": "empātija", "tags": ["emotions", "C2"] },
-    { "source": "смирение", "target": "pazemība", "tags": ["emotions", "C2"] },
-    { "source": "гордость", "target": "lepnums", "tags": ["emotions", "C2"] },
-    { "source": "коренное население", "target": "pamatiedzīvotāji", "tags": ["social", "C2"] },
-    { "source": "колониализм", "target": "koloniālisms", "tags": ["social", "C2"] },
-    { "source": "ассимиляция", "target": "asimilācija", "tags": ["social", "C2"] },
-    { "source": "аккультурация", "target": "akulturācija", "tags": ["social", "C2"] },
-    { "source": "этноцентризм", "target": "etnocentrisms", "tags": ["social", "C2"] },
-    { "source": "плюрализм", "target": "plurālisms", "tags": ["social", "C2"] },
-    { "source": "гегемония", "target": "hegemonija", "tags": ["social", "C2"] },
-    { "source": "дискриминация", "target": "diskriminācija", "tags": ["social", "C2"] },
-    { "source": "эмансипация", "target": "emancipācija", "tags": ["social", "C2"] },
-    { "source": "сегрегация", "target": "segregācija", "tags": ["social", "C2"] },
-    { "source": "афоризм", "target": "aforisms", "tags": ["literary", "C2"] },
-    { "source": "метафора", "target": "metafora", "tags": ["literary", "C2"] },
-    { "source": "аллегория", "target": "alegorija", "tags": ["literary", "C2"] },
-    { "source": "эпитет", "target": "epitets", "tags": ["literary", "C2"] },
-    { "source": "олицетворение", "target": "personifikācija", "tags": ["literary", "C2"] },
-    { "source": "возникать", "target": "parādīties", "tags": ["literary", "C2"] },
-    { "source": "исчезать", "target": "izzust", "tags": ["literary", "C2"] },
-    { "source": "мерцать", "target": "mirdzeties", "tags": ["literary", "C2"] },
-    { "source": "дрожать", "target": "drebēt", "tags": ["literary", "C2"] },
-    { "source": "квинтэссенция", "target": "kvintesence", "tags": ["academic", "C2"] },
-    { "source": "аксиома", "target": "aksioma", "tags": ["academic", "C2"] },
-    { "source": "тавтология", "target": "tautologija", "tags": ["academic", "C2"] },
-    { "source": "парадокс", "target": "paradokss", "tags": ["academic", "C2"] },
-    { "source": "феноменология", "target": "fenomenoloģija", "tags": ["academic", "C2"] },
-    { "source": "герменевтика", "target": "hermeneitika", "tags": ["academic", "C2"] },
-    { "source": "диалектика", "target": "dialektika", "tags": ["academic", "C2"] },
-    { "source": "прагматизм", "target": "pragmatisms", "tags": ["academic", "C2"] },
-    { "source": "великодушный", "target": "dižciltīgs", "tags": ["archaic", "C2"] },
-    { "source": "великолепие", "target": "krāšņums", "tags": ["archaic", "C2"] },
-    { "source": "блеск", "target": "spožums", "tags": ["archaic", "C2"] },
-    { "source": "осязаемый", "target": "tverams", "tags": ["archaic", "C2"] },
-    { "source": "неосязаемый", "target": "netverams", "tags": ["archaic", "C2"] },
-    { "source": "двусмысленный", "target": "divdomīgs", "tags": ["register", "C2"] },
-    { "source": "нейтральный", "target": "neitrāls", "tags": ["register", "C2"] },
-    { "source": "тонкий", "target": "smalks", "tags": ["register", "C2"] },
-    { "source": "утончённый", "target": "izsmalcināts", "tags": ["register", "C2"] },
-    { "source": "экспрессивный", "target": "ekspresīvs", "tags": ["register", "C2"] },
-    { "source": "благозвучный", "target": "skanīgs", "tags": ["register", "C2"] },
-    { "source": "ассонанс", "target": "assonanse", "tags": ["register", "C2"] },
-    { "source": "аллитерация", "target": "aliterācija", "tags": ["register", "C2"] },
-    { "source": "неоднозначность", "target": "neskaidrība", "tags": ["register", "C2"] },
-    { "source": "художественный", "target": "māksliniecisks", "tags": ["register", "C2"] },
-    { "source": "эстетический", "target": "estētisks", "tags": ["register", "C2"] },
-    { "source": "романтический", "target": "romantisks", "tags": ["register", "C2"] },
-    { "source": "символический", "target": "simbolisks", "tags": ["register", "C2"] },
-    { "source": "мистический", "target": "mistisks", "tags": ["register", "C2"] },
-    { "source": "эклектический", "target": "eklektisks", "tags": ["academic", "C2"] },
-    { "source": "синергия", "target": "sinērgija", "tags": ["academic", "C2"] },
-    { "source": "холистический", "target": "holistisks", "tags": ["academic", "C2"] },
-    { "source": "редукционизм", "target": "reduktīvisms", "tags": ["academic", "C2"] },
-    { "source": "детерминизм", "target": "determinisms", "tags": ["academic", "C2"] },
-    { "source": "релятивизм", "target": "relativisms", "tags": ["academic", "C2"] },
-    { "source": "нигилизм", "target": "nihilisms", "tags": ["academic", "C2"] },
-    { "source": "скептицизм", "target": "skepticisms", "tags": ["academic", "C2"] },
-    { "source": "эмпиризм", "target": "empirisms", "tags": ["academic", "C2"] },
-    { "source": "рационализм", "target": "racionālisms", "tags": ["academic", "C2"] },
-    { "source": "в переносном смысле", "target": "pārnestā nozīmē", "tags": ["literary", "C2"] },
-    { "source": "в буквальном смысле", "target": "tiešā nozīmē", "tags": ["literary", "C2"] },
-    { "source": "риторика", "target": "retorika", "tags": ["literary", "C2"] },
-    { "source": "полемика", "target": "polemika", "tags": ["literary", "C2"] },
-    { "source": "эпиграмма", "target": "epigramma", "tags": ["literary", "C2"] },
-    { "source": "сатира", "target": "satīra", "tags": ["literary", "C2"] },
-    { "source": "пародия", "target": "parodija", "tags": ["literary", "C2"] },
-    { "source": "аналогия", "target": "analoģija", "tags": ["literary", "C2"] },
-    { "source": "метонимия", "target": "metonīmija", "tags": ["literary", "C2"] },
-    { "source": "экзистенциальный", "target": "eksistenciāls", "tags": ["academic", "C2"] },
-    { "source": "трансцендентный", "target": "transcendentāls", "tags": ["academic", "C2"] },
-    { "source": "метафизический", "target": "metafizisks", "tags": ["academic", "C2"] },
-    { "source": "телеологический", "target": "teleologs", "tags": ["academic", "C2"] },
-    { "source": "деонтологический", "target": "deontologs", "tags": ["academic", "C2"] },
-    { "source": "утилитаризм", "target": "utilitārisms", "tags": ["academic", "C2"] },
-    { "source": "непоправимый", "target": "neatjaunojams", "tags": ["archaic", "C2"] },
-    { "source": "необратимый", "target": "neatgriezenisks", "tags": ["archaic", "C2"] },
-    { "source": "печаль", "target": "bēdas", "tags": ["archaic", "C2"] },
-    { "source": "томиться", "target": "nīkuļot", "tags": ["archaic", "C2"] },
-    { "source": "лелеять", "target": "lolot", "tags": ["archaic", "C2"] },
-    { "source": "вздыхать", "target": "nopūsties", "tags": ["archaic", "C2"] },
-    { "source": "прослеживать", "target": "izsekot", "tags": ["verbs", "C2"] },
-    { "source": "вспоминать", "target": "atcerēties", "tags": ["verbs", "C2"] },
-    { "source": "воплощать", "target": "iemieso", "tags": ["verbs", "C2"] },
-    { "source": "проявляться", "target": "izpausties", "tags": ["verbs", "C2"] },
-    { "source": "искоренять", "target": "iznīdēt", "tags": ["verbs", "C2"] },
-    { "source": "укореняться", "target": "iesakņoties", "tags": ["verbs", "C2"] },
-    { "source": "нормативный", "target": "normatīvs", "tags": ["academic", "C2"] },
-    { "source": "дескриптивный", "target": "deskriptīvs", "tags": ["academic", "C2"] },
-    { "source": "прескриптивный", "target": "preskriptīvs", "tags": ["academic", "C2"] },
-    { "source": "символика", "target": "simbolika", "tags": ["literary", "C2"] },
-    { "source": "гипербола", "target": "hiperbola", "tags": ["literary", "C2"] },
-    { "source": "литота", "target": "litota", "tags": ["literary", "C2"] },
-    { "source": "общественное мнение", "target": "sabiedriskā doma", "tags": ["social", "C2"] },
-    { "source": "приток", "target": "pieplūdums", "tags": ["social", "C2"] }
+    {
+      "source": "меланхолия",
+      "target": "melanholija",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "ностальгия",
+      "target": "nostalģija",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "эйфория",
+      "target": "eiforija",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "апатия",
+      "target": "apatija",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "амбивалентность",
+      "target": "ambivalence",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "тревога",
+      "target": "nemiers",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "наивность",
+      "target": "naivums",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "ирония",
+      "target": "ironija",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "сарказм",
+      "target": "sarkasms",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "презрение",
+      "target": "nicinājums",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "честолюбие",
+      "target": "godkārība",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "невинность",
+      "target": "nevainīgums",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "восхищение",
+      "target": "apbrīna",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "благоговение",
+      "target": "bijāšana",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "недоверие",
+      "target": "neuzticēšanās",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "энтузиазм",
+      "target": "entuziasms",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "отчуждение",
+      "target": "atsvešinātība",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "эмпатия",
+      "target": "empātija",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "смирение",
+      "target": "pazemība",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "гордость",
+      "target": "lepnums",
+      "tags": ["emotions", "C2"]
+    },
+    {
+      "source": "коренное население",
+      "target": "pamatiedzīvotāji",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "колониализм",
+      "target": "koloniālisms",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "ассимиляция",
+      "target": "asimilācija",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "аккультурация",
+      "target": "akulturācija",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "этноцентризм",
+      "target": "etnocentrisms",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "плюрализм",
+      "target": "plurālisms",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "гегемония",
+      "target": "hegemonija",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "дискриминация",
+      "target": "diskriminācija",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "эмансипация",
+      "target": "emancipācija",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "сегрегация",
+      "target": "segregācija",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "афоризм",
+      "target": "aforisms",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "метафора",
+      "target": "metafora",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "аллегория",
+      "target": "alegorija",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "эпитет",
+      "target": "epitets",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "олицетворение",
+      "target": "personifikācija",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "возникать",
+      "target": "parādīties",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "исчезать",
+      "target": "izzust",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "мерцать",
+      "target": "mirdzeties",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "дрожать",
+      "target": "drebēt",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "квинтэссенция",
+      "target": "kvintesence",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "аксиома",
+      "target": "aksioma",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "тавтология",
+      "target": "tautologija",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "парадокс",
+      "target": "paradokss",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "феноменология",
+      "target": "fenomenoloģija",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "герменевтика",
+      "target": "hermeneitika",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "диалектика",
+      "target": "dialektika",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "прагматизм",
+      "target": "pragmatisms",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "великодушный",
+      "target": "dižciltīgs",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "великолепие",
+      "target": "krāšņums",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "блеск",
+      "target": "spožums",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "осязаемый",
+      "target": "tverams",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "неосязаемый",
+      "target": "netverams",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "двусмысленный",
+      "target": "divdomīgs",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "нейтральный",
+      "target": "neitrāls",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "тонкий",
+      "target": "smalks",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "утончённый",
+      "target": "izsmalcināts",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "экспрессивный",
+      "target": "ekspresīvs",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "благозвучный",
+      "target": "skanīgs",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "ассонанс",
+      "target": "assonanse",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "аллитерация",
+      "target": "aliterācija",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "неоднозначность",
+      "target": "neskaidrība",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "художественный",
+      "target": "māksliniecisks",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "эстетический",
+      "target": "estētisks",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "романтический",
+      "target": "romantisks",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "символический",
+      "target": "simbolisks",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "мистический",
+      "target": "mistisks",
+      "tags": ["register", "C2"]
+    },
+    {
+      "source": "эклектический",
+      "target": "eklektisks",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "синергия",
+      "target": "sinērgija",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "холистический",
+      "target": "holistisks",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "редукционизм",
+      "target": "reduktīvisms",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "детерминизм",
+      "target": "determinisms",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "релятивизм",
+      "target": "relativisms",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "нигилизм",
+      "target": "nihilisms",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "скептицизм",
+      "target": "skepticisms",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "эмпиризм",
+      "target": "empirisms",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "рационализм",
+      "target": "racionālisms",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "в переносном смысле",
+      "target": "pārnestā nozīmē",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "в буквальном смысле",
+      "target": "tiešā nozīmē",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "риторика",
+      "target": "retorika",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "полемика",
+      "target": "polemika",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "эпиграмма",
+      "target": "epigramma",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "сатира",
+      "target": "satīra",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "пародия",
+      "target": "parodija",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "аналогия",
+      "target": "analoģija",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "метонимия",
+      "target": "metonīmija",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "экзистенциальный",
+      "target": "eksistenciāls",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "трансцендентный",
+      "target": "transcendentāls",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "метафизический",
+      "target": "metafizisks",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "телеологический",
+      "target": "teleologs",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "деонтологический",
+      "target": "deontologs",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "утилитаризм",
+      "target": "utilitārisms",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "непоправимый",
+      "target": "neatjaunojams",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "необратимый",
+      "target": "neatgriezenisks",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "печаль",
+      "target": "bēdas",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "томиться",
+      "target": "nīkuļot",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "лелеять",
+      "target": "lolot",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "вздыхать",
+      "target": "nopūsties",
+      "tags": ["archaic", "C2"]
+    },
+    {
+      "source": "прослеживать",
+      "target": "izsekot",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "вспоминать",
+      "target": "atcerēties",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "воплощать",
+      "target": "iemieso",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "проявляться",
+      "target": "izpausties",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "искоренять",
+      "target": "iznīdēt",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "укореняться",
+      "target": "iesakņoties",
+      "tags": ["verbs", "C2"]
+    },
+    {
+      "source": "нормативный",
+      "target": "normatīvs",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "дескриптивный",
+      "target": "deskriptīvs",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "прескриптивный",
+      "target": "preskriptīvs",
+      "tags": ["academic", "C2"]
+    },
+    {
+      "source": "символика",
+      "target": "simbolika",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "гипербола",
+      "target": "hiperbola",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "литота",
+      "target": "litota",
+      "tags": ["literary", "C2"]
+    },
+    {
+      "source": "общественное мнение",
+      "target": "sabiedriskā doma",
+      "tags": ["social", "C2"]
+    },
+    {
+      "source": "приток",
+      "target": "pieplūdums",
+      "tags": ["social", "C2"]
+    }
   ]
 }

--- a/scripts/fix-pack-duplicates.py
+++ b/scripts/fix-pack-duplicates.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Fix cross-level duplicate words in starter packs.
+
+Strategy: For each language pair, keep each word in its lowest-level pack
+and remove it from higher-level packs. This preserves the original data
+while ensuring no duplicates across levels.
+
+Level order (lowest to highest): A1, A2, B1, B2, C1, C2
+"""
+
+import json
+import os
+
+PACKS_DIR = os.path.join(os.path.dirname(__file__), '..', 'public', 'starter-packs')
+LEVEL_ORDER = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2']
+LEVEL_FILES = {
+    'A1': 'a1', 'A2': 'a2', 'B1': 'b1', 'B2': 'b2', 'C1': 'c1', 'C2': 'c2'
+}
+PAIRS = ['en-lv', 'ru-en', 'ru-lv']
+
+
+def load_pack(pack_id: str) -> dict:
+    path = os.path.join(PACKS_DIR, f'{pack_id}.json')
+    with open(path) as f:
+        return json.load(f)
+
+
+def save_pack(pack_id: str, data: dict) -> None:
+    path = os.path.join(PACKS_DIR, f'{pack_id}.json')
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.write('\n')
+
+
+def fix_pair(pair: str) -> None:
+    print(f'\nProcessing {pair}...')
+
+    # Load all packs for this pair
+    packs = {}
+    for level in LEVEL_ORDER:
+        pack_id = f'{pair}-{LEVEL_FILES[level]}'
+        packs[level] = load_pack(pack_id)
+
+    # Track seen words (source+target key) as we go from lowest to highest level
+    seen: set[tuple[str, str]] = set()
+    removed_counts: dict[str, int] = {}
+
+    for level in LEVEL_ORDER:
+        pack = packs[level]
+        original_words = pack['words']
+        filtered_words = []
+        removed = 0
+
+        for word in original_words:
+            key = (word['source'].lower().strip(), word['target'].lower().strip())
+            if key in seen:
+                removed += 1
+            else:
+                seen.add(key)
+                filtered_words.append(word)
+
+        removed_counts[level] = removed
+        pack['words'] = filtered_words
+
+    # Report and save
+    for level in LEVEL_ORDER:
+        pack_id = f'{pair}-{LEVEL_FILES[level]}'
+        removed = removed_counts[level]
+        word_count = len(packs[level]['words'])
+        if removed > 0:
+            print(f'  {pack_id}: removed {removed} duplicates, {word_count} words remaining')
+        else:
+            print(f'  {pack_id}: no duplicates, {word_count} words')
+        save_pack(pack_id, packs[level])
+
+
+def verify_no_duplicates() -> bool:
+    print('\nVerifying no duplicates remain...')
+    all_ok = True
+    for pair in PAIRS:
+        seen: set[tuple[str, str]] = set()
+        pair_ok = True
+        for level in LEVEL_ORDER:
+            pack_id = f'{pair}-{LEVEL_FILES[level]}'
+            pack = load_pack(pack_id)
+            for word in pack['words']:
+                key = (word['source'].lower().strip(), word['target'].lower().strip())
+                if key in seen:
+                    print(f'  ERROR: {pair}: duplicate {word["source"]}/{word["target"]} in {level}')
+                    pair_ok = False
+                    all_ok = False
+                else:
+                    seen.add(key)
+        if pair_ok:
+            print(f'  {pair}: OK')
+    return all_ok
+
+
+def main() -> None:
+    print('Fixing cross-level duplicate words in starter packs...')
+    print(f'Strategy: Keep words in lowest-level pack, remove from higher levels')
+
+    for pair in PAIRS:
+        fix_pair(pair)
+
+    ok = verify_no_duplicates()
+
+    print('\nFinal word counts:')
+    for pair in PAIRS:
+        counts = []
+        for level in LEVEL_ORDER:
+            pack_id = f'{pair}-{LEVEL_FILES[level]}'
+            pack = load_pack(pack_id)
+            counts.append(f'{level}:{len(pack["words"])}')
+        print(f'  {pair}: {", ".join(counts)}')
+
+    if ok:
+        print('\nAll duplicates fixed successfully.')
+    else:
+        print('\nERROR: Some duplicates remain - check output above.')
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- 310 words were duplicated across CEFR levels within the same language pair (e.g., basic food words like \"bread\", \"water\", \"milk\" appeared in both A1 and B1)
- This violated acceptance criteria #5: \"No duplicate words across levels within the same language pair\"
- Strategy: keep each word in its lowest-level pack, remove it from all higher-level packs
- Adds `scripts/fix-pack-duplicates.py` for reproducibility and future use

## Changes

- `public/starter-packs/en-lv-*.json` - removed cross-level duplicates from 6 packs
- `public/starter-packs/ru-en-*.json` - removed cross-level duplicates from 6 packs
- `public/starter-packs/ru-lv-*.json` - removed cross-level duplicates from 6 packs
- `scripts/fix-pack-duplicates.py` - new script that performed the deduplication

## Final word counts after deduplication

| Pair | A1 | A2 | B1 | B2 | C1 | C2 |
|------|----|----|----|----|----|----|
| en-lv | 187 | 143 | 125 | 128 | 147 | 130 |
| ru-en | 186 | 138 | 124 | 121 | 141 | 119 |
| ru-lv | 186 | 137 | 121 | 120 | 132 | 111 |

B1/B2 splits are in the 100-130 range as expected (split from ~250-word combined packs). All other levels are 100+.

## Testing

- All 690 tests pass (`npm test -- --run`)
- TypeScript strict check passes (`npx tsc --noEmit`)
- Production build succeeds (`npm run build`)
- ESLint passes with zero warnings (`npx eslint . --max-warnings 0`)
- Prettier clean (`npx prettier --check .`)
- Custom acceptance criteria script verifies: no duplicates, all packs have correct schema, all words have level + topic tags

Closes #83