### PR TITLE
fix(e2e): suppress PWA install banner via storage key to eliminate navigateTo flake (#172)

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -31,6 +31,11 @@ import { expect } from '@playwright/test'
 const STORAGE_KEYS = {
   LANGUAGE_PAIRS: 'lexio:language-pairs',
   SETTINGS: 'lexio:settings',
+  // Must match STORAGE_KEYS.DISMISSED_AT in useInstallPrompt.ts.
+  // Pre-seeding this key with the current timestamp puts the banner into its
+  // 7-day cooldown window so it never renders during E2E tests, eliminating the
+  // race between banner appearance and tab-bar clicks.
+  INSTALL_BANNER_DISMISSED_AT: 'lexio:meta:install-banner:dismissed-at',
 } as const
 
 // ─── State reset ─────────────────────────────────────────────────────────────
@@ -42,10 +47,24 @@ const STORAGE_KEYS = {
  * After calling this function the app will show the onboarding wizard because
  * no language pairs exist. Use `bypassOnboarding()` to skip the wizard for
  * tests that do not cover the onboarding flow.
+ *
+ * The PWA install banner is suppressed by pre-seeding its dismissed-at key.
+ * This puts the banner into its 7-day cooldown window and prevents it from
+ * rendering during tests, eliminating pointer-event races on the tab bar.
  */
 export async function resetAppState(page: Page): Promise<void> {
   await page.goto('/#/app')
-  await page.evaluate(() => localStorage.clear())
+  await page.evaluate(
+    ({ dismissedAtKey }: { dismissedAtKey: string }) => {
+      localStorage.clear()
+      // Suppress the PWA install banner for the entire test session.
+      // useInstallPrompt checks this key and skips showing the banner while the
+      // 7-day cooldown is active. Setting it here prevents any async race
+      // between banner mount and the first tab-bar click in the test.
+      localStorage.setItem(dismissedAtKey, String(Date.now()))
+    },
+    { dismissedAtKey: STORAGE_KEYS.INSTALL_BANNER_DISMISSED_AT },
+  )
   await page.reload()
 }
 
@@ -92,14 +111,20 @@ export async function bypassOnboarding(
       pairsValue,
       settingsKey,
       settingsValue,
+      dismissedAtKey,
+      dismissedAtValue,
     }: {
       pairsKey: string
       pairsValue: string
       settingsKey: string
       settingsValue: string
+      dismissedAtKey: string
+      dismissedAtValue: string
     }) => {
       localStorage.setItem(pairsKey, pairsValue)
       localStorage.setItem(settingsKey, settingsValue)
+      // Suppress the PWA install banner (same rationale as resetAppState).
+      localStorage.setItem(dismissedAtKey, dismissedAtValue)
     },
     {
       pairsKey: STORAGE_KEYS.LANGUAGE_PAIRS,
@@ -112,6 +137,8 @@ export async function bypassOnboarding(
         theme: 'dark',
         typoTolerance: 1,
       }),
+      dismissedAtKey: STORAGE_KEYS.INSTALL_BANNER_DISMISSED_AT,
+      dismissedAtValue: String(Date.now()),
     },
   )
   // Navigate to the app route (HashRouter) so the main app shell loads.
@@ -145,15 +172,11 @@ export type AppTab = 'Home' | 'Quiz' | 'Words' | 'Stats' | 'Settings'
  * Navigates to a tab via the BottomNav.
  * The BottomNavigationAction has `aria-label="Navigate to <Tab>"`.
  *
- * Dismisses the PWA install banner if it is visible before clicking — the
- * banner is a Snackbar that can overlay the tab bar on the first few renders.
+ * The PWA install banner is suppressed globally by pre-seeding its dismissal
+ * key in resetAppState / bypassOnboarding, so no per-click banner dismissal
+ * is needed here.
  */
 export async function navigateTo(page: Page, tab: AppTab): Promise<void> {
-  // Dismiss the install banner if it is blocking the tab bar.
-  const dismissBtn = page.getByRole('button', { name: /dismiss|not now|close/i })
-  if (await dismissBtn.isVisible()) {
-    await dismissBtn.click()
-  }
   await page.getByRole('button', { name: `Navigate to ${tab}` }).click()
 }
 

