### PR TITLE
fix: replace deprecated Dialog PaperProps with slotProps.paper

### DIFF
--- a/src/features/words/components/AddWordModal.tsx
+++ b/src/features/words/components/AddWordModal.tsx
@@ -641,10 +641,12 @@ export function AddWordModal({
         aria-modal="true"
         aria-labelledby={titleId}
         // Remove the default Dialog paper background so PaperSurface wallpaper shows through
-        PaperProps={{
-          sx: {
-            background: 'transparent',
-            boxShadow: 'none',
+        slotProps={{
+          paper: {
+            sx: {
+              background: 'transparent',
+              boxShadow: 'none',
+            },
           },
         }}
       >


### PR DESCRIPTION
## Summary
- MUI 6 deprecated `Dialog.PaperProps` in favor of `slotProps.paper`. The LSP diagnostic surfaced on `AddWordModal.tsx:644` after #150 merged.
- Swap is a direct translation — same keys (`sx.background`, `sx.boxShadow`), just under the new slot-based API. No behavior or styling change.

Follow-up to #150 / PR #170.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `AddWordModal.test.tsx` — 26/26 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)