### PR TITLE
fix(e2e): replace Promise.any with allSettled for ES2020 compat

### DIFF
--- a/e2e/quiz.spec.ts
+++ b/e2e/quiz.spec.ts
@@ -187,14 +187,12 @@ test('quiz handles empty word list gracefully', async ({ page }) => {
   await expect(page.getByText('Lexio')).toBeVisible()
 
   // It should show either "Session complete!" or an error/empty message.
-  const hasValidResponse = await Promise.any([
+  const hasValidResponse = await Promise.allSettled([
     page.getByText('Session complete!').waitFor({ timeout: 3_000 }),
     page.getByText(/something went wrong|no words|loading/i).waitFor({ timeout: 3_000 }),
     // The mode selector might still be visible if quiz didn't start
     page.getByText('Choose your quiz mode').waitFor({ timeout: 3_000 }),
-  ])
-    .then(() => true)
-    .catch(() => false)
+  ]).then((results) => results.some((r) => r.status === 'fulfilled'))
 
   // Whether or not we got a specific message, the app must not have crashed.
   // hasValidResponse is checked implicitly - the key assertion is that Lexio is still visible.


### PR DESCRIPTION
## Summary
- IDE LSP was flagging `Promise.any` on `e2e/quiz.spec.ts:190` — it requires ES2021+ in the TS lib, but the project targets ES2020 per `tsconfig.app.json`.
- Swapped to `Promise.allSettled(...).then(r => r.some(fulfilled))`, which is semantically equivalent under the 3-second `waitFor` timeouts and keeps the codebase aligned with its declared ES2020 target.

## Why this slipped past #163 CI
- `npm run e2e` passed because Playwright runs the file through Node, where `Promise.any` is available at runtime.
- `npx tsc --noEmit` passed because `tsconfig.app.json`'s `include` only covers `src/` — `e2e/` isn't typechecked by the standard gate.

Follow-up to #146 / PR #163.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [ ] `npm run e2e` — empty-word-list path still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)