### PR TITLE
fix: make ActivityChart and StreakCalendar responsive (#120)

### DIFF
--- a/src/features/stats/components/ActivityChart.tsx
+++ b/src/features/stats/components/ActivityChart.tsx
@@ -3,6 +3,9 @@
  *
  * Supports a 7-day and 30-day toggle. Each bar is colour-coded by the
  * correct/incorrect ratio for that day. Uses pure SVG — no chart library.
+ *
+ * The viewBox is calculated to exactly match the content bounds so the SVG
+ * scales uniformly with `preserveAspectRatio="xMidYMid meet"`.
  */
 
 import { useState } from 'react'
@@ -28,8 +31,30 @@ export interface ActivityChartProps {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const CHART_HEIGHT = 80
+/** Intrinsic chart height (SVG units). Wide enough to give bars visual weight. */
+const CHART_HEIGHT = 120
+
+/** Gap between bars in SVG units. */
 const BAR_GAP = 2
+
+/**
+ * Bar width per range.
+ * 7-day bars are wider so they fill the chart area without crowding.
+ * 30-day bars are narrower to fit 30 columns comfortably.
+ */
+const BAR_WIDTH: Record<ActivityRange, number> = {
+  7: 16,
+  30: 6,
+}
+
+/**
+ * Font size for day labels relative to bar width.
+ * Must be proportional so text doesn't appear oversized next to bars.
+ */
+const LABEL_FONT_SIZE: Record<ActivityRange, number> = {
+  7: 10,
+  30: 5,
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -62,22 +87,32 @@ interface SvgBarsProps {
 function SvgBars({ days, range, correctColor, incorrectColor, emptyColor }: SvgBarsProps) {
   const maxReviewed = Math.max(...days.map((d) => d.wordsReviewed), 1)
 
+  const barWidth = BAR_WIDTH[range]
+  const fontSize = LABEL_FONT_SIZE[range]
+
+  // Total width of all bars plus gaps — the SVG viewBox is sized to match exactly
+  // so every pixel of width is used and bars are evenly distributed.
+  const totalWidth = days.length * (barWidth + BAR_GAP) - BAR_GAP
+  // Extra vertical room for x-axis labels below the bars
+  const labelAreaHeight = fontSize + 6
+  const viewBoxHeight = CHART_HEIGHT + labelAreaHeight
+
   // For 30-day range only show every 5th x-axis label to avoid clutter.
   const labelEvery = range === 30 ? 5 : 1
 
   return (
-    <Box sx={{ width: '100%', overflowX: 'auto' }}>
+    <Box sx={{ width: '100%' }}>
       <svg
         width="100%"
-        viewBox={`0 0 ${days.length * (4 + BAR_GAP) * (range === 30 ? 1 : 2.5)} ${CHART_HEIGHT + 20}`}
-        preserveAspectRatio="none"
+        viewBox={`0 0 ${totalWidth} ${viewBoxHeight}`}
+        preserveAspectRatio="xMidYMid meet"
         aria-label={`Activity bar chart showing last ${range} days`}
         role="img"
         style={{ display: 'block' }}
       >
         {days.map((day, idx) => {
           const barHeight = (day.wordsReviewed / maxReviewed) * CHART_HEIGHT
-          const x = idx * (4 + BAR_GAP)
+          const x = idx * (barWidth + BAR_GAP)
           const y = CHART_HEIGHT - barHeight
 
           // Colour by accuracy ratio
@@ -100,16 +135,16 @@ function SvgBars({ days, range, correctColor, incorrectColor, emptyColor }: SvgB
               <rect
                 x={x}
                 y={day.wordsReviewed === 0 ? CHART_HEIGHT - 2 : y}
-                width={4}
+                width={barWidth}
                 height={day.wordsReviewed === 0 ? 2 : barHeight}
                 fill={barColor}
                 rx={1}
               />
               {showLabel && (
                 <text
-                  x={x + 2}
-                  y={CHART_HEIGHT + 14}
-                  fontSize={range === 30 ? 5 : 7}
+                  x={x + barWidth / 2}
+                  y={CHART_HEIGHT + labelAreaHeight - 2}
+                  fontSize={fontSize}
                   textAnchor="middle"
                   fill={emptyColor}
                 >

--- a/src/features/stats/components/StreakCalendar.tsx
+++ b/src/features/stats/components/StreakCalendar.tsx
@@ -8,6 +8,10 @@
  *   Level 2 = moderate  (25% of goal)
  *   Level 3 = good      (50%+ of goal)
  *   Level 4 = excellent (100%+ of goal / goal met)
+ *
+ * Layout uses CSS Grid with `1fr` columns so the calendar fills the full
+ * card width at any container size. Each cell has `aspect-ratio: 1` so the
+ * grid rows stay square without fixed pixel dimensions.
  */
 
 import { Box, Card, CardContent, Skeleton, Tooltip, Typography } from '@mui/material'
@@ -23,9 +27,13 @@ export interface StreakCalendarProps {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const CELL_SIZE = 12
-const CELL_GAP = 2
 const DAYS_PER_WEEK = 7
+
+/**
+ * Fixed size (px) used only for legend swatches and the loading skeleton.
+ * The actual calendar cells scale with the container via CSS Grid.
+ */
+const LEGEND_SWATCH_SIZE = 12
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -84,40 +92,51 @@ export function StreakCalendar({ days, loading }: StreakCalendarProps) {
         {loading ? (
           <Skeleton
             width="100%"
-            height={DAYS_PER_WEEK * (CELL_SIZE + CELL_GAP)}
+            height={DAYS_PER_WEEK * (LEGEND_SWATCH_SIZE + 2)}
             sx={{ borderRadius: 1 }}
           />
         ) : (
           <>
+            {/*
+             * Responsive grid: each week is a column of equal width (1fr).
+             * Cells use aspect-ratio:1 so they remain square at any width.
+             * gap is expressed in pixels because it needs to be consistent
+             * regardless of the container width.
+             */}
             <Box
-              sx={{ display: 'flex', gap: `${CELL_GAP}px`, overflowX: 'auto', py: 0.5 }}
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: `repeat(${weeks.length}, 1fr)`,
+                gap: '2px',
+                width: '100%',
+              }}
               role="grid"
               aria-label="Activity calendar heatmap"
             >
               {weeks.map((week, weekIdx) => (
                 <Box
                   key={weekIdx}
-                  sx={{ display: 'flex', flexDirection: 'column', gap: `${CELL_GAP}px` }}
+                  sx={{ display: 'flex', flexDirection: 'column', gap: '2px' }}
                   role="row"
                 >
                   {week.map((day) => {
                     const bgColor =
                       day.level === 0 ? emptyColor : levelToColor(day.level, emptyColor, primaryHex)
+                    const tooltipText = calendarTooltip(day)
 
                     return (
-                      <Tooltip key={day.date} title={calendarTooltip(day)} placement="top" arrow>
+                      <Tooltip key={day.date} title={tooltipText} placement="top" arrow>
                         <Box
                           role="gridcell"
-                          aria-label={calendarTooltip(day)}
+                          aria-label={tooltipText}
                           sx={{
-                            width: CELL_SIZE,
-                            height: CELL_SIZE,
+                            width: '100%',
+                            aspectRatio: '1',
                             borderRadius: '2px',
                             backgroundColor: bgColor,
                             cursor: 'default',
                             transition: 'opacity 0.15s',
                             '&:hover': { opacity: 0.8 },
-                            flexShrink: 0,
                           }}
                         />
                       </Tooltip>
@@ -136,11 +155,12 @@ export function StreakCalendar({ days, loading }: StreakCalendarProps) {
                 <Box
                   key={level}
                   sx={{
-                    width: CELL_SIZE,
-                    height: CELL_SIZE,
+                    width: LEGEND_SWATCH_SIZE,
+                    height: LEGEND_SWATCH_SIZE,
                     borderRadius: '2px',
                     backgroundColor:
                       level === 0 ? emptyColor : levelToColor(level, emptyColor, primaryHex),
+                    flexShrink: 0,
                   }}
                   aria-hidden="true"
                 />


### PR DESCRIPTION
## Summary

Fixes broken/non-responsive SVG layouts on the Stats screen.

- **ActivityChart**: viewBox was miscalculated (bars used ~40% of width, rest was empty space). Labels used a fixed font size of 7 while bars were 4 units wide, making them appear huge. Fixed by calculating viewBox to exactly match content bounds, switching to `preserveAspectRatio="xMidYMid meet"`, increasing chart height, and adding named constants for bar width and font size per range.
- **StreakCalendar**: used fixed 12px cells so the calendar sat as a 182px block regardless of container width. Fixed by replacing the flex layout with CSS Grid (`repeat(N, 1fr)`) and `aspectRatio: 1` cells.

## Changes

- `src/features/stats/components/ActivityChart.tsx` — correct viewBox calculation, named `BAR_WIDTH`/`LABEL_FONT_SIZE` constants, `xMidYMid meet` aspect ratio, centred labels
- `src/features/stats/components/StreakCalendar.tsx` — CSS Grid responsive layout, square cells via `aspectRatio: 1`

## Testing

- 805 tests across 56 files — all passing
- `npx tsc --noEmit` — clean
- `npm run build` — successful
- ESLint — no warnings
- Prettier — formatted

## Review

Code review passed — no issues found.

Closes #120