### PR TITLE
feat: add Liquid Glass design tokens and Glass primitive (#142)

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,15 +37,9 @@
       content="Learn vocabulary in any language. Designed by a human, built entirely by autonomous AI agents."
     />
     <meta name="twitter:image" content="https://mreppo.github.io/lexio/og-image.png" />
-    <!-- Google Fonts: Sora (display) + Nunito (body). Both support Latvian diacritics.
-         No integrity attribute: Google Fonts CSS is dynamically generated per user-agent
-         and changes frequently, making static SRI hashes impractical. -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&family=Nunito:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap"
-    />
+    <!-- Fonts are loaded via @fontsource/inter imported in src/main.tsx.
+         Inter covers Latvian diacritics (ā, č, ē, ģ, ī, ķ, ļ, ņ, š, ū, ž) and serves
+         as the cross-platform fallback for the SF Pro Display / SF Pro Text system stack. -->
     <!-- GoatCounter analytics: cookie-free, GDPR-compliant, ~3.5KB gzipped.
          no_onload: true disables automatic pageview on load — required for
          HashRouter SPAs where GoatCounter's pushState detection does not fire.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",
+        "@fontsource/inter": "^5.2.8",
         "@mui/icons-material": "^6.4.7",
         "@mui/material": "^6.4.7",
         "@sentry/react": "^10.45.0",
@@ -2499,6 +2500,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.5",
     "@emotion/styled": "^11.13.5",
+    "@fontsource/inter": "^5.2.8",
     "@mui/icons-material": "^6.4.7",
     "@mui/material": "^6.4.7",
     "@sentry/react": "^10.45.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,15 @@ import { BrandedLoader } from './components/BrandedLoader'
 import { useAnalytics } from './hooks/useAnalytics'
 
 /**
+ * Dev-only: lazy-load the Glass demo page so it is never included in the
+ * production bundle. The import() is inside the DEV guard so the module
+ * reference itself is dead code in production builds (tree-shaken by Vite).
+ */
+const LazyGlassDemo = import.meta.env.DEV
+  ? lazy(() => import('./features/glass-demo/GlassDemo').then((m) => ({ default: m.GlassDemo })))
+  : null
+
+/**
  * A single shared storage instance for the entire application.
  * Created here (entry point) so both the landing page and the lazy-loaded
  * app shell share the same instance via StorageContext.
@@ -113,6 +122,18 @@ export default function App() {
                 </Suspense>
               }
             />
+
+            {/* Dev-only Glass demo route — tree-shaken out of production builds */}
+            {import.meta.env.DEV && LazyGlassDemo && (
+              <Route
+                path="/__glass-demo"
+                element={
+                  <Suspense fallback={<Box sx={{ p: 4, color: '#fff' }}>Loading demo…</Box>}>
+                    <LazyGlassDemo />
+                  </Suspense>
+                }
+              />
+            )}
 
             {/* Redirect any unknown route to the landing page */}
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/primitives/Glass.test.tsx
+++ b/src/components/primitives/Glass.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from '@mui/material'
+import { createAppTheme } from '../../theme'
+import { Glass } from './Glass'
+
+function renderWithTheme(
+  ui: React.ReactNode,
+  mode: 'light' | 'dark' = 'dark',
+): ReturnType<typeof render> {
+  return render(<ThemeProvider theme={createAppTheme(mode)}>{ui}</ThemeProvider>)
+}
+
+describe('Glass', () => {
+  it('should render children', () => {
+    renderWithTheme(
+      <Glass>
+        <span>Hello Glass</span>
+      </Glass>,
+    )
+    expect(screen.getByText('Hello Glass')).toBeInTheDocument()
+  })
+
+  it('should render with default props (no strong, no floating)', () => {
+    const { container } = renderWithTheme(<Glass>content</Glass>)
+    expect(container.firstChild).toBeTruthy()
+  })
+
+  it('should render with strong prop', () => {
+    renderWithTheme(<Glass strong>strong content</Glass>)
+    expect(screen.getByText('strong content')).toBeInTheDocument()
+  })
+
+  it('should render with floating prop', () => {
+    renderWithTheme(<Glass floating>floating content</Glass>)
+    expect(screen.getByText('floating content')).toBeInTheDocument()
+  })
+
+  it('should render with strong and floating combined', () => {
+    renderWithTheme(
+      <Glass strong floating>
+        combo
+      </Glass>,
+    )
+    expect(screen.getByText('combo')).toBeInTheDocument()
+  })
+
+  it('should render with radius preset "card"', () => {
+    renderWithTheme(<Glass radius="card">card</Glass>)
+    expect(screen.getByText('card')).toBeInTheDocument()
+  })
+
+  it('should render with radius preset "btn"', () => {
+    renderWithTheme(<Glass radius="btn">btn</Glass>)
+    expect(screen.getByText('btn')).toBeInTheDocument()
+  })
+
+  it('should render with radius preset "glass"', () => {
+    renderWithTheme(<Glass radius="glass">glass</Glass>)
+    expect(screen.getByText('glass')).toBeInTheDocument()
+  })
+
+  it('should render with radius preset "pill"', () => {
+    renderWithTheme(<Glass radius="pill">pill</Glass>)
+    expect(screen.getByText('pill')).toBeInTheDocument()
+  })
+
+  it('should render with numeric radius', () => {
+    renderWithTheme(<Glass radius={8}>eight</Glass>)
+    expect(screen.getByText('eight')).toBeInTheDocument()
+  })
+
+  it('should render with radius 0', () => {
+    renderWithTheme(<Glass radius={0}>zero</Glass>)
+    expect(screen.getByText('zero')).toBeInTheDocument()
+  })
+
+  it('should render with custom pad', () => {
+    renderWithTheme(<Glass pad={24}>padded</Glass>)
+    expect(screen.getByText('padded')).toBeInTheDocument()
+  })
+
+  it('should render correctly in light mode', () => {
+    renderWithTheme(<Glass>light mode</Glass>, 'light')
+    expect(screen.getByText('light mode')).toBeInTheDocument()
+  })
+
+  it('should render correctly in dark mode', () => {
+    renderWithTheme(<Glass>dark mode</Glass>, 'dark')
+    expect(screen.getByText('dark mode')).toBeInTheDocument()
+  })
+
+  it('should render with a custom component type', () => {
+    renderWithTheme(<Glass component="section">section content</Glass>)
+    const el = screen.getByText('section content').closest('section')
+    expect(el).toBeTruthy()
+  })
+
+  it('should apply sx prop styles', () => {
+    const { container } = renderWithTheme(<Glass sx={{ width: 200 }}>styled</Glass>)
+    expect(container.firstChild).toBeTruthy()
+    expect(screen.getByText('styled')).toBeInTheDocument()
+  })
+
+  it('should have 3 child nodes (fill, rim, content layers)', () => {
+    const { container } = renderWithTheme(<Glass>layers</Glass>)
+    // The outer wrapper has 3 children: fill layer, rim layer, content layer
+    expect(container.firstChild?.childNodes).toHaveLength(3)
+  })
+
+  it('should mark fill and rim layers as aria-hidden', () => {
+    const { container } = renderWithTheme(<Glass>a11y</Glass>)
+    const hiddenEls = container.querySelectorAll('[aria-hidden="true"]')
+    // fill layer + rim layer = 2 aria-hidden elements
+    expect(hiddenEls).toHaveLength(2)
+  })
+})

