### PR TITLE
fix: container maxWidth from md to lg for better desktop layout (#118)

### DIFF
--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -240,7 +240,7 @@ function AppContent(): React.JSX.Element {
           </AppBar>
 
           {/* Main content — bottom padding makes room for the fixed BottomNav */}
-          <Container maxWidth="md" sx={{ py: 3, pb: showNav ? '72px' : 3 }}>
+          <Container maxWidth="lg" sx={{ py: 3, pb: showNav ? '72px' : 3 }}>
             <TabTransition activeTab={activeTab}>
               {activeTab === 'home' && (
                 <DashboardScreen


### PR DESCRIPTION
## Summary

- Change `maxWidth="md"` (900px) to `maxWidth="lg"` (1200px) on the app `Container` in `src/AppContent.tsx`

## Changes

- `src/AppContent.tsx` - single line change: `maxWidth="md"` → `maxWidth="lg"`

## Testing

- All 805 tests pass (`npm test -- --run`)
- TypeScript strict mode passes (`npx tsc --noEmit`)
- ESLint passes with zero warnings (`npx eslint . --max-warnings 0`)
- Prettier formatting verified
- Production build succeeds (`npm run build`)

## Review

- Code review passed - minimal, correct, follows MUI conventions

Closes #118