### PR TITLE
fix: replace deprecated apple-mobile-web-app-capable meta tag (#114)

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
          which are needed to handle the iPhone notch and home indicator. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#0a0f1a" />
-    <!-- iOS PWA meta tags -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <!-- PWA meta tags -->
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Lexio" />
     <title>Lexio - Vocabulary Trainer Built by AI</title>


### PR DESCRIPTION
## Summary

Removes the deprecated `apple-mobile-web-app-capable` meta tag from `index.html` and replaces it with the standard `mobile-web-app-capable` equivalent, silencing the Chrome DevTools deprecation warning.

## Changes

- `index.html`: replace `apple-mobile-web-app-capable` with `mobile-web-app-capable`
- `index.html`: update comment from `<!-- iOS PWA meta tags -->` to `<!-- PWA meta tags -->`

## Testing

- All 805 tests pass across 56 test files
- TypeScript type check: no errors
- ESLint: no warnings or errors
- Prettier: all files formatted correctly
- Build: succeeds with PWA assets generated correctly

## Review

- Code review passed — change is minimal, targeted, and correct

Closes #114