--- a/e2e/starter-packs.spec.ts
+++ b/e2e/starter-packs.spec.ts
@@ -88,33 +88,19 @@ test('install starter pack from populated word list', async ({ page }) => {
 
 test('reversed pack direction installs with swapped words', async ({ page }) => {
   // The default pair is EN-LV. We need an LV-EN pair for the reversed test.
-  // Use bypassOnboarding with a custom reversed pair.
-  await page.goto('/#/app')
-  await page.evaluate(() => localStorage.clear())
-  await page.evaluate(() => {
-    const reversedPair = {
+  // Use resetAndBypassOnboarding with a custom reversed pair so the PWA install
+  // banner suppression key is also set (same as all other tests).
+  await resetAndBypassOnboarding(page, {
+    pair: {
       id: 'test-lv-en-id',
       sourceLang: 'Latvian',
       sourceCode: 'lv',
       targetLang: 'English',
       targetCode: 'en',
-      createdAt: Date.now(),
-    }
-    localStorage.setItem('lexio:language-pairs', JSON.stringify([reversedPair]))
-    localStorage.setItem(
-      'lexio:settings',
-      JSON.stringify({
-        activePairId: 'test-lv-en-id',
-        quizMode: 'type',
-        dailyGoal: 20,
-        theme: 'dark',
-        typoTolerance: 1,
-      }),
-    )
+    },
   })
-  await page.goto('/#/app')
-  // The Home tab now uses a Liquid Glass NavBar — wait for the "Today" large title.
-  await expect(page.getByText('Today').first()).toBeVisible({ timeout: 10_000 })
+  // The Home tab now uses a Liquid Glass NavBar — "Today" large title is visible
+  // after resetAndBypassOnboarding completes.
 
   await openPackBrowserFromWordsTab(page)
 


### PR DESCRIPTION
## Summary

- Pre-seed `lexio:meta:install-banner:dismissed-at` in `resetAppState` and `bypassOnboarding` (e2e/helpers.ts) so `useInstallPrompt`'s 7-day cooldown keeps the PWA install banner hidden for the entire E2E test session.
- Migrate the `reversed pack direction` test off its own raw `localStorage.clear()` + `localStorage.setItem` setup to use `resetAndBypassOnboarding` — the old inline setup was missing the suppression key, making it the primary flake source.
- Simplify `navigateTo` by removing the racy dismiss-button `isVisible` check, which is now unnecessary.

## Approach: storage-flag suppression (Preference B)

The `useInstallPrompt` hook already has a `DISMISSED_AT` storage key (`lexio:meta:install-banner:dismissed-at`) that triggers a 7-day cooldown. Setting this key to `Date.now()` in every state-reset helper puts the banner into its cooldown window before the app boots, eliminating the async race entirely.

**No production component changes were needed.** The storage key already existed; we just teach the E2E helpers to pre-seed it.

## Changes

- `e2e/helpers.ts` — added `INSTALL_BANNER_DISMISSED_AT` to `STORAGE_KEYS`, updated `resetAppState` to set it after clearing localStorage, updated `bypassOnboarding` to set it alongside pair/settings, simplified `navigateTo` (removed racy dismiss-button check)
- `e2e/starter-packs.spec.ts` — replaced the `reversed pack` test's inline localStorage setup with `resetAndBypassOnboarding({ pair: ... })`

## Testing

- `retries: 0` was already the local default (`process.env.CI ? 1 : 0`) — no config change needed
- **Verification loop: 10/10 runs green with `retries: 0`** (was 4/10 before the fix)
- Full quality gate: `npm run lint`, `npm run format:check`, `npm test -- --run` (1166 tests), `npx tsc --noEmit`, `npm run build`, `npm run e2e` — all green

## Review

- No `click({ force: true })` anywhere in the diff
- `playwright.config.ts` `retries` value unchanged (temporarily zeroed during verification was unnecessary since local retries are already 0)
- Fix lives in `helpers.ts` — not copy-pasted across specs
- New storage key matches Lexio naming conventions (`lexio:meta:` namespace)
- Key is read via `StorageService` in the component (`useInstallPrompt` uses `storage.getItem`), not directly

Closes #172