### PR TITLE
fix(ci): type-check e2e and bump TS lib to ES2022 (#164)

### DIFF
--- a/e2e/quiz.spec.ts
+++ b/e2e/quiz.spec.ts
@@ -187,12 +187,16 @@ test('quiz handles empty word list gracefully', async ({ page }) => {
   await expect(page.getByText('Lexio')).toBeVisible()
 
   // It should show either "Session complete!" or an error/empty message.
-  const hasValidResponse = await Promise.allSettled([
+  // Promise.any resolves as soon as the first selector matches, avoiding the
+  // full 3s timeout that Promise.allSettled would impose when only one matches.
+  const hasValidResponse = await Promise.any([
     page.getByText('Session complete!').waitFor({ timeout: 3_000 }),
     page.getByText(/something went wrong|no words|loading/i).waitFor({ timeout: 3_000 }),
     // The mode selector might still be visible if quiz didn't start
     page.getByText('Choose your quiz mode').waitFor({ timeout: 3_000 }),
-  ]).then((results) => results.some((r) => r.status === 'fulfilled'))
+  ])
+    .then(() => true)
+    .catch(() => false)
 
   // Whether or not we got a specific message, the app must not have crashed.
   // hasValidResponse is checked implicitly - the key assertion is that Lexio is still visible.

--- a/e2e/quiz.spec.ts
+++ b/e2e/quiz.spec.ts
@@ -187,14 +187,12 @@ test('quiz handles empty word list gracefully', async ({ page }) => {
   await expect(page.getByText('Lexio')).toBeVisible()
 
   // It should show either "Session complete!" or an error/empty message.
-  const hasValidResponse = await Promise.any([
+  const hasValidResponse = await Promise.allSettled([
     page.getByText('Session complete!').waitFor({ timeout: 3_000 }),
     page.getByText(/something went wrong|no words|loading/i).waitFor({ timeout: 3_000 }),
     // The mode selector might still be visible if quiz didn't start
     page.getByText('Choose your quiz mode').waitFor({ timeout: 3_000 }),
-  ])
-    .then(() => true)
-    .catch(() => false)
+  ]).then((results) => results.some((r) => r.status === 'fulfilled'))
 
   // Whether or not we got a specific message, the app must not have crashed.
   // hasValidResponse is checked implicitly - the key assertion is that Lexio is still visible.

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,7 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
+    "types": ["@playwright/test"],
+    "noEmit": true
+  },
+  "include": ["e2e"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "files": [],
-  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.e2e.json" }
+  ]
 }


### PR DESCRIPTION
## Summary

- Bumps `lib` in `tsconfig.app.json` from `ES2020` to `ES2022` so `Promise.any` (ES2021) type-checks cleanly. `target` stays `ES2020`.
- Adds `tsconfig.e2e.json` (Option A) extending the app config with `@playwright/test` types scoped to e2e only; `include` limited to `e2e/`.
- References the new e2e project from root `tsconfig.json` so `tsc -b` (invoked by `npm run build`) covers e2e files.
- Reverts the `Promise.allSettled` workaround (commit `e6e611d`) — restores `Promise.any` at `e2e/quiz.spec.ts:192`.

## Option A rationale

Playwright types (`test`, `expect`, `Page`, etc.) are browser-context types inappropriate in the React SPA project. A separate `tsconfig.e2e.json` mirrors the existing app/node split, keeps app and e2e type contexts isolated, and lets both diverge independently in future.

## Changes

- `tsconfig.app.json` — `lib` bumped to `["ES2022", "DOM", "DOM.Iterable"]`
- `tsconfig.e2e.json` — new file, extends app config, `types: ["@playwright/test"]`, `include: ["e2e"]`
- `tsconfig.json` — added `{ "path": "./tsconfig.e2e.json" }` to references
- `e2e/quiz.spec.ts` — `Promise.any` restored at line 192 with explanatory comment

## Intentional-break verification

Two separate breaks were tested:

1. **DevOps:** `const _intentionalBreak: number = 'this is not a number'` injected into `e2e/quiz.spec.ts` — `tsc -b` emitted `error TS2322: Type 'string' is not assignable to type 'number'`.
2. **QA (independent):** same pattern in `e2e/helpers.ts` — same error, confirmed both files covered.

Both reverted; `tsc -b` exits clean.

## Testing

- `npm run lint` — PASS
- `npm run format:check` — PASS
- `npm run test:run` — PASS (73 files, 1022 tests)
- `npx tsc -b` — PASS
- `npm run build` — PASS
- `npm run e2e` — PASS (15 tests)

## Acceptance criteria

- [x] `Promise.allSettled` workaround reverted; `Promise.any` at `e2e/quiz.spec.ts:192`
- [x] `lib` set to `["ES2022", "DOM", "DOM.Iterable"]` in `tsconfig.app.json`
- [x] `tsconfig.e2e.json` created and referenced from root `tsconfig.json`
- [x] `npm run build` type-checks e2e files — verified with intentional breaks
- [x] All quality gates green

Closes #164