### PR TITLE
fix: run build workflow on pull requests (#156)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -75,6 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

The `build` status check was never appearing on PRs because `.github/workflows/deploy.yml` only triggered on `push` to `main`. Branch protection requires `build` to pass before merge, so every PR was permanently blocked.

## Changes

- `.github/workflows/deploy.yml` — three targeted changes:
  1. Added `pull_request: branches: [main]` trigger alongside the existing `push` trigger
  2. Gated the `deploy` job with `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` so PRs never publish to Pages
  3. Updated `concurrency.group` from `pages` to `pages-${{ github.ref }}` so PR builds cannot cancel a main deploy

## Testing

- All 806 unit tests pass locally (`npm test -- --run`)
- Lint, format, type check, and build all pass locally
- This PR is itself the acceptance test (self-bootstrap): the `build` check should appear and run on this PR due to the new trigger
- No app code was modified — only the CI workflow file

## Review

- Code review passed (see issue #156 comments)
- Reviewer confirmed: `pull_request` (not `pull_request_target`) is correct for repo-owned branches, deploy gating condition is correct, concurrency group change is correct

Closes #156