--- a/src/components/primitives/Glass.tsx
+++ b/src/components/primitives/Glass.tsx
@@ -1,0 +1,139 @@
+/**
+ * Glass — the core Liquid Glass surface primitive.
+ *
+ * Every glass surface in Lexio is built from this component. It implements the
+ * 3-layer anatomy described in docs/design/liquid-glass/README.md:
+ *
+ *   1. Fill layer  — backdrop-filter + background fill (glassBg / glassBgStrong)
+ *   2. Rim layer   — 0.5px border + inner-highlight box-shadow
+ *   3. Content layer — relative positioned slot with padding
+ *
+ * All three layers share border-radius via `border-radius: inherit`.
+ *
+ * Reduce Transparency fallback:
+ *   When `@media (prefers-reduced-transparency: reduce)` matches, the blur is
+ *   removed and the surface becomes solid (bg token) with a rule2-coloured
+ *   0.5px border. This ensures legibility for users who have disabled
+ *   transparency in their OS accessibility settings.
+ *
+ * GPU note: do NOT animate properties on blurred surfaces. Enter/exit
+ * transitions should use opacity/transform only (no animating background,
+ * backdrop-filter, or box-shadow).
+ */
+
+import { Box, type SxProps, type Theme } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { getGlassTokens, glassRadius } from '../../theme/liquidGlass'
+
+/** Named radius presets matching tokens.json. */
+type RadiusPreset = 'card' | 'btn' | 'glass' | 'pill'
+
+export interface GlassProps {
+  /** Use glassBgStrong instead of glassBg for the fill layer. */
+  readonly strong?: boolean
+  /** Add the outer drop shadow (glassShadow). */
+  readonly floating?: boolean
+  /**
+   * Border-radius override.
+   * - number: explicit pixel value
+   * - 'card' | 'btn' | 'glass' | 'pill': token preset
+   * Defaults to glassRadius.card (22px).
+   */
+  readonly radius?: number | RadiusPreset
+  /** Content padding override in px. Defaults to 16. */
+  readonly pad?: number
+  readonly children?: React.ReactNode
+  readonly sx?: SxProps<Theme>
+  readonly className?: string
+  /** HTML element to render as (default: 'div'). */
+  readonly component?: React.ElementType
+}
+
+function resolveRadius(radius: number | RadiusPreset | undefined): number {
+  if (radius === undefined) return glassRadius.card
+  if (typeof radius === 'number') return radius
+  return glassRadius[radius]
+}
+
+export function Glass({
+  strong = false,
+  floating = false,
+  radius,
+  pad = 16,
+  children,
+  sx,
+  className,
+  component = 'div',
+}: GlassProps): React.JSX.Element {
+  const theme = useTheme()
+  const tokens = getGlassTokens(theme.palette.mode)
+  const r = resolveRadius(radius)
+
+  const fillBg = strong ? tokens.glass.bgStrong : tokens.glass.bg
+  const outerShadow = floating ? tokens.glass.shadow : undefined
+
+  return (
+    // Outer wrapper — establishes the border-radius context that all layers inherit
+    <Box
+      component={component}
+      className={className}
+      sx={{
+        position: 'relative',
+        borderRadius: `${r}px`,
+        // Outer drop shadow when floating
+        boxShadow: outerShadow,
+        // Pass through any caller overrides
+        ...sx,
+      }}
+    >
+      {/* Layer 1: Fill — backdrop-filter + glass background */}
+      <Box
+        aria-hidden="true"
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius: 'inherit',
+          // Backdrop blur + saturate — requires -webkit- prefix for iOS Safari
+          backdropFilter: tokens.glass.backdropFilter,
+          WebkitBackdropFilter: tokens.glass.backdropFilter,
+          backgroundColor: fillBg,
+          // Reduce Transparency fallback: solid bg, no blur
+          '@media (prefers-reduced-transparency: reduce)': {
+            backdropFilter: 'none',
+            WebkitBackdropFilter: 'none',
+            backgroundColor: tokens.color.bg,
+          },
+        }}
+      />
+
+      {/* Layer 2: Rim + inner highlight — pointer-events: none so it never blocks interaction */}
+      <Box
+        aria-hidden="true"
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius: 'inherit',
+          border: `0.5px solid ${tokens.glass.border}`,
+          boxShadow: tokens.glass.inner,
+          pointerEvents: 'none',
+          // Reduce Transparency fallback: swap rim to rule2 hairline, remove inner highlight
+          '@media (prefers-reduced-transparency: reduce)': {
+            border: `0.5px solid ${tokens.color.rule2}`,
+            boxShadow: 'none',
+          },
+        }}
+      />
+
+      {/* Layer 3: Content — relative so it sits above the absolute fill/rim layers */}
+      <Box
+        sx={{
+          position: 'relative',
+          borderRadius: 'inherit',
+          padding: `${pad}px`,
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/primitives/PaperSurface.test.tsx
+++ b/src/components/primitives/PaperSurface.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from '@mui/material'
+import { createAppTheme } from '../../theme'
+import { PaperSurface } from './PaperSurface'
+import { lightGlass, darkGlass } from '../../theme/liquidGlass'
+
+function renderWithTheme(
+  ui: React.ReactNode,
+  mode: 'light' | 'dark' = 'dark',
+): ReturnType<typeof render> {
+  return render(<ThemeProvider theme={createAppTheme(mode)}>{ui}</ThemeProvider>)
+}
+
+describe('PaperSurface', () => {
+  it('should render children', () => {
+    renderWithTheme(
+      <PaperSurface>
+        <span>Hello Surface</span>
+      </PaperSurface>,
+    )
+    expect(screen.getByText('Hello Surface')).toBeInTheDocument()
+  })
+
+  it('should render without children', () => {
+    const { container } = renderWithTheme(<PaperSurface />)
+    expect(container.firstChild).toBeTruthy()
+  })
+
+  it('should apply the wallpaper gradient in light mode', () => {
+    const { container } = renderWithTheme(<PaperSurface>content</PaperSurface>, 'light')
+    const el = container.firstChild as HTMLElement
+    // The wallpaper background should contain the light variant gradient fragments
+    const bg = el.style.background
+    // MUI applies styles via emotion class — check that tokens reference correct gradient
+    // (jsdom may not render computed styles perfectly, but we verify rendering doesn't throw)
+    expect(el).toBeTruthy()
+    // Token cross-check: light wallpaper contains #FFD6A5
+    expect(lightGlass.wallpaper).toContain('#FFD6A5')
+    void bg // suppress unused variable warning
+  })
+
+  it('should apply the wallpaper gradient in dark mode', () => {
+    const { container } = renderWithTheme(<PaperSurface>content</PaperSurface>, 'dark')
+    const el = container.firstChild as HTMLElement
+    expect(el).toBeTruthy()
+    // Token cross-check: dark wallpaper contains #3A1E6B
+    expect(darkGlass.wallpaper).toContain('#3A1E6B')
+  })
+
+  it('should pass through sx prop', () => {
+    renderWithTheme(<PaperSurface sx={{ padding: 4 }}>padded</PaperSurface>)
+    expect(screen.getByText('padded')).toBeInTheDocument()
+  })
+
+  it('should render multiple children', () => {
+    renderWithTheme(
+      <PaperSurface>
+        <div>First</div>
+        <div>Second</div>
+      </PaperSurface>,
+    )
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+})

--- a/src/components/primitives/PaperSurface.tsx
+++ b/src/components/primitives/PaperSurface.tsx
@@ -1,0 +1,46 @@
+/**
+ * PaperSurface — full-bleed screen root component.
+ *
+ * Every screen in Lexio is wrapped in PaperSurface. It:
+ *   - Fills the entire viewport (min-height: 100dvh, width: 100%)
+ *   - Renders the wallpaper gradient from Liquid Glass tokens as the background
+ *   - Sets the text color to the ink token
+ *   - Clips overflow (so glass cards don't leak outside the screen bounds)
+ *
+ * The wallpaper is 4 stacked CSS radial/linear gradients from tokens.json,
+ * applied verbatim — this is the "vivid backdrop" that the glass surfaces
+ * need to refract through.
+ */
+
+import { Box, type SxProps, type Theme } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { getGlassTokens } from '../../theme/liquidGlass'
+
+export interface PaperSurfaceProps {
+  readonly children?: React.ReactNode
+  readonly sx?: SxProps<Theme>
+}
+
+export function PaperSurface({ children, sx }: PaperSurfaceProps): React.JSX.Element {
+  const theme = useTheme()
+  const tokens = getGlassTokens(theme.palette.mode)
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        minHeight: '100dvh',
+        width: '100%',
+        // Wallpaper: 4 stacked gradients verbatim from tokens.json
+        background: tokens.wallpaper,
+        // Fallback solid color if gradients cannot render
+        backgroundColor: tokens.color.bg,
+        color: tokens.color.ink,
+        overflow: 'hidden',
+        ...sx,
+      }}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/src/components/primitives/index.ts
+++ b/src/components/primitives/index.ts
@@ -1,0 +1,4 @@
+export { Glass } from './Glass'
+export type { GlassProps } from './Glass'
+export { PaperSurface } from './PaperSurface'
+export type { PaperSurfaceProps } from './PaperSurface'

--- a/src/features/glass-demo/GlassDemo.tsx
+++ b/src/features/glass-demo/GlassDemo.tsx
@@ -1,0 +1,170 @@
+/**
+ * GlassDemo — dev-only visual test page for the Liquid Glass primitives.
+ *
+ * Accessible at /#/__glass-demo in development builds only.
+ * This file is tree-shaken out of production bundles because every code path
+ * is gated via the `import.meta.env.DEV` check in App.tsx where the route is
+ * registered. If App.tsx imports this lazily (React.lazy), it is only fetched
+ * when the route is visited.
+ *
+ * Grid: light × dark  ×  default / strong / floating  ×  all radius presets
+ */
+
+import { useState } from 'react'
+import { Box, Typography, Switch, FormControlLabel } from '@mui/material'
+import { ThemeProvider, CssBaseline } from '@mui/material'
+import { createAppTheme } from '../../theme'
+import { Glass } from '../../components/primitives/Glass'
+import { PaperSurface } from '../../components/primitives/PaperSurface'
+import { glassRadius } from '../../theme/liquidGlass'
+
+const RADIUS_PRESETS = [
+  { label: 'card (22)', value: 'card' },
+  { label: 'btn (18)', value: 'btn' },
+  { label: 'glass (28)', value: 'glass' },
+  { label: 'pill (999)', value: 'pill' },
+  { label: 'custom: 0', value: 0 },
+  { label: 'custom: 8', value: 8 },
+  { label: 'custom: 40', value: 40 },
+] as const
+
+type RadiusValue = (typeof RADIUS_PRESETS)[number]['value']
+
+function GlassDemoSection({ mode }: { readonly mode: 'light' | 'dark' }) {
+  const theme = createAppTheme(mode)
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <PaperSurface
+        sx={{
+          minHeight: 'auto',
+          p: 3,
+          borderRadius: 2,
+          overflow: 'visible',
+        }}
+      >
+        <Typography
+          variant="h4"
+          sx={{
+            mb: 2,
+            fontWeight: 800,
+            color: mode === 'dark' ? '#fff' : '#111114',
+          }}
+        >
+          {mode === 'light' ? 'Liquid Glass — Light' : 'Liquid Glass Dark'}
+        </Typography>
+
+        {/* default vs strong */}
+        <Typography variant="body2" sx={{ mb: 1, opacity: 0.6 }}>
+          Default vs Strong
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 2, mb: 3, flexWrap: 'wrap' }}>
+          <Glass sx={{ flex: '1 1 200px' }}>
+            <Typography variant="body1">Default glass</Typography>
+            <Typography variant="body2" sx={{ opacity: 0.6 }}>
+              glassBg fill
+            </Typography>
+          </Glass>
+          <Glass strong sx={{ flex: '1 1 200px' }}>
+            <Typography variant="body1">Strong glass</Typography>
+            <Typography variant="body2" sx={{ opacity: 0.6 }}>
+              glassBgStrong fill
+            </Typography>
+          </Glass>
+        </Box>
+
+        {/* floating */}
+        <Typography variant="body2" sx={{ mb: 1, opacity: 0.6 }}>
+          Floating (outer shadow)
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 2, mb: 3, flexWrap: 'wrap' }}>
+          <Glass floating sx={{ flex: '1 1 200px' }}>
+            <Typography variant="body1">Floating</Typography>
+            <Typography variant="body2" sx={{ opacity: 0.6 }}>
+              glassShadow outer drop
+            </Typography>
+          </Glass>
+          <Glass strong floating sx={{ flex: '1 1 200px' }}>
+            <Typography variant="body1">Strong + Floating</Typography>
+            <Typography variant="body2" sx={{ opacity: 0.6 }}>
+              Combined variant
+            </Typography>
+          </Glass>
+        </Box>
+
+        {/* all radius presets */}
+        <Typography variant="body2" sx={{ mb: 1, opacity: 0.6 }}>
+          Radius presets
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+          {RADIUS_PRESETS.map((preset) => (
+            <Glass
+              key={String(preset.value)}
+              radius={preset.value as RadiusValue}
+              floating
+              sx={{ flex: '1 1 140px', minWidth: 120 }}
+            >
+              <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                {preset.label}
+              </Typography>
+              <Typography variant="caption" sx={{ opacity: 0.5 }}>
+                {typeof preset.value === 'number'
+                  ? `${preset.value}px`
+                  : `${glassRadius[preset.value as keyof typeof glassRadius]}px`}
+              </Typography>
+            </Glass>
+          ))}
+        </Box>
+      </PaperSurface>
+    </ThemeProvider>
+  )
+}
+
+export function GlassDemo(): React.JSX.Element {
+  const [showDark, setShowDark] = useState(true)
+
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        background: '#1a1a2e',
+        p: 2,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
+        <Typography variant="h5" sx={{ color: '#fff', fontWeight: 800, flexGrow: 1 }}>
+          Glass Demo — /__glass-demo (DEV ONLY)
+        </Typography>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={showDark}
+              onChange={(e) => setShowDark(e.target.checked)}
+              sx={{ '& .MuiSwitch-track': { bgcolor: '#444' } }}
+            />
+          }
+          label={<Typography sx={{ color: '#fff' }}>Dark</Typography>}
+        />
+      </Box>
+
+      {/* Light mode section */}
+      {!showDark && <GlassDemoSection mode="light" />}
+      {/* Dark mode section */}
+      {showDark && <GlassDemoSection mode="dark" />}
+
+      {/* Both side by side when screen is wide enough */}
+      <Box sx={{ display: { xs: 'none', lg: 'flex' }, gap: 2 }}>
+        <Box sx={{ flex: 1 }}>
+          <GlassDemoSection mode="light" />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <GlassDemoSection mode="dark" />
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,14 @@
 import { initSentry } from './services/sentry'
 initSentry()
 
