### PR TITLE
fix: responsive layout, clipped label, chart legend, and chip touch targets (#116)

### DIFF
--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -240,7 +240,7 @@ function AppContent(): React.JSX.Element {
           </AppBar>
 
           {/* Main content — bottom padding makes room for the fixed BottomNav */}
-          <Container maxWidth="sm" sx={{ py: 3, pb: showNav ? '72px' : 3 }}>
+          <Container maxWidth="md" sx={{ py: 3, pb: showNav ? '72px' : 3 }}>
             <TabTransition activeTab={activeTab}>
               {activeTab === 'home' && (
                 <DashboardScreen

--- a/src/features/settings/components/SettingsScreen.tsx
+++ b/src/features/settings/components/SettingsScreen.tsx
@@ -366,7 +366,7 @@ export function SettingsScreen({
 
       {/* ── 1. Preferences ── */}
       <Card variant="outlined">
-        <CardContent sx={{ p: 2.5 }}>
+        <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
           <Typography variant="subtitle2" fontWeight={700} gutterBottom>
             Preferences
           </Typography>
@@ -459,11 +459,11 @@ export function SettingsScreen({
               marks={[
                 { value: 0, label: 'Exact' },
                 { value: 1, label: 'Lenient' },
-                { value: 2, label: 'Very lenient' },
+                { value: 2, label: 'Lenient+' },
               ]}
               aria-label="Typo tolerance"
               aria-valuetext={typoInfo.label}
-              sx={{ mt: 1 }}
+              sx={{ mt: 1, mb: 1 }}
             />
             <Typography variant="caption" color="text.secondary">
               {typoInfo.description}
@@ -474,7 +474,7 @@ export function SettingsScreen({
 
       {/* ── 2. CEFR Levels ── */}
       <Card variant="outlined">
-        <CardContent sx={{ p: 2.5 }}>
+        <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
           <Typography variant="subtitle2" fontWeight={700} gutterBottom>
             Training levels
           </Typography>
@@ -496,7 +496,7 @@ export function SettingsScreen({
 
       {/* ── 3. Language Pairs ── */}
       <Card variant="outlined">
-        <CardContent sx={{ p: 2.5 }}>
+        <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
           <Typography variant="subtitle2" fontWeight={700} gutterBottom>
             Language pairs
           </Typography>
@@ -517,7 +517,7 @@ export function SettingsScreen({
 
       {/* ── 4. Data Management ── */}
       <Card variant="outlined">
-        <CardContent sx={{ p: 2.5 }}>
+        <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
           <Typography variant="subtitle2" fontWeight={700} gutterBottom>
             Data management
           </Typography>
@@ -602,7 +602,7 @@ export function SettingsScreen({
 
       {/* ── 5. About ── */}
       <Card variant="outlined">
-        <CardContent sx={{ p: 2.5 }}>
+        <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
             <InfoOutlinedIcon
               fontSize="small"

--- a/src/features/stats/components/ActivityChart.tsx
+++ b/src/features/stats/components/ActivityChart.tsx
@@ -33,11 +33,18 @@ const BAR_GAP = 2
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-/** Short label for a date (e.g. "Mon", "15"). For 7-day we show day name, for 30-day we show day-of-month. */
+/** Single-letter day abbreviations (locale-independent). */
+const DAY_LETTERS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'] as const
+
+/**
+ * Short label for a date.
+ * For 7-day view: single-letter day abbreviation (M, T, W…) to prevent overlap.
+ * For 30-day view: day-of-month number (1, 2, 3…).
+ */
 function dayLabel(dateStr: string, range: ActivityRange): string {
   const d = new Date(`${dateStr}T00:00:00`)
   if (range === 7) {
-    return d.toLocaleDateString(undefined, { weekday: 'short' })
+    return DAY_LETTERS[d.getDay()] ?? 'D'
   }
   return String(d.getDate())
 }

--- a/src/features/stats/components/OverallSummary.tsx
+++ b/src/features/stats/components/OverallSummary.tsx
@@ -39,10 +39,10 @@ function StatCell({ value, label, icon, color }: StatCellProps) {
     <Box sx={{ textAlign: 'center', p: 1 }}>
       {icon && <Box sx={{ display: 'flex', justifyContent: 'center', mb: 0.25 }}>{icon}</Box>}
       <Typography
-        variant="h5"
+        variant="h6"
         fontWeight={700}
         lineHeight={1}
-        sx={{ color: color ?? 'text.primary' }}
+        sx={{ color: color ?? 'text.primary', fontSize: '1.25rem' }}
       >
         {value}
       </Typography>

--- a/src/features/words/components/WordList.tsx
+++ b/src/features/words/components/WordList.tsx
@@ -246,18 +246,31 @@ export function WordList({ words, progressMap, onEdit, onDelete, onBulkDelete }:
           </FormControl>
         </Box>
 
-        {/* Tag filter chips */}
+        {/* Tag filter chips — horizontally scrollable on mobile for comfortable touch targets */}
         {allTags.length > 0 && (
-          <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 1,
+              flexWrap: 'nowrap',
+              overflowX: 'auto',
+              WebkitOverflowScrolling: 'touch',
+              pb: 0.5,
+              // Hide scrollbar on webkit while keeping scrollability
+              '&::-webkit-scrollbar': { display: 'none' },
+              scrollbarWidth: 'none',
+            }}
+          >
             {allTags.map((tag) => (
               <Chip
                 key={tag}
                 label={tag}
-                size="small"
+                size="medium"
                 onClick={() => handleToggleTag(tag)}
                 color={activeTags.includes(tag) ? 'primary' : 'default'}
                 variant={activeTags.includes(tag) ? 'filled' : 'outlined'}
                 aria-pressed={activeTags.includes(tag)}
+                sx={{ flexShrink: 0 }}
               />
             ))}
           </Box>


### PR DESCRIPTION
## Summary

Post-launch UI audit fixes — 6 usability issues across Settings, Stats, and Words screens.

## Changes

- **SettingsScreen.tsx** — Shorten typo tolerance slider mark to 'Lenient+' (was 'Very lenient', got clipped); make card padding responsive (`p: { xs: 2, sm: 2.5 }`)
- **ActivityChart.tsx** — Use single-letter day abbreviations (M T W T F S S) for 7-day chart x-axis to prevent label overlap/garble
- **OverallSummary.tsx** — Lock all stat numbers to `variant="h6"` at explicit `1.25rem` so they render identically regardless of MUI theme scaling
- **AppContent.tsx** — Increase container `maxWidth` from `"sm"` (~600px) to `"md"` (~900px) for better tablet/desktop layouts
- **WordList.tsx** — Upgrade category filter chips to `size="medium"` with 8px gap in a horizontally scrollable row (hidden scrollbar, touch-friendly)

## Testing

- All 805 tests pass (`npm test -- --run`)
- TypeScript strict mode passes (`npx tsc --noEmit`)
- Production build successful (`npm run build`)
- ESLint clean (`npx eslint . --max-warnings 0`)
- Prettier formatted (`npx prettier --check .`)

## Review

- Code review passed — all changes follow CLAUDE.md conventions, no hardcoded colours, no direct localStorage calls, mobile-first approach

Closes #116