### PR TITLE
fix: replace deprecated Dialog PaperProps with slotProps.paper in Settings

### DIFF
--- a/src/features/settings/components/SettingsScreen.tsx
+++ b/src/features/settings/components/SettingsScreen.tsx
@@ -535,7 +535,7 @@ export function SettingsScreen({
         onClose={() => setQuizPickerOpen(false)}
         maxWidth="xs"
         fullWidth
-        PaperProps={{ sx: { borderRadius: 3 } }}
+        slotProps={{ paper: { sx: { borderRadius: 3 } } }}
         aria-labelledby="quiz-mode-dialog-title"
       >
         <DialogTitle id="quiz-mode-dialog-title">
@@ -567,7 +567,7 @@ export function SettingsScreen({
         onClose={() => setThemePickerOpen(false)}
         maxWidth="xs"
         fullWidth
-        PaperProps={{ sx: { borderRadius: 3 } }}
+        slotProps={{ paper: { sx: { borderRadius: 3 } } }}
         aria-labelledby="theme-dialog-title"
       >
         <DialogTitle id="theme-dialog-title">
@@ -599,7 +599,7 @@ export function SettingsScreen({
         onClose={handleImportCancel}
         maxWidth="xs"
         fullWidth
-        PaperProps={{ sx: { borderRadius: 3 } }}
+        slotProps={{ paper: { sx: { borderRadius: 3 } } }}
         aria-labelledby="import-dialog-title"
       >
         <DialogTitle id="import-dialog-title">
@@ -632,7 +632,7 @@ export function SettingsScreen({
         onClose={() => setResetConfirmOpen(false)}
         maxWidth="xs"
         fullWidth
-        PaperProps={{ sx: { borderRadius: 3 } }}
+        slotProps={{ paper: { sx: { borderRadius: 3 } } }}
         aria-labelledby="reset-progress-dialog-title"
       >
         <DialogTitle id="reset-progress-dialog-title">


### PR DESCRIPTION
## Summary
- Four Dialog instances in `SettingsScreen.tsx` (Quiz mode picker, Theme picker, Import picker, Reset confirm) used the deprecated MUI 6 `PaperProps` API.
- Swap to `slotProps.paper` — direct translation, same `sx: { borderRadius: 3 }` under each Dialog.
- Same deprecation follow-up pattern as #171 (which covered `AddWordModal`).

Follow-up to #152 / PR #174.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `SettingsScreen.test.tsx` — 31/31 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)