+// Inter font — cross-platform fallback for the SF Pro Display/Text system stack.
+// Weights 400–800 cover all type roles defined in docs/design/liquid-glass/tokens.json.
+import '@fontsource/inter/400.css'
+import '@fontsource/inter/500.css'
+import '@fontsource/inter/600.css'
+import '@fontsource/inter/700.css'
+import '@fontsource/inter/800.css'
+
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'

--- a/src/theme/liquidGlass.ts
+++ b/src/theme/liquidGlass.ts
@@ -1,0 +1,254 @@
+/**
+ * Liquid Glass design tokens — iOS 26 aesthetic.
+ *
+ * Two variants:
+ *   lightGlass — vivid wallpaper gradient, translucent glass chrome
+ *   darkGlass  — deep ambient background, refractive glass
+ *
+ * Values are copied verbatim from docs/design/liquid-glass/tokens.json.
+ * Do NOT change any numeric or color value without updating tokens.json first.
+ */
+
+export interface GlassColorTokens {
+  readonly bg: string
+  readonly ink: string
+  readonly inkSoft: string
+  readonly inkSec: string
+  readonly inkFaint: string
+  readonly rule2: string
+  readonly accent: string
+  readonly accentSoft: string
+  readonly accentText: string
+  readonly ok: string
+  readonly warn: string
+  readonly red: string
+  readonly violet: string
+  readonly pink: string
+}
+
+export interface GlassLayerTokens {
+  readonly bg: string
+  readonly bgStrong: string
+  readonly border: string
+  readonly inner: string
+  readonly shadow: string
+  readonly backdropFilter: string
+}
+
+export interface GlassTypographyRoleTokens {
+  readonly size: number
+  readonly weight: number
+  readonly tracking: number
+  readonly lineHeight: number
+  readonly transform?: string
+}
+
+export interface GlassTypographyTokens {
+  readonly display: string
+  readonly body: string
+  readonly mono: string
+  readonly roles: {
+    readonly heroWord: GlassTypographyRoleTokens
+    readonly largeTitle: GlassTypographyRoleTokens
+    readonly onboardHeadline: GlassTypographyRoleTokens
+    readonly title: GlassTypographyRoleTokens
+    readonly body: GlassTypographyRoleTokens
+    readonly button: GlassTypographyRoleTokens
+    readonly copy: GlassTypographyRoleTokens
+    readonly caption: GlassTypographyRoleTokens
+    readonly micro: GlassTypographyRoleTokens
+    readonly uppercaseLabel: GlassTypographyRoleTokens
+  }
+}
+
+export interface GlassRadiusTokens {
+  readonly card: number
+  readonly btn: number
+  readonly glass: number
+  readonly inline: number
+  readonly iconSquare: number
+  readonly pill: number
+}
+
+export interface GlassSpacingTokens {
+  readonly unit: number
+  readonly scale: readonly number[]
+  readonly screenPadX: number
+  readonly navTop: number
+  readonly tabBottom: number
+}
+
+export interface GlassShadowTokens {
+  readonly glassFloat: string
+  readonly glassFloatDark: string
+  readonly accentBtn: string
+  readonly whiteBtn: string
+  readonly iconSquare: string
+  readonly activeTab: string
+  readonly filterActive: string
+}
+
+export interface GlassMotionTokens {
+  readonly toggle: string
+  readonly progress: string
+  readonly caretBlink: string
+}
+
+export interface GlassVariantTokens {
+  readonly name: string
+  readonly wallpaper: string
+  readonly color: GlassColorTokens
+  readonly glass: GlassLayerTokens
+  readonly dark: boolean
+}
+
+export interface LiquidGlassTokens {
+  readonly lightGlass: GlassVariantTokens
+  readonly darkGlass: GlassVariantTokens
+  readonly radius: GlassRadiusTokens
+  readonly spacing: GlassSpacingTokens
+  readonly typography: GlassTypographyTokens
+  readonly shadows: GlassShadowTokens
+  readonly motion: GlassMotionTokens
+}
+
+/**
+ * Light variant — vivid wallpaper gradient, translucent glass chrome.
+ * Wallpaper is 4 stacked CSS gradients in one declaration (verbatim from tokens.json).
+ */
+export const lightGlass: GlassVariantTokens = {
+  name: 'Liquid Glass',
+  wallpaper:
+    'radial-gradient(1200px 600px at 85% -10%, #FFD6A5 0%, transparent 50%), radial-gradient(900px 500px at -10% 30%, #A5C8FF 0%, transparent 55%), radial-gradient(800px 500px at 50% 110%, #FFB3D4 0%, transparent 55%), linear-gradient(180deg,#F9F7F2 0%,#EEEDF6 100%)',
+  color: {
+    bg: '#F4F2EE',
+    ink: '#111114',
+    inkSoft: 'rgba(30,30,36,0.75)',
+    inkSec: 'rgba(30,30,36,0.55)',
+    inkFaint: 'rgba(30,30,36,0.28)',
+    rule2: 'rgba(0,0,0,0.08)',
+    accent: '#007AFF',
+    accentSoft: 'rgba(0,122,255,0.14)',
+    accentText: '#0060D6',
+    ok: '#34C759',
+    warn: '#FF9500',
+    red: '#FF3B30',
+    violet: '#AF52DE',
+    pink: '#FF2D55',
+  },
+  glass: {
+    bg: 'rgba(255,255,255,0.55)',
+    bgStrong: 'rgba(255,255,255,0.72)',
+    border: 'rgba(255,255,255,0.7)',
+    inner:
+      'inset 1.5px 1.5px 1px rgba(255,255,255,0.85), inset -1px -1px 1px rgba(255,255,255,0.5)',
+    shadow: '0 1px 3px rgba(0,0,0,0.05), 0 8px 30px rgba(0,0,0,0.08)',
+    backdropFilter: 'blur(24px) saturate(180%)',
+  },
+  dark: false,
+}
+
+/**
+ * Dark variant — deep ambient background, refractive glass.
+ * Wallpaper is 4 stacked CSS gradients in one declaration (verbatim from tokens.json).
+ */
+export const darkGlass: GlassVariantTokens = {
+  name: 'Liquid Glass Dark',
+  wallpaper:
+    'radial-gradient(900px 500px at 100% -10%, #3A1E6B 0%, transparent 55%), radial-gradient(900px 500px at -10% 50%, #0F3B6C 0%, transparent 55%), radial-gradient(700px 400px at 50% 110%, #6B1E4A 0%, transparent 55%), linear-gradient(180deg,#0A0A10 0%,#14121D 100%)',
+  color: {
+    bg: '#0A0A10',
+    ink: '#FFFFFF',
+    inkSoft: 'rgba(255,255,255,0.82)',
+    inkSec: 'rgba(255,255,255,0.55)',
+    inkFaint: 'rgba(255,255,255,0.28)',
+    rule2: 'rgba(255,255,255,0.1)',
+    accent: '#0A84FF',
+    accentSoft: 'rgba(10,132,255,0.22)',
+    accentText: '#6FB4FF',
+    ok: '#30D158',
+    warn: '#FF9F0A',
+    red: '#FF453A',
+    violet: '#BF5AF2',
+    pink: '#FF375F',
+  },
+  glass: {
+    bg: 'rgba(255,255,255,0.10)',
+    bgStrong: 'rgba(255,255,255,0.18)',
+    border: 'rgba(255,255,255,0.22)',
+    inner:
+      'inset 1.5px 1.5px 1px rgba(255,255,255,0.14), inset -1px -1px 1px rgba(255,255,255,0.06)',
+    shadow: '0 1px 3px rgba(0,0,0,0.4), 0 12px 36px rgba(0,0,0,0.5)',
+    backdropFilter: 'blur(24px) saturate(180%)',
+  },
+  dark: true,
+}
+
+/** Shared radius scale (same for both variants). */
+export const glassRadius: GlassRadiusTokens = {
+  card: 22,
+  btn: 18,
+  glass: 28,
+  inline: 14,
+  iconSquare: 10,
+  pill: 999,
+}
+
+/** Shared spacing scale (same for both variants). */
+export const glassSpacing: GlassSpacingTokens = {
+  unit: 4,
+  scale: [4, 8, 10, 12, 14, 16, 18, 20, 22, 24, 28, 36, 46, 56, 72],
+  screenPadX: 16,
+  navTop: 52,
+  tabBottom: 30,
+}
+
+/**
+ * Typography tokens.
+ * Display font: SF Pro Display (system) with Inter as cross-platform fallback.
+ * Body font: SF Pro Text (system) with Inter as cross-platform fallback.
+ * The Inter import (via @fontsource/inter) is in src/main.tsx.
+ */
+export const glassTypography: GlassTypographyTokens = {
+  display: '-apple-system, "SF Pro Display", "Helvetica Neue", Inter, system-ui, sans-serif',
+  body: '-apple-system, "SF Pro Text", Inter, system-ui, sans-serif',
+  mono: '"SF Mono", ui-monospace, monospace',
+  roles: {
+    heroWord: { size: 72, weight: 800, tracking: -1.2, lineHeight: 1.02 },
+    largeTitle: { size: 36, weight: 800, tracking: -1, lineHeight: 1.05 },
+    onboardHeadline: { size: 42, weight: 800, tracking: -1, lineHeight: 1.05 },
+    title: { size: 28, weight: 800, tracking: -0.6, lineHeight: 1.1 },
+    body: { size: 17, weight: 500, tracking: -0.3, lineHeight: 1.3 },
+    button: { size: 17, weight: 600, tracking: -0.2, lineHeight: 1 },
+    copy: { size: 15, weight: 500, tracking: -0.2, lineHeight: 1.5 },
+    caption: { size: 13, weight: 500, tracking: -0.1, lineHeight: 1.3 },
+    micro: { size: 12, weight: 700, tracking: -0.1, lineHeight: 1 },
+    uppercaseLabel: { size: 13, weight: 700, tracking: 1, lineHeight: 1, transform: 'uppercase' },
+  },
+}
+
+/** Shared shadow scale (same for both variants). */
+export const glassShadows: GlassShadowTokens = {
+  glassFloat: '0 1px 3px rgba(0,0,0,0.05), 0 8px 30px rgba(0,0,0,0.08)',
+  glassFloatDark: '0 1px 3px rgba(0,0,0,0.4), 0 12px 36px rgba(0,0,0,0.5)',
+  accentBtn: '0 6px 20px rgba(0,122,255,0.32)',
+  whiteBtn: '0 6px 20px rgba(0,0,0,0.2)',
+  iconSquare: 'inset 0 1px 0 rgba(255,255,255,0.35), 0 2px 6px rgba(0,0,0,0.1)',
+  activeTab: '0 4px 14px rgba(0,122,255,0.35)',
+  filterActive: '0 4px 14px rgba(0,0,0,0.18)',
+}
+
+/** Shared motion tokens. */
+export const glassMotion: GlassMotionTokens = {
+  toggle: '200ms ease',
+  progress: '300ms ease',
+  caretBlink: '1s steps(2) infinite',
+}
+
+/**
+ * Convenience function — returns the correct variant token set for a given mode.
+ * Use this inside createAppTheme to pick the right color set.
+ */
+export function getGlassTokens(mode: 'light' | 'dark'): GlassVariantTokens {
+  return mode === 'dark' ? darkGlass : lightGlass
+}

--- a/src/theme/theme.test.ts
+++ b/src/theme/theme.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createAppTheme, resolveThemeMode } from './theme'
+import {
+  lightGlass,
+  darkGlass,
+  glassRadius,
+  glassTypography,
+  glassMotion,
+  glassShadows,
+} from './liquidGlass'
 
 describe('resolveThemeMode', () => {
   beforeEach(() => {
@@ -31,6 +39,178 @@ describe('resolveThemeMode', () => {
   })
 })
 
+// --- Token shape verification ---
+// These tests assert that lightGlass/darkGlass match the expected token structure.
+// Values are cross-checked against docs/design/liquid-glass/tokens.json.
+
+describe('lightGlass tokens', () => {
+  it('should have the correct wallpaper gradient', () => {
+    expect(lightGlass.wallpaper).toContain('#FFD6A5')
+    expect(lightGlass.wallpaper).toContain('#A5C8FF')
+    expect(lightGlass.wallpaper).toContain('#FFB3D4')
+    expect(lightGlass.wallpaper).toContain('#F9F7F2')
+    expect(lightGlass.wallpaper).toContain('#EEEDF6')
+  })
+
+  it('should have the correct ink color', () => {
+    expect(lightGlass.color.ink).toBe('#111114')
+  })
+
+  it('should have the correct bg color', () => {
+    expect(lightGlass.color.bg).toBe('#F4F2EE')
+  })
+
+  it('should have the correct accent color (iOS blue)', () => {
+    expect(lightGlass.color.accent).toBe('#007AFF')
+  })
+
+  it('should have the correct ok color (iOS green)', () => {
+    expect(lightGlass.color.ok).toBe('#34C759')
+  })
+
+  it('should have the correct red color', () => {
+    expect(lightGlass.color.red).toBe('#FF3B30')
+  })
+
+  it('should have the correct glass.bg value', () => {
+    expect(lightGlass.glass.bg).toBe('rgba(255,255,255,0.55)')
+  })
+
+  it('should have the correct glass.bgStrong value', () => {
+    expect(lightGlass.glass.bgStrong).toBe('rgba(255,255,255,0.72)')
+  })
+
+  it('should have the correct glass.backdropFilter value', () => {
+    expect(lightGlass.glass.backdropFilter).toBe('blur(24px) saturate(180%)')
+  })
+
+  it('should have dark: false', () => {
+    expect(lightGlass.dark).toBe(false)
+  })
+})
+
+describe('darkGlass tokens', () => {
+  it('should have the correct wallpaper gradient (deep purple/navy)', () => {
+    expect(darkGlass.wallpaper).toContain('#3A1E6B')
+    expect(darkGlass.wallpaper).toContain('#0F3B6C')
+    expect(darkGlass.wallpaper).toContain('#6B1E4A')
+    expect(darkGlass.wallpaper).toContain('#0A0A10')
+    expect(darkGlass.wallpaper).toContain('#14121D')
+  })
+
+  it('should have the correct ink color (white for dark mode)', () => {
+    expect(darkGlass.color.ink).toBe('#FFFFFF')
+  })
+
+  it('should have the correct bg color', () => {
+    expect(darkGlass.color.bg).toBe('#0A0A10')
+  })
+
+  it('should have the correct accent color (iOS dark-mode blue)', () => {
+    expect(darkGlass.color.accent).toBe('#0A84FF')
+  })
+
+  it('should have the correct ok color (iOS dark-mode green)', () => {
+    expect(darkGlass.color.ok).toBe('#30D158')
+  })
+
+  it('should have the correct glass.bg value', () => {
+    expect(darkGlass.glass.bg).toBe('rgba(255,255,255,0.10)')
+  })
+
+  it('should have the correct glass.bgStrong value', () => {
+    expect(darkGlass.glass.bgStrong).toBe('rgba(255,255,255,0.18)')
+  })
+
+  it('should have dark: true', () => {
+    expect(darkGlass.dark).toBe(true)
+  })
+})
+
+describe('shared radius tokens', () => {
+  it('should have card radius 22', () => {
+    expect(glassRadius.card).toBe(22)
+  })
+
+  it('should have btn radius 18', () => {
+    expect(glassRadius.btn).toBe(18)
+  })
+
+  it('should have glass radius 28', () => {
+    expect(glassRadius.glass).toBe(28)
+  })
+
+  it('should have pill radius 999', () => {
+    expect(glassRadius.pill).toBe(999)
+  })
+
+  it('should have inline radius 14', () => {
+    expect(glassRadius.inline).toBe(14)
+  })
+
+  it('should have iconSquare radius 10', () => {
+    expect(glassRadius.iconSquare).toBe(10)
+  })
+})
+
+describe('shared typography tokens', () => {
+  it('should reference SF Pro Display as the display font', () => {
+    expect(glassTypography.display).toContain('SF Pro Display')
+  })
+
+  it('should reference Inter as cross-platform fallback in display', () => {
+    expect(glassTypography.display).toContain('Inter')
+  })
+
+  it('should reference SF Pro Text as the body font', () => {
+    expect(glassTypography.body).toContain('SF Pro Text')
+  })
+
+  it('should reference Inter as cross-platform fallback in body', () => {
+    expect(glassTypography.body).toContain('Inter')
+  })
+
+  it('should have heroWord at 72px weight 800', () => {
+    expect(glassTypography.roles.heroWord.size).toBe(72)
+    expect(glassTypography.roles.heroWord.weight).toBe(800)
+  })
+
+  it('should have button at 17px weight 600', () => {
+    expect(glassTypography.roles.button.size).toBe(17)
+    expect(glassTypography.roles.button.weight).toBe(600)
+  })
+
+  it('should have uppercaseLabel transform uppercase', () => {
+    expect(glassTypography.roles.uppercaseLabel.transform).toBe('uppercase')
+  })
+})
+
+describe('shared motion tokens', () => {
+  it('should have toggle at 200ms ease', () => {
+    expect(glassMotion.toggle).toBe('200ms ease')
+  })
+
+  it('should have progress at 300ms ease', () => {
+    expect(glassMotion.progress).toBe('300ms ease')
+  })
+})
+
+describe('shared shadow tokens', () => {
+  it('should have accentBtn shadow', () => {
+    expect(glassShadows.accentBtn).toContain('rgba(0,122,255,0.32)')
+  })
+
+  it('should have glassFloat shadow matching light glass.shadow', () => {
+    expect(glassShadows.glassFloat).toBe(lightGlass.glass.shadow)
+  })
+
+  it('should have glassFloatDark shadow matching dark glass.shadow', () => {
+    expect(glassShadows.glassFloatDark).toBe(darkGlass.glass.shadow)
+  })
+})
+
+// --- MUI theme integration tests ---
+
 describe('createAppTheme', () => {
   it('should create a dark theme with correct palette mode', () => {
     const darkTheme = createAppTheme('dark')
@@ -42,52 +222,92 @@ describe('createAppTheme', () => {
     expect(lightTheme.palette.mode).toBe('light')
   })
 
-  it('should use amber/gold as the primary colour', () => {
-    const darkTheme = createAppTheme('dark')
-    expect(darkTheme.palette.primary.main).toBe('#f59e0b')
-  })
-
-  it('should use blue as the secondary colour', () => {
-    const darkTheme = createAppTheme('dark')
-    expect(darkTheme.palette.secondary.main).toBe('#3b82f6')
-  })
-
-  it('should use deep navy as dark mode default background', () => {
-    const darkTheme = createAppTheme('dark')
-    expect(darkTheme.palette.background.default).toBe('#0a0f1a')
-  })
-
-  it('should use warm white as light mode default background', () => {
+  it('should use iOS blue as the primary colour (light mode)', () => {
     const lightTheme = createAppTheme('light')
-    expect(lightTheme.palette.background.default).toBe('#fafaf9')
+    expect(lightTheme.palette.primary.main).toBe('#007AFF')
   })
 
-  it('should not have the MUI default blue/purple leaking through (no default primary)', () => {
+  it('should use iOS dark-mode blue as the primary colour (dark mode)', () => {
     const darkTheme = createAppTheme('dark')
-    // MUI default primary is #1976d2 - ensure it is overridden
+    expect(darkTheme.palette.primary.main).toBe('#0A84FF')
+  })
+
+  it('should NOT use amber/gold as the primary colour (Hero Arc removed)', () => {
+    const darkTheme = createAppTheme('dark')
+    expect(darkTheme.palette.primary.main).not.toBe('#f59e0b')
+  })
+
+  it('should NOT have MUI default blue/purple leaking through', () => {
+    const darkTheme = createAppTheme('dark')
     expect(darkTheme.palette.primary.main).not.toBe('#1976d2')
   })
 
-  it('should use Sora and Nunito fonts (not Inter/Roboto/Arial as primary body font)', () => {
+  it('should use dark bg token as dark mode background', () => {
+    const darkTheme = createAppTheme('dark')
+    expect(darkTheme.palette.background.default).toBe(darkGlass.color.bg)
+  })
+
+  it('should use light bg token as light mode background', () => {
+    const lightTheme = createAppTheme('light')
+    expect(lightTheme.palette.background.default).toBe(lightGlass.color.bg)
+  })
+
+  it('should use iOS green as the success colour (light)', () => {
+    const lightTheme = createAppTheme('light')
+    expect(lightTheme.palette.success.main).toBe('#34C759')
+  })
+
+  it('should use iOS dark-mode green as the success colour (dark)', () => {
+    const darkTheme = createAppTheme('dark')
+    expect(darkTheme.palette.success.main).toBe('#30D158')
+  })
+
+  it('should use iOS red as the error colour (light)', () => {
+    const lightTheme = createAppTheme('light')
+    expect(lightTheme.palette.error.main).toBe('#FF3B30')
+  })
+
+  it('should use iOS dark-mode red as the error colour (dark)', () => {
+    const darkTheme = createAppTheme('dark')
+    expect(darkTheme.palette.error.main).toBe('#FF453A')
+  })
+
+  it('should use the card radius as borderRadius', () => {
+    const darkTheme = createAppTheme('dark')
+    expect(darkTheme.shape.borderRadius).toBe(glassRadius.card)
+  })
+
+  it('should include Inter in the typography font stack', () => {
     const darkTheme = createAppTheme('dark')
     const fontFamily = darkTheme.typography.fontFamily ?? ''
-    expect(fontFamily).toContain('Nunito')
-    expect(fontFamily).not.toMatch(/^"?Inter"?,/)
-    expect(fontFamily).not.toMatch(/^Roboto,/)
+    expect(fontFamily).toContain('Inter')
   })
 
-  it('should set rounded corners (borderRadius 12)', () => {
+  it('should NOT use Nunito or Sora as the primary font (old Hero Arc fonts removed)', () => {
     const darkTheme = createAppTheme('dark')
-    expect(darkTheme.shape.borderRadius).toBe(12)
+    const fontFamily = darkTheme.typography.fontFamily ?? ''
+    expect(fontFamily).not.toContain('Nunito')
+    expect(fontFamily).not.toContain('Sora')
   })
 
-  it('should set green success colour', () => {
+  it('should use SF Pro Text family as the body font', () => {
     const darkTheme = createAppTheme('dark')
-    expect(darkTheme.palette.success.main).toBe('#22c55e')
+    const fontFamily = darkTheme.typography.fontFamily ?? ''
+    expect(fontFamily).toContain('SF Pro Text')
   })
 
-  it('should set red error colour', () => {
-    const darkTheme = createAppTheme('dark')
-    expect(darkTheme.palette.error.main).toBe('#ef4444')
+  it('should use the divider token from the active variant', () => {
+    const lightTheme = createAppTheme('light')
+    expect(lightTheme.palette.divider).toBe(lightGlass.color.rule2)
+  })
+
+  it('should set text.primary to ink token', () => {
+    const lightTheme = createAppTheme('light')
+    expect(lightTheme.palette.text.primary).toBe(lightGlass.color.ink)
+  })
+
+  it('should set text.secondary to inkSec token', () => {
+    const lightTheme = createAppTheme('light')
+    expect(lightTheme.palette.text.secondary).toBe(lightGlass.color.inkSec)
   })
 })

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,71 +1,90 @@
 import { createTheme, type Theme } from '@mui/material/styles'
 import type { ThemePreference } from '@/types'
+import { getGlassTokens, glassRadius, glassTypography, glassShadows } from './liquidGlass'
 
 /**
- * Palette tokens shared between both modes.
- * Defined here so component overrides can reference them without
- * needing the full theme object (avoids circular dependency).
+ * Build MUI typography config from Liquid Glass typography tokens.
+ * Display font (SF Pro Display / Inter) for headings; body font (SF Pro Text / Inter) for body.
+ * Typography tokens are shared between light and dark variants.
  */
-const PALETTE = {
-  primary: {
-    main: '#f59e0b',
-    light: '#fbbf24',
-    dark: '#d97706',
-    contrastText: '#0a0f1a',
-  },
-  secondary: {
-    main: '#3b82f6',
-    light: '#60a5fa',
-    dark: '#1d4ed8',
-    contrastText: '#ffffff',
-  },
-  success: {
-    main: '#22c55e',
-    light: '#4ade80',
-    dark: '#16a34a',
-    contrastText: '#ffffff',
-  },
-  error: {
-    main: '#ef4444',
-    light: '#f87171',
-    dark: '#dc2626',
-    contrastText: '#ffffff',
-  },
-} as const
-
-/**
- * Typography using Nunito (body – clean, high readability, full Latvian diacritics support)
- * and Sora (display/headings – modern geometric with character).
- * Both fonts are loaded via index.html Google Fonts link tag.
- */
-const FONT_DISPLAY = '"Sora", "Nunito", sans-serif'
-const FONT_BODY = '"Nunito", "Sora", sans-serif'
-
 function buildTypography() {
   return {
-    fontFamily: FONT_BODY,
-    h1: { fontFamily: FONT_DISPLAY, fontWeight: 700 },
-    h2: { fontFamily: FONT_DISPLAY, fontWeight: 700 },
-    h3: { fontFamily: FONT_DISPLAY, fontWeight: 600 },
-    h4: { fontFamily: FONT_DISPLAY, fontWeight: 600 },
-    h5: { fontFamily: FONT_DISPLAY, fontWeight: 600 },
-    h6: { fontFamily: FONT_DISPLAY, fontWeight: 600 },
-    subtitle1: { fontWeight: 500 },
-    subtitle2: { fontWeight: 500 },
-    button: { fontFamily: FONT_BODY, fontWeight: 700, textTransform: 'none' as const },
+    fontFamily: glassTypography.body,
+    h1: {
+      fontFamily: glassTypography.display,
+      fontWeight: glassTypography.roles.largeTitle.weight,
+      fontSize: `${glassTypography.roles.largeTitle.size}px`,
+      letterSpacing: `${glassTypography.roles.largeTitle.tracking}px`,
+      lineHeight: glassTypography.roles.largeTitle.lineHeight,
+    },
+    h2: {
+      fontFamily: glassTypography.display,
+      fontWeight: glassTypography.roles.title.weight,
+      fontSize: `${glassTypography.roles.title.size}px`,
+      letterSpacing: `${glassTypography.roles.title.tracking}px`,
+      lineHeight: glassTypography.roles.title.lineHeight,
+    },
+    h3: {
+      fontFamily: glassTypography.display,
+      fontWeight: glassTypography.roles.title.weight,
+      letterSpacing: `${glassTypography.roles.title.tracking}px`,
+    },
+    h4: {
+      fontFamily: glassTypography.display,
+      fontWeight: glassTypography.roles.title.weight,
+      letterSpacing: `${glassTypography.roles.title.tracking}px`,
+    },
+    h5: {
+      fontFamily: glassTypography.display,
+      fontWeight: glassTypography.roles.title.weight,
+    },
+    h6: {
+      fontFamily: glassTypography.display,
+      fontWeight: glassTypography.roles.title.weight,
+    },
+    body1: {
+      fontSize: `${glassTypography.roles.body.size}px`,
+      fontWeight: glassTypography.roles.body.weight,
+      letterSpacing: `${glassTypography.roles.body.tracking}px`,
+      lineHeight: glassTypography.roles.body.lineHeight,
+    },
+    body2: {
+      fontSize: `${glassTypography.roles.copy.size}px`,
+      fontWeight: glassTypography.roles.copy.weight,
+      letterSpacing: `${glassTypography.roles.copy.tracking}px`,
+      lineHeight: glassTypography.roles.copy.lineHeight,
+    },
+    button: {
+      fontFamily: glassTypography.body,
+      fontWeight: glassTypography.roles.button.weight,
+      fontSize: `${glassTypography.roles.button.size}px`,
+      letterSpacing: `${glassTypography.roles.button.tracking}px`,
+      textTransform: 'none' as const,
+    },
+    caption: {
+      fontSize: `${glassTypography.roles.caption.size}px`,
+      fontWeight: glassTypography.roles.caption.weight,
+      letterSpacing: `${glassTypography.roles.caption.tracking}px`,
+      lineHeight: glassTypography.roles.caption.lineHeight,
+    },
+    subtitle1: { fontWeight: glassTypography.roles.body.weight },
+    subtitle2: { fontWeight: glassTypography.roles.copy.weight },
   }
 }
 
-function buildComponents() {
+function buildComponents(tokens: ReturnType<typeof getGlassTokens>) {
   return {
     MuiButton: {
       styleOverrides: {
         root: {
-          borderRadius: 10,
+          borderRadius: glassRadius.btn,
           minHeight: 44,
-          fontWeight: 700,
+          fontWeight: glassTypography.roles.button.weight,
+          fontSize: `${glassTypography.roles.button.size}px`,
+          letterSpacing: `${glassTypography.roles.button.tracking}px`,
           textTransform: 'none' as const,
-          transition: 'transform 0.15s ease, box-shadow 0.15s ease',
+          // Enter/exit use opacity/transform only — no animating on blurred surfaces.
+          transition: 'opacity 200ms ease, transform 200ms ease',
           '&:hover': {
             transform: 'translateY(-1px)',
           },
@@ -73,14 +92,23 @@ function buildComponents() {
             transform: 'translateY(0)',
           },
         },
+        containedPrimary: {
+          backgroundColor: tokens.color.accent,
+          color: '#ffffff',
+          boxShadow: glassShadows.accentBtn,
+          '&:hover': {
+            backgroundColor: tokens.color.accent,
+            boxShadow: glassShadows.accentBtn,
+          },
+        },
       },
     },
     MuiCard: {
       styleOverrides: {
         root: {
-          borderRadius: 16,
+          borderRadius: glassRadius.card,
           backgroundImage: 'none',
-          transition: 'box-shadow 0.2s ease, transform 0.2s ease',
+          transition: 'opacity 200ms ease, transform 200ms ease',
           '&:hover': {
             transform: 'translateY(-2px)',
           },
@@ -93,7 +121,7 @@ function buildComponents() {
           backgroundImage: 'none',
         },
         rounded: {
-          borderRadius: 16,
+          borderRadius: glassRadius.card,
         },
       },
     },
@@ -101,10 +129,10 @@ function buildComponents() {
       styleOverrides: {
         root: {
           '& .MuiOutlinedInput-root': {
-            borderRadius: 10,
-            transition: 'box-shadow 0.15s ease',
+            borderRadius: glassRadius.inline,
+            transition: 'box-shadow 150ms ease',
             '&.Mui-focused': {
-              boxShadow: `0 0 0 3px rgba(245, 158, 11, 0.25)`,
+              boxShadow: `0 0 0 3px ${tokens.color.accentSoft}`,
             },
           },
         },
@@ -113,15 +141,18 @@ function buildComponents() {
     MuiOutlinedInput: {
       styleOverrides: {
         root: {
-          borderRadius: 10,
+          borderRadius: glassRadius.inline,
         },
       },
     },
     MuiChip: {
       styleOverrides: {
         root: {
-          borderRadius: 8,
-          fontWeight: 600,
+          borderRadius: glassRadius.pill,
+          fontWeight: glassTypography.roles.micro.weight,
+          fontSize: `${glassTypography.roles.micro.size}px`,
+          letterSpacing: `${glassTypography.roles.micro.tracking}px`,
+          height: 26,
         },
       },
     },
@@ -150,27 +181,49 @@ function buildComponents() {
 }
 
 export function createAppTheme(mode: 'light' | 'dark'): Theme {
-  const isDark = mode === 'dark'
+  const tokens = getGlassTokens(mode)
 
   return createTheme({
     palette: {
       mode,
-      ...PALETTE,
+      primary: {
+        main: tokens.color.accent,
+        light: tokens.color.accentSoft,
+        dark: tokens.color.accentText,
+        contrastText: '#ffffff',
+      },
+      secondary: {
+        main: tokens.color.violet,
+        contrastText: '#ffffff',
+      },
+      success: {
+        main: tokens.color.ok,
+        contrastText: '#ffffff',
+      },
+      error: {
+        main: tokens.color.red,
+        contrastText: '#ffffff',
+      },
+      warning: {
+        main: tokens.color.warn,
+        contrastText: '#ffffff',
+      },
       background: {
-        default: isDark ? '#0a0f1a' : '#fafaf9',
-        paper: isDark ? '#111827' : '#f5f5f4',
+        default: tokens.color.bg,
+        paper: tokens.color.bg,
       },
       text: {
-        primary: isDark ? '#f9fafb' : '#111827',
-        secondary: isDark ? '#9ca3af' : '#6b7280',
+        primary: tokens.color.ink,
+        secondary: tokens.color.inkSec,
+        disabled: tokens.color.inkFaint,
       },
-      divider: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
+      divider: tokens.color.rule2,
     },
     typography: buildTypography(),
     shape: {
-      borderRadius: 12,
+      borderRadius: glassRadius.card,
     },
-    components: buildComponents(),
+    components: buildComponents(tokens),
   })
 }
 


### PR DESCRIPTION
## Summary

- Replaces the Hero Arc amber/gold theme with iOS 26 Liquid Glass token system
- Ships the \`<Glass>\` primitive that every subsequent screen surface will be built from
- Installs \`@fontsource/inter\` as the cross-platform font fallback; removes Google Fonts link

## Acceptance criteria

- [x] \`src/theme/liquidGlass.ts\` exports \`lightGlass\` and \`darkGlass\` matching \`tokens.json\` exactly
- [x] \`createAppTheme(mode)\` rebuilt on Liquid Glass tokens; amber/gold MUI palette removed
- [x] \`src/theme/index.ts\` still exports \`createAppTheme\` with the same signature
- [x] \`<PaperSurface>\` in \`src/components/primitives/PaperSurface.tsx\`: full-bleed, wallpaper gradient, ink color, overflow:hidden
- [x] \`<Glass>\` with props \`{ strong?, floating?, radius?, pad? }\`, 3-layer anatomy, backdrop-filter + -webkit- prefix
- [x] Reduce Transparency fallback: solid bg + rule2 border, no blur
- [x] \`@fontsource/inter\` added; Google Fonts link removed; SF Pro / Inter font stack
- [x] Dev-only \`/__glass-demo\` route, gated with \`import.meta.env.DEV\`, tree-shaken from production
- [x] Tests updated; all quality gates green

## Changes

| File | Change |
|---|---|
| \`src/theme/liquidGlass.ts\` | New — token exports |
| \`src/theme/theme.ts\` | Rebuilt on Liquid Glass tokens |
| \`src/theme/index.ts\` | Unchanged (same public API) |
| \`src/components/primitives/Glass.tsx\` | New — Glass primitive |
| \`src/components/primitives/PaperSurface.tsx\` | New — screen root |
| \`src/components/primitives/index.ts\` | New — barrel |
| \`src/features/glass-demo/GlassDemo.tsx\` | New — dev demo page |
| \`src/App.tsx\` | Add /__glass-demo route (DEV-gated) |
| \`src/main.tsx\` | Import @fontsource/inter weights |
| \`index.html\` | Remove Sora/Nunito Google Fonts link |
| \`src/theme/theme.test.ts\` | Updated for new token shape |
| \`src/components/primitives/Glass.test.tsx\` | New — 18 tests |
| \`src/components/primitives/PaperSurface.test.tsx\` | New — 6 tests |

## Testing

- All 874 unit tests pass (58 test files)
- 15/15 E2E tests pass — no regressions
- Production build: GlassDemo correctly tree-shaken (zero bytes in prod JS)
- TypeScript strict: 0 errors
- Lint: 0 errors
- Format: clean

## Manual smoke test note

The \`/__glass-demo\` route is only accessible in development builds (\`npm run dev\`). Visual confirmation of light/dark × strong/floating × all radius presets requires running the dev server. The Reduce Transparency media query branch requires toggling the OS accessibility setting or DevTools media query emulation. Both are documented in the QA comment on the issue.

## Review

Code review passed (see reviewer comment on #142). Token fidelity, 3-layer anatomy, -webkit- prefix, and production tree-shaking all verified.

Closes #142
Unblocks epic #141 sub-issues #143–#155

🤖 Generated with [Claude Code](https://claude.com/claude-code)