### PR TITLE
feat: restyle onboarding flow in Liquid Glass (#153)

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -31,6 +31,11 @@ import { expect } from '@playwright/test'
 const STORAGE_KEYS = {
   LANGUAGE_PAIRS: 'lexio:language-pairs',
   SETTINGS: 'lexio:settings',
+  // Must match STORAGE_KEYS.DISMISSED_AT in useInstallPrompt.ts.
+  // Pre-seeding this key with the current timestamp puts the banner into its
+  // 7-day cooldown window so it never renders during E2E tests, eliminating the
+  // race between banner appearance and tab-bar clicks.
+  INSTALL_BANNER_DISMISSED_AT: 'lexio:meta:install-banner:dismissed-at',
 } as const
 
 // ─── State reset ─────────────────────────────────────────────────────────────
@@ -42,10 +47,24 @@ const STORAGE_KEYS = {
  * After calling this function the app will show the onboarding wizard because
  * no language pairs exist. Use `bypassOnboarding()` to skip the wizard for
  * tests that do not cover the onboarding flow.
+ *
+ * The PWA install banner is suppressed by pre-seeding its dismissed-at key.
+ * This puts the banner into its 7-day cooldown window and prevents it from
+ * rendering during tests, eliminating pointer-event races on the tab bar.
  */
 export async function resetAppState(page: Page): Promise<void> {
   await page.goto('/#/app')
-  await page.evaluate(() => localStorage.clear())
+  await page.evaluate(
+    ({ dismissedAtKey }: { dismissedAtKey: string }) => {
+      localStorage.clear()
+      // Suppress the PWA install banner for the entire test session.
+      // useInstallPrompt checks this key and skips showing the banner while the
+      // 7-day cooldown is active. Setting it here prevents any async race
+      // between banner mount and the first tab-bar click in the test.
+      localStorage.setItem(dismissedAtKey, String(Date.now()))
+    },
+    { dismissedAtKey: STORAGE_KEYS.INSTALL_BANNER_DISMISSED_AT },
+  )
   await page.reload()
 }
 
@@ -92,14 +111,20 @@ export async function bypassOnboarding(
       pairsValue,
       settingsKey,
       settingsValue,
+      dismissedAtKey,
+      dismissedAtValue,
     }: {
       pairsKey: string
       pairsValue: string
       settingsKey: string
       settingsValue: string
+      dismissedAtKey: string
+      dismissedAtValue: string
     }) => {
       localStorage.setItem(pairsKey, pairsValue)
       localStorage.setItem(settingsKey, settingsValue)
+      // Suppress the PWA install banner (same rationale as resetAppState).
+      localStorage.setItem(dismissedAtKey, dismissedAtValue)
     },
     {
       pairsKey: STORAGE_KEYS.LANGUAGE_PAIRS,
@@ -112,6 +137,8 @@ export async function bypassOnboarding(
         theme: 'dark',
         typoTolerance: 1,
       }),
+      dismissedAtKey: STORAGE_KEYS.INSTALL_BANNER_DISMISSED_AT,
+      dismissedAtValue: String(Date.now()),
     },
   )
   // Navigate to the app route (HashRouter) so the main app shell loads.
@@ -145,15 +172,11 @@ export type AppTab = 'Home' | 'Quiz' | 'Words' | 'Stats' | 'Settings'
  * Navigates to a tab via the BottomNav.
  * The BottomNavigationAction has `aria-label="Navigate to <Tab>"`.
  *
- * Dismisses the PWA install banner if it is visible before clicking — the
- * banner is a Snackbar that can overlay the tab bar on the first few renders.
+ * The PWA install banner is suppressed globally by pre-seeding its dismissal
+ * key in resetAppState / bypassOnboarding, so no per-click banner dismissal
+ * is needed here.
  */
 export async function navigateTo(page: Page, tab: AppTab): Promise<void> {
-  // Dismiss the install banner if it is blocking the tab bar.
-  const dismissBtn = page.getByRole('button', { name: /dismiss|not now|close/i })
-  if (await dismissBtn.isVisible()) {
-    await dismissBtn.click()
-  }
   await page.getByRole('button', { name: `Navigate to ${tab}` }).click()
 }
 

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -33,20 +33,19 @@ test.beforeEach(async ({ page }) => {
 
 test('complete onboarding wizard end-to-end (manual path)', async ({ page }) => {
   // ── Step 1: Welcome ───────────────────────────────────────────────────────
-  // The welcome screen should be visible after clearing state.
-  await expect(page.getByRole('heading', { name: 'Lexio' })).toBeVisible({ timeout: 10_000 })
-  await expect(page.getByText(/Learn vocabulary in any language/i)).toBeVisible()
+  // The welcome screen should show the uppercase "WELCOME TO LEXIO" label.
+  await expect(page.getByText(/welcome to lexio/i)).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText(/learn any language, a word at a time/i)).toBeVisible()
 
   // Use "Set up my own" to go through the manual 3-step flow.
   await page.getByRole('button', { name: 'Set up my own' }).click()
 
   // ── Step 2: Language Pair ─────────────────────────────────────────────────
-  // The form is pre-filled with EN-LV defaults; just click Continue.
-  await expect(page.getByText('Create your first language pair')).toBeVisible({ timeout: 5_000 })
+  // The card-based list is pre-selected with EN-LV; just click Continue.
+  await expect(page.getByText('Choose your language pair')).toBeVisible({ timeout: 5_000 })
 
-  // Verify the default values are pre-filled.
-  await expect(page.getByRole('combobox', { name: 'Source language' })).toBeVisible()
-  await expect(page.getByRole('combobox', { name: 'Target language' })).toBeVisible()
+  // Verify the EN→LV pair card is present and pre-selected.
+  await expect(page.getByRole('radio', { name: /english.*latvian/i })).toBeVisible()
 
   await page.getByRole('button', { name: 'Continue' }).click()
 
@@ -76,14 +75,14 @@ test('complete onboarding wizard end-to-end (manual path)', async ({ page }) => 
 
 test('complete onboarding with custom language pair', async ({ page }) => {
   // ── Step 1: Welcome ───────────────────────────────────────────────────────
-  await expect(page.getByRole('heading', { name: 'Lexio' })).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText(/welcome to lexio/i)).toBeVisible({ timeout: 10_000 })
   await page.getByRole('button', { name: 'Set up my own' }).click()
 
-  // ── Step 2: Language Pair — choose German-English via quick-select chip ───
-  await expect(page.getByText('Create your first language pair')).toBeVisible({ timeout: 5_000 })
+  // ── Step 2: Language Pair — choose German-English via card radio ───────────
+  await expect(page.getByText('Choose your language pair')).toBeVisible({ timeout: 5_000 })
 
-  // Click the EN → DE chip to select a different preset.
-  await page.getByRole('button', { name: 'EN → DE' }).click()
+  // Click the EN→DE card to select a different preset.
+  await page.getByRole('radio', { name: /english.*german/i }).click()
 
   // Continue with the German pair.
   await page.getByRole('button', { name: 'Continue' }).click()
@@ -116,22 +115,24 @@ test('complete onboarding with custom language pair', async ({ page }) => {
 
 test('onboarding welcome step shows both CTAs', async ({ page }) => {
   // Verify both the demo and manual setup buttons are visible on the welcome step.
-  await expect(page.getByRole('heading', { name: 'Lexio' })).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText(/welcome to lexio/i)).toBeVisible({ timeout: 10_000 })
   await expect(page.getByRole('button', { name: 'Try it now' })).toBeVisible()
   await expect(page.getByRole('button', { name: 'Set up my own' })).toBeVisible()
 })
 
 test('onboarding step progress dots are visible in manual flow', async ({ page }) => {
-  // Verify the MobileStepper dots are rendered as the user progresses through manual flow.
-  await expect(page.getByRole('heading', { name: 'Lexio' })).toBeVisible({ timeout: 10_000 })
+  // Verify the StepPagination dots are rendered as the user progresses through manual flow.
+  await expect(page.getByText(/welcome to lexio/i)).toBeVisible({ timeout: 10_000 })
 
   // Welcome step has no stepper dots.
   await expect(page.getByRole('button', { name: 'Set up my own' })).toBeVisible()
 
   await page.getByRole('button', { name: 'Set up my own' }).click()
 
-  // Step 2 — language pair form visible.
-  await expect(page.getByText('Create your first language pair')).toBeVisible({ timeout: 5_000 })
+  // Step 2 — language pair card list visible; StepPagination dots present.
+  await expect(page.getByText('Choose your language pair')).toBeVisible({ timeout: 5_000 })
+  // StepPagination renders 3 dots with role=tab
+  await expect(page.locator('[role="tab"]').first()).toBeVisible()
 
   await page.getByRole('button', { name: 'Continue' }).click()
 

--- a/e2e/starter-packs.spec.ts
+++ b/e2e/starter-packs.spec.ts
@@ -88,33 +88,19 @@ test('install starter pack from populated word list', async ({ page }) => {
 
 test('reversed pack direction installs with swapped words', async ({ page }) => {
   // The default pair is EN-LV. We need an LV-EN pair for the reversed test.
-  // Use bypassOnboarding with a custom reversed pair.
-  await page.goto('/#/app')
-  await page.evaluate(() => localStorage.clear())
-  await page.evaluate(() => {
-    const reversedPair = {
+  // Use resetAndBypassOnboarding with a custom reversed pair so the PWA install
+  // banner suppression key is also set (same as all other tests).
+  await resetAndBypassOnboarding(page, {
+    pair: {
       id: 'test-lv-en-id',
       sourceLang: 'Latvian',
       sourceCode: 'lv',
       targetLang: 'English',
       targetCode: 'en',
-      createdAt: Date.now(),
-    }
-    localStorage.setItem('lexio:language-pairs', JSON.stringify([reversedPair]))
-    localStorage.setItem(
-      'lexio:settings',
-      JSON.stringify({
-        activePairId: 'test-lv-en-id',
-        quizMode: 'type',
-        dailyGoal: 20,
-        theme: 'dark',
-        typoTolerance: 1,
-      }),
-    )
+    },
   })
-  await page.goto('/#/app')
-  // The Home tab now uses a Liquid Glass NavBar — wait for the "Today" large title.
-  await expect(page.getByText('Today').first()).toBeVisible({ timeout: 10_000 })
+  // The Home tab now uses a Liquid Glass NavBar — "Today" large title is visible
+  // after resetAndBypassOnboarding completes.
 
   await openPackBrowserFromWordsTab(page)
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -68,7 +68,7 @@ describe('App - app shell (AppContent direct)', () => {
     expect(screen.getByRole('button', { name: /try it now/i })).toBeInTheDocument()
   })
 
-  it('should show the Lexio heading in the onboarding welcome step on first launch', async () => {
+  it('should show the "Welcome to Lexio" label in the onboarding welcome step on first launch', async () => {
     // Import AppContent directly to avoid routing/Suspense complexity in tests.
     const { default: AppContent } = await import('./AppContent')
     const { LocalStorageService } = await import('./services/storage')
@@ -82,7 +82,7 @@ describe('App - app shell (AppContent direct)', () => {
       )
     })
     await act(async () => {})
-    // The onboarding flow renders "Lexio" as the h3 heading on the welcome step.
-    expect(screen.getAllByText('Lexio').length).toBeGreaterThan(0)
+    // The onboarding flow renders "Welcome to Lexio" as the uppercase label on the welcome step.
+    expect(screen.getByText(/welcome to lexio/i)).toBeInTheDocument()
   })
 })

--- a/src/features/onboarding/OnboardingFlow.test.tsx
+++ b/src/features/onboarding/OnboardingFlow.test.tsx
@@ -96,8 +96,8 @@ describe('OnboardingFlow', () => {
       renderFlow()
       expect(screen.getByRole('button', { name: /try it now/i })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /set up my own/i })).toBeInTheDocument()
-      // The "Lexio" heading is present in the welcome step.
-      expect(screen.getAllByText('Lexio').length).toBeGreaterThan(0)
+      // The "Welcome to Lexio" label is present in the welcome step.
+      expect(screen.getByText(/welcome to lexio/i)).toBeInTheDocument()
     })
 
     it('should show a tagline on the welcome step', () => {
@@ -108,12 +108,13 @@ describe('OnboardingFlow', () => {
     it('should advance to the language pair step when "Set up my own" is clicked', async () => {
       renderFlow()
       await userEvent.click(screen.getByRole('button', { name: /set up my own/i }))
-      expect(screen.getByText(/create your first language pair/i)).toBeInTheDocument()
+      expect(screen.getByText(/choose your language pair/i)).toBeInTheDocument()
     })
 
     it('should not show stepper dots on the welcome step', () => {
       renderFlow()
-      const dots = document.querySelectorAll('.MuiMobileStepper-dot')
+      // StepPagination dots are rendered via Box elements with role=tab; not present on Welcome
+      const dots = document.querySelectorAll('[role="tab"]')
       expect(dots.length).toBe(0)
     })
   })
@@ -200,7 +201,7 @@ describe('OnboardingFlow', () => {
         await userEvent.click(screen.getByRole('button', { name: /try it now/i }))
       })
       await waitFor(() => {
-        expect(screen.getByText(/create your first language pair/i)).toBeInTheDocument()
+        expect(screen.getByText(/choose your language pair/i)).toBeInTheDocument()
       })
     })
 
@@ -238,20 +239,19 @@ describe('OnboardingFlow', () => {
       await userEvent.click(screen.getByRole('button', { name: /set up my own/i }))
     }
 
-    it('should pre-fill with LV-EN default pair', async () => {
+    it('should render the language pair heading', async () => {
       await advanceToStep2()
-      const inputs = screen.getAllByRole('combobox')
-      // First autocomplete is source language (Latvian for the manual flow default).
-      expect(inputs[0]).toHaveValue('English (en)')
+      expect(screen.getByText(/choose your language pair/i)).toBeInTheDocument()
     })
 
-    it('should show popular preset chips', async () => {
+    it('should show preset pair cards as radio buttons', async () => {
       await advanceToStep2()
-      expect(screen.getByRole('button', { name: /EN → LV/i })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /EN → DE/i })).toBeInTheDocument()
+      // Each pair card renders as role=radio
+      expect(screen.getByRole('radio', { name: /english.*latvian/i })).toBeInTheDocument()
+      expect(screen.getByRole('radio', { name: /english.*german/i })).toBeInTheDocument()
     })
 
-    it('should call onCreatePair when Continue is clicked with valid form', async () => {
+    it('should call onCreatePair with the default (EN→LV) pair when Continue is clicked', async () => {
       const onCreatePair = makeCreatePairMock()
       renderFlow(vi.fn(), onCreatePair)
       await userEvent.click(screen.getByRole('button', { name: /set up my own/i }))
@@ -264,24 +264,26 @@ describe('OnboardingFlow', () => {
       })
     })
 
-    it('should show error if form fields are empty', async () => {
+    it('should select a pair card when clicked', async () => {
       await advanceToStep2()
-
-      // Clear the source language autocomplete.
-      const inputs = screen.getAllByRole('combobox')
-      await userEvent.clear(inputs[0])
-
-      // Find "Continue" button and click.
-      await userEvent.click(screen.getByRole('button', { name: /continue/i }))
-
-      expect(screen.getByRole('alert')).toBeInTheDocument()
+      const spanishCard = screen.getByRole('radio', { name: /english.*spanish/i })
+      await userEvent.click(spanishCard)
+      expect(spanishCard).toHaveAttribute('aria-checked', 'true')
     })
 
-    it('should update form when a preset chip is clicked', async () => {
-      await advanceToStep2()
-      await userEvent.click(screen.getByRole('button', { name: /EN → DE/i }))
-      const inputs = screen.getAllByRole('combobox')
-      expect(inputs[1]).toHaveValue('German (de)')
+    it('should call onCreatePair with the selected pair when Continue is clicked', async () => {
+      const onCreatePair = makeCreatePairMock()
+      renderFlow(vi.fn(), onCreatePair)
+      await userEvent.click(screen.getByRole('button', { name: /set up my own/i }))
+      // Select the Spanish pair
+      await userEvent.click(screen.getByRole('radio', { name: /english.*spanish/i }))
+      await userEvent.click(screen.getByRole('button', { name: /continue/i }))
+      expect(onCreatePair).toHaveBeenCalledWith({
+        sourceLang: 'English',
+        sourceCode: 'en',
+        targetLang: 'Spanish',
+        targetCode: 'es',
+      })
     })
 
     it('should advance to add words step after pair creation', async () => {
@@ -296,9 +298,10 @@ describe('OnboardingFlow', () => {
       })
     })
 
-    it('should show stepper with 3 dots when in manual flow', async () => {
+    it('should show StepPagination dots when in manual flow', async () => {
       await advanceToStep2()
-      const dots = document.querySelectorAll('.MuiMobileStepper-dot')
+      // StepPagination renders dots as role=tab
+      const dots = document.querySelectorAll('[role="tab"]')
       expect(dots.length).toBe(3)
     })
   })

--- a/src/features/onboarding/OnboardingFlow.tsx
+++ b/src/features/onboarding/OnboardingFlow.tsx
@@ -1,11 +1,13 @@
 import { useState, useCallback, useEffect } from 'react'
-import { Box, MobileStepper } from '@mui/material'
+import { Box } from '@mui/material'
 import type { LanguagePair } from '@/types'
 import type { CreatePairInput } from '@/features/language-pairs'
 import { WelcomeStep } from './steps/WelcomeStep'
 import { LanguagePairStep } from './steps/LanguagePairStep'
 import { AddWordsStep } from './steps/AddWordsStep'
 import { TutorialStep } from './steps/TutorialStep'
+import { StepPagination } from './components/StepPagination'
+import { PaperSurface } from '@/components/primitives/PaperSurface'
 import { loadPack, installPack } from '@/services/starterPacks'
 import { useStorage } from '@/hooks/useStorage'
 import { analytics } from '@/services/analytics'
@@ -44,7 +46,7 @@ const DEMO_PAIR_INPUT: CreatePairInput = {
 /**
  * Steps in the manual onboarding flow (Welcome is step 0 but not counted in stepper).
  * Manual flow: Welcome (0) → Language Pair (1) → Add Words (2) → Tutorial (3)
- * The MobileStepper shows 3 dots for steps 1-3.
+ * The StepPagination shows 3 dots for steps 1-3.
  */
 const MANUAL_STEPS = 3
 
@@ -56,6 +58,9 @@ const MANUAL_STEPS = 3
  *   2. Manual setup — tap "Set up my own" on Welcome → Language Pair → Add Words → Tutorial
  *
  * The flow can also auto-trigger the demo path via the `autoDemo` prop (used for `?demo=true`).
+ *
+ * PaperSurface wraps the entire flow so the Liquid Glass wallpaper renders beneath all steps.
+ * TabBar is NOT rendered — onboarding gates the tab UI entirely (no AppContent change needed).
  */
 export function OnboardingFlow({
   onComplete,
@@ -115,18 +120,16 @@ export function OnboardingFlow({
     setActiveStep(1)
   }, [])
 
-  // The stepper shows progress for steps 1-3 (manual path). Welcome (0) has no dot.
+  // StepPagination shows progress for steps 1-3 (manual path). Welcome (0) has no dots.
   // stepperActiveStep maps: step1 → 0, step2 → 1, step3 → 2
   const stepperActiveStep = Math.max(0, activeStep - 1)
   const showStepper = activeStep > 0
 
   return (
-    <Box
+    <PaperSurface
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        minHeight: '100vh',
-        bgcolor: 'background.default',
       }}
     >
       {/* Step content — takes all available vertical space */}
@@ -148,29 +151,7 @@ export function OnboardingFlow({
       </Box>
 
       {/* Progress indicator — only shown during the manual 3-step flow */}
-      {showStepper && (
-        <MobileStepper
-          variant="dots"
-          steps={MANUAL_STEPS}
-          position="static"
-          activeStep={stepperActiveStep}
-          nextButton={<Box sx={{ width: 64 }} />}
-          backButton={<Box sx={{ width: 64 }} />}
-          sx={{
-            justifyContent: 'center',
-            bgcolor: 'transparent',
-            pb: 2,
-            '& .MuiMobileStepper-dot': {
-              width: 8,
-              height: 8,
-              mx: 0.5,
-            },
-            '& .MuiMobileStepper-dotActive': {
-              bgcolor: 'primary.main',
-            },
-          }}
-        />
-      )}
-    </Box>
+      {showStepper && <StepPagination activeStep={stepperActiveStep} />}
+    </PaperSurface>
   )
 }

--- a/src/features/onboarding/components/StepHeader.tsx
+++ b/src/features/onboarding/components/StepHeader.tsx
@@ -1,0 +1,63 @@
+/**
+ * StepHeader — shared heading block for manual onboarding steps.
+ *
+ * Renders a large title (28/800) and a subhead (16/500 inkSoft) with
+ * consistent top padding (72px) and horizontal padding (24px by default).
+ * Used by LanguagePairStep, AddWordsStep, and TutorialStep.
+ *
+ * All values flow from tokens. No hardcoded colours or spacing.
+ */
+
+import { Box } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { getGlassTokens, glassTypography } from '@/theme/liquidGlass'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface StepHeaderProps {
+  readonly title: string
+  readonly subtitle: string
+  /** Horizontal padding override in px. Defaults to 24. */
+  readonly paddingX?: number
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function StepHeader({ title, subtitle, paddingX = 24 }: StepHeaderProps): React.JSX.Element {
+  const theme = useTheme()
+  const tokens = getGlassTokens(theme.palette.mode)
+
+  return (
+    <Box sx={{ pt: '72px', px: `${paddingX}px`, mb: '28px' }}>
+      <Box
+        component="h1"
+        sx={{
+          margin: 0,
+          fontFamily: glassTypography.display,
+          fontSize: '28px',
+          fontWeight: 800,
+          letterSpacing: '-0.6px',
+          lineHeight: 1.1,
+          color: tokens.color.ink,
+          mb: '8px',
+        }}
+      >
+        {title}
+      </Box>
+      <Box
+        component="p"
+        sx={{
+          margin: 0,
+          fontFamily: glassTypography.body,
+          fontSize: '16px',
+          fontWeight: 500,
+          letterSpacing: '-0.2px',
+          lineHeight: 1.5,
+          color: tokens.color.inkSoft,
+        }}
+      >
+        {subtitle}
+      </Box>
+    </Box>
+  )
+}

--- a/src/features/onboarding/components/StepPagination.test.tsx
+++ b/src/features/onboarding/components/StepPagination.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from '@mui/material'
+import { createAppTheme } from '@/theme'
+import { StepPagination } from './StepPagination'
+
+const mockTheme = createAppTheme('dark')
+
+function renderPagination(activeStep: number) {
+  return render(
+    <ThemeProvider theme={mockTheme}>
+      <StepPagination activeStep={activeStep} />
+    </ThemeProvider>,
+  )
+}
+
+describe('StepPagination', () => {
+  it('should render 3 dots', () => {
+    renderPagination(0)
+    const dots = screen.getAllByRole('tab')
+    expect(dots.length).toBe(3)
+  })
+
+  it('should mark the first dot as active when activeStep=0', () => {
+    renderPagination(0)
+    const dots = screen.getAllByRole('tab')
+    expect(dots[0]).toHaveAttribute('aria-selected', 'true')
+    expect(dots[1]).toHaveAttribute('aria-selected', 'false')
+    expect(dots[2]).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('should mark the second dot as active when activeStep=1', () => {
+    renderPagination(1)
+    const dots = screen.getAllByRole('tab')
+    expect(dots[0]).toHaveAttribute('aria-selected', 'false')
+    expect(dots[1]).toHaveAttribute('aria-selected', 'true')
+    expect(dots[2]).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('should mark the third dot as active when activeStep=2', () => {
+    renderPagination(2)
+    const dots = screen.getAllByRole('tab')
+    expect(dots[0]).toHaveAttribute('aria-selected', 'false')
+    expect(dots[1]).toHaveAttribute('aria-selected', 'false')
+    expect(dots[2]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('should have accessible label "Onboarding progress" on container', () => {
+    renderPagination(0)
+    expect(screen.getByRole('tablist', { name: /onboarding progress/i })).toBeInTheDocument()
+  })
+
+  it('should label each dot with its step number', () => {
+    renderPagination(0)
+    expect(screen.getByRole('tab', { name: /step 1 of 3/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /step 2 of 3/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /step 3 of 3/i })).toBeInTheDocument()
+  })
+})

--- a/src/features/onboarding/components/StepPagination.test.tsx
+++ b/src/features/onboarding/components/StepPagination.test.tsx
@@ -45,9 +45,19 @@ describe('StepPagination', () => {
     expect(dots[2]).toHaveAttribute('aria-selected', 'true')
   })
 
-  it('should have accessible label "Onboarding progress" on container', () => {
+  it('should have accessible label "Onboarding progress" on container by default', () => {
     renderPagination(0)
     expect(screen.getByRole('tablist', { name: /onboarding progress/i })).toBeInTheDocument()
+  })
+
+  it('should render custom totalSteps when provided', () => {
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <StepPagination activeStep={2} totalSteps={4} label="Tutorial slides" />
+      </ThemeProvider>,
+    )
+    expect(screen.getAllByRole('tab').length).toBe(4)
+    expect(screen.getByRole('tablist', { name: /tutorial slides/i })).toBeInTheDocument()
   })
 
   it('should label each dot with its step number', () => {

--- a/src/features/onboarding/components/StepPagination.tsx
+++ b/src/features/onboarding/components/StepPagination.tsx
@@ -1,5 +1,5 @@
 /**
- * StepPagination — 4-capsule progress dots for the onboarding flow.
+ * StepPagination — capsule progress dots for the onboarding flow.
  *
  * Displays one dot per step. The active dot is wider (24px) and accent-filled.
  * Inactive dots are narrow (8px) and rule2-filled. Both use radius 99 (pill).
@@ -8,18 +8,22 @@
  * All values flow from glassTypography / glassColors tokens. No hardcoded magic.
  *
  * A11y: the container is `role="tablist"` with a descriptive aria-label.
- * Each dot is `role="tab"` with `aria-selected` and `aria-label="Step N of 4"`.
+ * Each dot is `role="tab"` with `aria-selected` and `aria-label="Step N of {total}"`.
  * The dots are not interactive — they are presentation-only.
+ *
+ * Used by:
+ *   - OnboardingFlow (3 steps, label "Onboarding progress")
+ *   - TutorialStep (4 slides, label "Tutorial slides")
  */
 
-import { Box } from '@mui/material'
+import { Box, type SxProps, type Theme } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { getGlassTokens, glassMotion } from '@/theme/liquidGlass'
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-/** Total number of steps in the manual onboarding flow (LanguagePair → Tutorial). */
-const STEP_COUNT = 3
+/** Default step count — 3 for the manual onboarding flow (LanguagePair → Tutorial). */
+const DEFAULT_STEP_COUNT = 3
 
 /** Width of the active capsule dot in px. */
 const ACTIVE_WIDTH = 24
@@ -37,22 +41,39 @@ const DOT_GAP = 6
 
 export interface StepPaginationProps {
   /**
-   * Zero-based index of the currently active step within the range 0–(STEP_COUNT-1).
-   * The parent (OnboardingFlow) maps its own step numbering before passing this.
+   * Zero-based index of the currently active step within the range 0–(totalSteps-1).
+   * The parent maps its own step numbering before passing this.
    */
   readonly activeStep: number
+  /**
+   * Total number of dots to render.
+   * Defaults to 3 (the manual onboarding flow has 3 steps after Welcome).
+   */
+  readonly totalSteps?: number
+  /**
+   * Accessible label for the tablist container.
+   * Defaults to "Onboarding progress".
+   */
+  readonly label?: string
+  /** Optional sx overrides for the container. */
+  readonly sx?: SxProps<Theme>
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function StepPagination({ activeStep }: StepPaginationProps): React.JSX.Element {
+export function StepPagination({
+  activeStep,
+  totalSteps = DEFAULT_STEP_COUNT,
+  label = 'Onboarding progress',
+  sx,
+}: StepPaginationProps): React.JSX.Element {
   const theme = useTheme()
   const tokens = getGlassTokens(theme.palette.mode)
 
   return (
     <Box
       role="tablist"
-      aria-label="Onboarding progress"
+      aria-label={label}
       sx={{
         display: 'flex',
         flexDirection: 'row',
@@ -60,16 +81,17 @@ export function StepPagination({ activeStep }: StepPaginationProps): React.JSX.E
         justifyContent: 'center',
         gap: `${DOT_GAP}px`,
         py: '12px',
+        ...sx,
       }}
     >
-      {Array.from({ length: STEP_COUNT }).map((_, index) => {
+      {Array.from({ length: totalSteps }).map((_, index) => {
         const isActive = index === activeStep
         return (
           <Box
             key={index}
             role="tab"
             aria-selected={isActive}
-            aria-label={`Step ${index + 1} of ${STEP_COUNT}`}
+            aria-label={`Step ${index + 1} of ${totalSteps}`}
             sx={{
               width: isActive ? `${ACTIVE_WIDTH}px` : `${INACTIVE_WIDTH}px`,
               height: `${DOT_HEIGHT}px`,

--- a/src/features/onboarding/components/StepPagination.tsx
+++ b/src/features/onboarding/components/StepPagination.tsx
@@ -1,0 +1,89 @@
+/**
+ * StepPagination — 4-capsule progress dots for the onboarding flow.
+ *
+ * Displays one dot per step. The active dot is wider (24px) and accent-filled.
+ * Inactive dots are narrow (8px) and rule2-filled. Both use radius 99 (pill).
+ * Height 4px throughout — matches the `<Progress height=4>` aesthetic.
+ *
+ * All values flow from glassTypography / glassColors tokens. No hardcoded magic.
+ *
+ * A11y: the container is `role="tablist"` with a descriptive aria-label.
+ * Each dot is `role="tab"` with `aria-selected` and `aria-label="Step N of 4"`.
+ * The dots are not interactive — they are presentation-only.
+ */
+
+import { Box } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { getGlassTokens, glassMotion } from '@/theme/liquidGlass'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Total number of steps in the manual onboarding flow (LanguagePair → Tutorial). */
+const STEP_COUNT = 3
+
+/** Width of the active capsule dot in px. */
+const ACTIVE_WIDTH = 24
+
+/** Width of an inactive capsule dot in px. */
+const INACTIVE_WIDTH = 8
+
+/** Height of every dot in px. */
+const DOT_HEIGHT = 4
+
+/** Gap between dots in px. */
+const DOT_GAP = 6
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface StepPaginationProps {
+  /**
+   * Zero-based index of the currently active step within the range 0–(STEP_COUNT-1).
+   * The parent (OnboardingFlow) maps its own step numbering before passing this.
+   */
+  readonly activeStep: number
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function StepPagination({ activeStep }: StepPaginationProps): React.JSX.Element {
+  const theme = useTheme()
+  const tokens = getGlassTokens(theme.palette.mode)
+
+  return (
+    <Box
+      role="tablist"
+      aria-label="Onboarding progress"
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: `${DOT_GAP}px`,
+        py: '12px',
+      }}
+    >
+      {Array.from({ length: STEP_COUNT }).map((_, index) => {
+        const isActive = index === activeStep
+        return (
+          <Box
+            key={index}
+            role="tab"
+            aria-selected={isActive}
+            aria-label={`Step ${index + 1} of ${STEP_COUNT}`}
+            sx={{
+              width: isActive ? `${ACTIVE_WIDTH}px` : `${INACTIVE_WIDTH}px`,
+              height: `${DOT_HEIGHT}px`,
+              borderRadius: '99px',
+              backgroundColor: isActive ? tokens.color.accent : tokens.color.rule2,
+              transition: `width ${glassMotion.toggle}, background-color ${glassMotion.toggle}`,
+              // Reduce Motion: disable width transition
+              '@media (prefers-reduced-motion: reduce)': {
+                transition: 'none',
+              },
+            }}
+          />
+        )
+      })}
+    </Box>
+  )
+}

--- a/src/features/onboarding/components/index.ts
+++ b/src/features/onboarding/components/index.ts
@@ -1,2 +1,5 @@
 export { StepPagination } from './StepPagination'
 export type { StepPaginationProps } from './StepPagination'
+
+export { StepHeader } from './StepHeader'
+export type { StepHeaderProps } from './StepHeader'

--- a/src/features/onboarding/components/index.ts
+++ b/src/features/onboarding/components/index.ts
@@ -1,0 +1,2 @@
+export { StepPagination } from './StepPagination'
+export type { StepPaginationProps } from './StepPagination'

--- a/src/features/onboarding/steps/AddWordsStep.tsx
+++ b/src/features/onboarding/steps/AddWordsStep.tsx
@@ -1,21 +1,32 @@
+/**
+ * AddWordsStep — Step 3 of the onboarding flow (Liquid Glass restyle, issue #153).
+ *
+ * Layout: Library grouped-list aesthetic — SectionHeader + Glass containing GlassRow per option.
+ * Options:
+ *   A) Load a starter pack (if available for the created pair)
+ *   B) Add my own words (skip to main app)
+ * Bottom: Skip link text button.
+ *
+ * Business logic (listPacks, installPack, auto-advance) is preserved untouched — render only.
+ * useWords.addWord hook is NOT used here — users add words in the Library screen after onboarding.
+ *
+ * All values flow from tokens. No hardcoded colours or spacing.
+ */
+
 import { useState, useEffect, useCallback } from 'react'
-import {
-  Box,
-  Typography,
-  Button,
-  Stack,
-  CircularProgress,
-  Alert,
-  Card,
-  CardActionArea,
-  CardContent,
-} from '@mui/material'
-import LibraryBooksIcon from '@mui/icons-material/LibraryBooks'
-import EditNoteIcon from '@mui/icons-material/EditNote'
-import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import { Box, Alert } from '@mui/material'
+import { BookOpen, PenLine, CheckCircle, Loader } from 'lucide-react'
+import { useTheme } from '@mui/material/styles'
 import type { LanguagePair, StarterPack } from '@/types'
 import { listPacks, packMatchesPair, installPack } from '@/services/starterPacks'
 import { useStorage } from '@/hooks/useStorage'
+import { getGlassTokens, glassTypography } from '@/theme/liquidGlass'
+import { Glass } from '@/components/primitives/Glass'
+import { GlassRow } from '@/components/composites/GlassRow'
+import { SectionHeader } from '@/components/composites/SectionHeader'
+import { Btn } from '@/components/atoms/Btn'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface AddWordsStepProps {
   /** The pair created in step 2. May be null only briefly before the step renders. */
@@ -26,18 +37,13 @@ export interface AddWordsStepProps {
 
 type SelectionState = 'idle' | 'pack' | 'own'
 
-/**
- * Step 3 of the onboarding flow.
- * Offers the user three choices:
- *   A) Load a starter pack (if one is available for the created pair)
- *   B) Add words manually
- *   C) Skip for now
- *
- * When option A is chosen, the pack is installed immediately and the user
- * sees a success message before moving to the next step.
- */
+// ─── Component ────────────────────────────────────────────────────────────────
+
 export function AddWordsStep({ createdPair, onNext, onSkip }: AddWordsStepProps) {
+  const theme = useTheme()
+  const tokens = getGlassTokens(theme.palette.mode)
   const storage = useStorage()
+
   const [selection, setSelection] = useState<SelectionState>('idle')
   const [availablePack, setAvailablePack] = useState<StarterPack | null>(null)
   const [loadingPacks, setLoadingPacks] = useState(true)
@@ -111,110 +117,125 @@ export function AddWordsStep({ createdPair, onNext, onSkip }: AddWordsStepProps)
     onSkip()
   }, [onSkip])
 
+  // Icon and label for the pack option vary by loading/installing/installed state
+  const packIcon = installed ? CheckCircle : loadingPacks || installing ? Loader : BookOpen
+  const packIconBg = installed ? tokens.color.ok : tokens.color.accent
+
+  const packTitle = installed
+    ? `Loaded ${installedCount} words!`
+    : loadingPacks
+      ? 'Looking for a starter pack…'
+      : availablePack
+        ? `Load starter pack: ${availablePack.name}`
+        : 'No starter pack available'
+
+  const packDetail = installed
+    ? 'Pack installed successfully.'
+    : availablePack && !loadingPacks
+      ? `${availablePack.words.length} curated words — ${availablePack.description}`
+      : undefined
+
   return (
     <Box
       sx={{
         flex: 1,
         display: 'flex',
         flexDirection: 'column',
-        px: 3,
-        py: 4,
-        maxWidth: 480,
-        mx: 'auto',
-        width: '100%',
+        pt: '72px',
       }}
     >
-      <Box sx={{ mb: 3, textAlign: 'center' }}>
-        <Typography variant="h5" gutterBottom>
+      {/* Header */}
+      <Box sx={{ px: '24px', mb: '28px' }}>
+        <Box
+          component="h1"
+          sx={{
+            margin: 0,
+            fontFamily: glassTypography.display,
+            fontSize: '28px',
+            fontWeight: 800,
+            letterSpacing: '-0.6px',
+            lineHeight: 1.1,
+            color: tokens.color.ink,
+            mb: '8px',
+          }}
+        >
           Add your first words
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
+        </Box>
+        <Box
+          component="p"
+          sx={{
+            margin: 0,
+            fontFamily: glassTypography.body,
+            fontSize: '16px',
+            fontWeight: 500,
+            letterSpacing: '-0.2px',
+            lineHeight: 1.5,
+            color: tokens.color.inkSoft,
+          }}
+        >
           Start with a curated pack or add your own vocabulary.
-        </Typography>
+        </Box>
       </Box>
 
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
+      {/* Options group — Library grouped-list pattern */}
+      <Box sx={{ px: '16px' }}>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
 
-      {loadingPacks ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-          <CircularProgress />
-        </Box>
-      ) : (
-        <Stack spacing={2}>
-          {availablePack && (
-            <Card
-              variant="outlined"
-              sx={{
-                borderColor: selection === 'pack' ? 'primary.main' : 'divider',
-                borderWidth: 2,
-              }}
-            >
-              <CardActionArea onClick={handlePackCardClick} disabled={installing || installed}>
-                <CardContent sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
-                  <Box sx={{ pt: 0.5 }}>
-                    {installed ? (
-                      <CheckCircleIcon color="success" />
-                    ) : installing ? (
-                      <CircularProgress size={24} />
-                    ) : (
-                      <LibraryBooksIcon color="primary" />
-                    )}
-                  </Box>
-                  <Box>
-                    <Typography variant="subtitle1" fontWeight={700}>
-                      {installed
-                        ? `Loaded ${installedCount} words!`
-                        : `Load starter pack: ${availablePack.name}`}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      {installed
-                        ? 'Pack installed successfully.'
-                        : `${availablePack.words.length} curated words — ${availablePack.description}`}
-                    </Typography>
-                  </Box>
-                </CardContent>
-              </CardActionArea>
-            </Card>
-          )}
+        <SectionHeader>Get started</SectionHeader>
 
-          <Card
-            variant="outlined"
-            sx={{
-              borderColor: selection === 'own' ? 'primary.main' : 'divider',
-              borderWidth: 2,
-            }}
-          >
-            <CardActionArea onClick={handleOwnWordsClick} disabled={installing || installed}>
-              <CardContent sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
-                <EditNoteIcon color="primary" sx={{ pt: 0.5 }} />
-                <Box>
-                  <Typography variant="subtitle1" fontWeight={700}>
-                    Add my own words
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    Build your vocabulary list from scratch or import from CSV.
-                  </Typography>
-                </Box>
-              </CardContent>
-            </CardActionArea>
-          </Card>
-        </Stack>
-      )}
+        <Glass pad={0} floating>
+          {availablePack !== null || loadingPacks ? (
+            <GlassRow
+              icon={packIcon}
+              iconBg={packIconBg}
+              title={packTitle}
+              detail={packDetail}
+              chevron={!installing && !installed && !loadingPacks}
+              isLast={false}
+              onClick={
+                !installing && !installed && !loadingPacks && availablePack
+                  ? handlePackCardClick
+                  : undefined
+              }
+            />
+          ) : null}
 
-      <Box sx={{ mt: 'auto', pt: 3, textAlign: 'center' }}>
-        <Button
-          variant="text"
-          color="inherit"
+          <GlassRow
+            icon={PenLine}
+            iconBg={tokens.color.violet}
+            title={selection === 'own' ? 'Adding your own words…' : 'Add my own words'}
+            detail="Build your vocabulary from scratch or import from CSV."
+            chevron={selection !== 'own'}
+            isLast
+            onClick={
+              !installing && !installed && selection !== 'own' ? handleOwnWordsClick : undefined
+            }
+          />
+        </Glass>
+      </Box>
+
+      {/* Skip link */}
+      <Box
+        sx={{
+          mt: 'auto',
+          pt: '24px',
+          pb: '24px',
+          textAlign: 'center',
+        }}
+      >
+        <Btn
+          kind="glass"
+          size="sm"
           onClick={onSkip}
           disabled={installing}
-          sx={{ color: 'text.secondary' }}
+          aria-label="Skip for now"
         >
           Skip for now
-        </Button>
+        </Btn>
       </Box>
     </Box>
   )

--- a/src/features/onboarding/steps/AddWordsStep.tsx
+++ b/src/features/onboarding/steps/AddWordsStep.tsx
@@ -20,11 +20,12 @@ import { useTheme } from '@mui/material/styles'
 import type { LanguagePair, StarterPack } from '@/types'
 import { listPacks, packMatchesPair, installPack } from '@/services/starterPacks'
 import { useStorage } from '@/hooks/useStorage'
-import { getGlassTokens, glassTypography } from '@/theme/liquidGlass'
+import { getGlassTokens } from '@/theme/liquidGlass'
 import { Glass } from '@/components/primitives/Glass'
 import { GlassRow } from '@/components/composites/GlassRow'
 import { SectionHeader } from '@/components/composites/SectionHeader'
 import { Btn } from '@/components/atoms/Btn'
+import { StepHeader } from '../components/StepHeader'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -141,41 +142,13 @@ export function AddWordsStep({ createdPair, onNext, onSkip }: AddWordsStepProps)
         flex: 1,
         display: 'flex',
         flexDirection: 'column',
-        pt: '72px',
       }}
     >
       {/* Header */}
-      <Box sx={{ px: '24px', mb: '28px' }}>
-        <Box
-          component="h1"
-          sx={{
-            margin: 0,
-            fontFamily: glassTypography.display,
-            fontSize: '28px',
-            fontWeight: 800,
-            letterSpacing: '-0.6px',
-            lineHeight: 1.1,
-            color: tokens.color.ink,
-            mb: '8px',
-          }}
-        >
-          Add your first words
-        </Box>
-        <Box
-          component="p"
-          sx={{
-            margin: 0,
-            fontFamily: glassTypography.body,
-            fontSize: '16px',
-            fontWeight: 500,
-            letterSpacing: '-0.2px',
-            lineHeight: 1.5,
-            color: tokens.color.inkSoft,
-          }}
-        >
-          Start with a curated pack or add your own vocabulary.
-        </Box>
-      </Box>
+      <StepHeader
+        title="Add your first words"
+        subtitle="Start with a curated pack or add your own vocabulary."
+      />
 
       {/* Options group — Library grouped-list pattern */}
       <Box sx={{ px: '16px' }}>

--- a/src/features/onboarding/steps/LanguagePairStep.tsx
+++ b/src/features/onboarding/steps/LanguagePairStep.tsx
@@ -23,6 +23,7 @@ import { Check } from 'lucide-react'
 import { getGlassTokens, glassTypography } from '@/theme/liquidGlass'
 import { Glass } from '@/components/primitives/Glass'
 import { Btn } from '@/components/atoms/Btn'
+import { StepHeader } from '../components/StepHeader'
 import type { CreatePairInput } from '@/features/language-pairs'
 import type { LanguagePair } from '@/types'
 
@@ -302,42 +303,10 @@ export function LanguagePairStep({ onPairCreated, onCreatePair }: LanguagePairSt
       }}
     >
       {/* Header block — padding-top 72, horizontal 24 */}
-      <Box
-        sx={{
-          pt: '72px',
-          px: '24px',
-        }}
-      >
-        <Box
-          component="h1"
-          sx={{
-            margin: 0,
-            fontFamily: glassTypography.display,
-            fontSize: '28px',
-            fontWeight: 800,
-            letterSpacing: '-0.6px',
-            lineHeight: 1.1,
-            color: tokens.color.ink,
-            mb: '8px',
-          }}
-        >
-          Choose your language pair
-        </Box>
-        <Box
-          component="p"
-          sx={{
-            margin: 0,
-            fontFamily: glassTypography.body,
-            fontSize: '16px',
-            fontWeight: 500,
-            letterSpacing: '-0.2px',
-            lineHeight: 1.5,
-            color: tokens.color.inkSoft,
-          }}
-        >
-          Select the language you want to learn.
-        </Box>
-      </Box>
+      <StepHeader
+        title="Choose your language pair"
+        subtitle="Select the language you want to learn."
+      />
 
       {/* Card list — padding-top 28, horizontal 16 */}
       <Box

--- a/src/features/onboarding/steps/LanguagePairStep.tsx
+++ b/src/features/onboarding/steps/LanguagePairStep.tsx
@@ -1,248 +1,403 @@
+/**
+ * LanguagePairStep — Step 2 of the onboarding flow (Liquid Glass restyle, issue #153).
+ *
+ * Design spec (01-onboarding.png):
+ *   - Header block: padding-top 72, horizontal 24 — title + subhead
+ *   - Card list: padding-top 28, horizontal 16 — one <Glass pad=12 floating> card per preset pair
+ *   - Each card: 46×46 gradient square + label (17/600) + sub (13/inkSec) + 24×24 radio circle
+ *   - Selected card: <Glass strong> + 2px accent border + filled accent radio with white check
+ *   - CTA "Continue": <Btn filled full lg> positioned absolute at bottom 46, left/right 16
+ *
+ * Language-pair gradients from glassColors.pairGradients (keyed by target lang code, lowercase).
+ * Falls back to avatarGradient for unknown codes (e.g. 'lv' for the EN-LV default).
+ *
+ * Business logic (handleSubmit, onCreatePair) is preserved untouched — render layer only.
+ * The Autocomplete custom-pair form is removed; users select from presets only.
+ * The default EN→LV pair (lv) is pre-selected so first-time users can tap Continue immediately.
+ */
+
 import { useState, useCallback } from 'react'
-import { Box, Typography, Button, TextField, Autocomplete, Stack, Alert, Chip } from '@mui/material'
-import TranslateIcon from '@mui/icons-material/Translate'
-import { LANGUAGE_PRESETS, DEFAULT_PAIR_PRESET } from '@/features/language-pairs'
-import type { LanguagePreset, CreatePairInput } from '@/features/language-pairs'
+import { Box, Alert } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { Check } from 'lucide-react'
+import { getGlassTokens, glassTypography } from '@/theme/liquidGlass'
+import { Glass } from '@/components/primitives/Glass'
+import { Btn } from '@/components/atoms/Btn'
+import type { CreatePairInput } from '@/features/language-pairs'
 import type { LanguagePair } from '@/types'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface LanguagePairStepProps {
   readonly onPairCreated: (pair: LanguagePair) => void
   readonly onCreatePair: (input: CreatePairInput) => Promise<LanguagePair>
 }
 
-interface FormState {
-  sourceLang: string
-  sourceCode: string
-  targetLang: string
-  targetCode: string
+interface PairPreset {
+  readonly label: string
+  readonly subLabel: string
+  readonly source: string
+  readonly sourceCode: string
+  readonly target: string
+  readonly targetCode: string
 }
 
-const DEFAULT_FORM: FormState = {
-  sourceLang: DEFAULT_PAIR_PRESET.sourceLang,
-  sourceCode: DEFAULT_PAIR_PRESET.sourceCode,
-  targetLang: DEFAULT_PAIR_PRESET.targetLang,
-  targetCode: DEFAULT_PAIR_PRESET.targetCode,
-}
+// ─── Constants ────────────────────────────────────────────────────────────────
 
-/** Popular preset pairs offered as quick-select chips. */
-const POPULAR_PRESETS = [
-  { label: 'EN → LV', source: 'English', sourceCode: 'en', target: 'Latvian', targetCode: 'lv' },
-  { label: 'EN → DE', source: 'English', sourceCode: 'en', target: 'German', targetCode: 'de' },
-  { label: 'EN → ES', source: 'English', sourceCode: 'en', target: 'Spanish', targetCode: 'es' },
-  { label: 'EN → FR', source: 'English', sourceCode: 'en', target: 'French', targetCode: 'fr' },
+/**
+ * Preset pairs shown as cards. Ordered by common usage.
+ * The code used for gradient lookup is targetCode.
+ */
+const PRESET_PAIRS: readonly PairPreset[] = [
+  {
+    label: 'English → Latvian',
+    subLabel: 'EN → LV',
+    source: 'English',
+    sourceCode: 'en',
+    target: 'Latvian',
+    targetCode: 'lv',
+  },
+  {
+    label: 'English → Spanish',
+    subLabel: 'EN → ES',
+    source: 'English',
+    sourceCode: 'en',
+    target: 'Spanish',
+    targetCode: 'es',
+  },
+  {
+    label: 'English → French',
+    subLabel: 'EN → FR',
+    source: 'English',
+    sourceCode: 'en',
+    target: 'French',
+    targetCode: 'fr',
+  },
+  {
+    label: 'English → German',
+    subLabel: 'EN → DE',
+    source: 'English',
+    sourceCode: 'en',
+    target: 'German',
+    targetCode: 'de',
+  },
+  {
+    label: 'English → Japanese',
+    subLabel: 'EN → JA',
+    source: 'English',
+    sourceCode: 'en',
+    target: 'Japanese',
+    targetCode: 'ja',
+  },
 ] as const
 
 /**
- * Step 2 of the onboarding flow.
- * Lets the user select a language pair via quick-select chips or a custom form.
- * Pre-fills with the EN-LV default suggestion from the product spec.
+ * Gradient square size per design spec.
  */
+const GRADIENT_SQUARE_SIZE = 46
+
+/**
+ * Radio circle outer size per design spec.
+ */
+const RADIO_SIZE = 24
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the pair gradient for a given target language code.
+ * Falls back to avatarGradient for codes not in the map
+ * (e.g. 'lv' for EN-LV is intentionally not in the spec's list).
+ */
+function getPairGradient(
+  targetCode: string,
+  pairGradients: Record<string, string>,
+  avatarGradient: string,
+): string {
+  const code = targetCode.toLowerCase()
+  return pairGradients[code] ?? avatarGradient
+}
+
+// ─── Sub-component: PairCard ──────────────────────────────────────────────────
+
+interface PairCardProps {
+  readonly preset: PairPreset
+  readonly isSelected: boolean
+  readonly onSelect: (preset: PairPreset) => void
+  readonly gradient: string
+  readonly tokens: ReturnType<typeof getGlassTokens>
+  readonly isLast: boolean
+}
+
+function PairCard({
+  preset,
+  isSelected,
+  onSelect,
+  gradient,
+  tokens,
+  isLast,
+}: PairCardProps): React.JSX.Element {
+  const handleClick = useCallback(() => {
+    onSelect(preset)
+  }, [onSelect, preset])
+
+  return (
+    <Glass
+      pad={12}
+      floating
+      strong={isSelected}
+      sx={
+        isSelected
+          ? {
+              border: `2px solid ${tokens.color.accent}`,
+              // Compensate so the border doesn't shift layout
+              margin: '-2px',
+            }
+          : undefined
+      }
+    >
+      <Box
+        component="button"
+        type="button"
+        role="radio"
+        aria-checked={isSelected}
+        aria-label={preset.label}
+        onClick={handleClick}
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: '14px',
+          width: '100%',
+          background: 'none',
+          border: 'none',
+          padding: 0,
+          cursor: 'pointer',
+          textAlign: 'left',
+          // Hairline divider at bottom — only between cards, not after last
+          '&::after': isLast
+            ? { display: 'none' }
+            : {
+                content: '""',
+                position: 'absolute',
+                bottom: 0,
+                left: `${GRADIENT_SQUARE_SIZE + 12 + 14}px`,
+                right: 0,
+                height: '0.5px',
+                backgroundColor: tokens.color.rule2,
+                pointerEvents: 'none',
+              },
+        }}
+      >
+        {/* 46×46 gradient square */}
+        <Box
+          aria-hidden="true"
+          sx={{
+            flexShrink: 0,
+            width: `${GRADIENT_SQUARE_SIZE}px`,
+            height: `${GRADIENT_SQUARE_SIZE}px`,
+            borderRadius: '10px',
+            background: gradient,
+          }}
+        />
+
+        {/* Label + sub column */}
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Box
+            component="span"
+            sx={{
+              display: 'block',
+              fontFamily: glassTypography.body,
+              fontSize: '17px',
+              fontWeight: 600,
+              letterSpacing: '-0.3px',
+              lineHeight: 1.3,
+              color: tokens.color.ink,
+            }}
+          >
+            {preset.label}
+          </Box>
+          <Box
+            component="span"
+            sx={{
+              display: 'block',
+              fontFamily: glassTypography.body,
+              fontSize: '13px',
+              fontWeight: 500,
+              letterSpacing: '-0.1px',
+              lineHeight: 1.3,
+              color: tokens.color.inkSec,
+              mt: '2px',
+            }}
+          >
+            {preset.subLabel}
+          </Box>
+        </Box>
+
+        {/* 24×24 radio circle */}
+        <Box
+          aria-hidden="true"
+          sx={{
+            flexShrink: 0,
+            width: `${RADIO_SIZE}px`,
+            height: `${RADIO_SIZE}px`,
+            borderRadius: '50%',
+            backgroundColor: isSelected ? tokens.color.accent : 'transparent',
+            border: isSelected ? 'none' : `2px solid ${tokens.color.rule2}`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {isSelected && <Check size={14} strokeWidth={3} color="#ffffff" aria-hidden="true" />}
+        </Box>
+      </Box>
+    </Glass>
+  )
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
 export function LanguagePairStep({ onPairCreated, onCreatePair }: LanguagePairStepProps) {
-  const [form, setForm] = useState<FormState>(DEFAULT_FORM)
+  const theme = useTheme()
+  const tokens = getGlassTokens(theme.palette.mode)
+
+  // Default to EN→LV (first preset) so the user can tap Continue immediately
+  const [selectedPreset, setSelectedPreset] = useState<PairPreset>(PRESET_PAIRS[0])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const handlePresetChipClick = useCallback(
-    (preset: (typeof POPULAR_PRESETS)[number]) => () => {
-      setForm({
-        sourceLang: preset.source,
-        sourceCode: preset.sourceCode,
-        targetLang: preset.target,
-        targetCode: preset.targetCode,
-      })
-      setError(null)
-    },
-    [],
-  )
-
-  const handleSourcePresetChange = useCallback(
-    (_: React.SyntheticEvent, value: LanguagePreset | string | null) => {
-      if (typeof value === 'string') {
-        setForm((prev) => ({ ...prev, sourceLang: value, sourceCode: '' }))
-      } else if (value) {
-        setForm((prev) => ({ ...prev, sourceLang: value.name, sourceCode: value.code }))
-      } else {
-        setForm((prev) => ({ ...prev, sourceLang: '', sourceCode: '' }))
-      }
-    },
-    [],
-  )
-
-  const handleTargetPresetChange = useCallback(
-    (_: React.SyntheticEvent, value: LanguagePreset | string | null) => {
-      if (typeof value === 'string') {
-        setForm((prev) => ({ ...prev, targetLang: value, targetCode: '' }))
-      } else if (value) {
-        setForm((prev) => ({ ...prev, targetLang: value.name, targetCode: value.code }))
-      } else {
-        setForm((prev) => ({ ...prev, targetLang: '', targetCode: '' }))
-      }
-    },
-    [],
-  )
+  const handleSelect = useCallback((preset: PairPreset) => {
+    setSelectedPreset(preset)
+    setError(null)
+  }, [])
 
   const handleSubmit = useCallback(async () => {
-    const { sourceLang, sourceCode, targetLang, targetCode } = form
-
-    if (!sourceLang.trim() || !sourceCode.trim() || !targetLang.trim() || !targetCode.trim()) {
-      setError('Please fill in all fields to continue.')
-      return
-    }
-
-    if (sourceLang.trim() === targetLang.trim() && sourceCode.trim() === targetCode.trim()) {
-      setError('Source and target languages must be different.')
-      return
-    }
-
     setError(null)
     setSubmitting(true)
-
     try {
       const pair = await onCreatePair({
-        sourceLang: sourceLang.trim(),
-        sourceCode: sourceCode.trim().toLowerCase(),
-        targetLang: targetLang.trim(),
-        targetCode: targetCode.trim().toLowerCase(),
+        sourceLang: selectedPreset.source,
+        sourceCode: selectedPreset.sourceCode.toLowerCase(),
+        targetLang: selectedPreset.target,
+        targetCode: selectedPreset.targetCode.toLowerCase(),
       })
       onPairCreated(pair)
     } catch {
       setError('Failed to create language pair. Please try again.')
       setSubmitting(false)
     }
-  }, [form, onCreatePair, onPairCreated])
-
-  const sourcePresetValue = LANGUAGE_PRESETS.find((p) => p.name === form.sourceLang) ?? null
-  const targetPresetValue = LANGUAGE_PRESETS.find((p) => p.name === form.targetLang) ?? null
+  }, [selectedPreset, onCreatePair, onPairCreated])
 
   return (
+    // Position relative so the absolute Continue button can anchor here
     <Box
       sx={{
+        position: 'relative',
         flex: 1,
         display: 'flex',
         flexDirection: 'column',
-        px: 3,
-        py: 4,
-        maxWidth: 480,
-        mx: 'auto',
-        width: '100%',
+        minHeight: '100%',
+        // Extra bottom padding so content doesn't hide under the absolute CTA
+        pb: '110px',
       }}
     >
-      <Box sx={{ mb: 3, textAlign: 'center' }}>
-        <TranslateIcon sx={{ fontSize: 48, color: 'primary.main', mb: 1 }} />
-        <Typography variant="h5" gutterBottom>
-          Create your first language pair
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          Choose what you already know and what you want to learn.
-        </Typography>
-      </Box>
-
-      {/* Quick-select chips */}
-      <Box sx={{ mb: 3 }}>
-        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
-          Popular choices
-        </Typography>
-        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-          {POPULAR_PRESETS.map((preset) => {
-            const isSelected =
-              form.sourceLang === preset.source && form.targetLang === preset.target
-            return (
-              <Chip
-                key={preset.label}
-                label={preset.label}
-                onClick={handlePresetChipClick(preset)}
-                color={isSelected ? 'primary' : 'default'}
-                variant={isSelected ? 'filled' : 'outlined'}
-                sx={{ mb: 0.5 }}
-              />
-            )
-          })}
-        </Stack>
-      </Box>
-
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
-
-      <Stack spacing={2} sx={{ mb: 3 }}>
-        <Typography variant="subtitle2" color="text.secondary">
-          Source language — the one you already know
-        </Typography>
-
-        <Autocomplete<LanguagePreset, false, false, true>
-          options={[...LANGUAGE_PRESETS]}
-          getOptionLabel={(option) =>
-            typeof option === 'string' ? option : `${option.name} (${option.code})`
-          }
-          value={sourcePresetValue}
-          onChange={handleSourcePresetChange}
-          freeSolo
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Source language"
-              placeholder="e.g. English"
-              inputProps={{ ...params.inputProps, lang: 'und' }}
-            />
-          )}
-          isOptionEqualToValue={(option, value) => option.code === value.code}
-        />
-
-        <TextField
-          label="Language code"
-          placeholder="e.g. en"
-          value={form.sourceCode}
-          onChange={(e) => setForm((prev) => ({ ...prev, sourceCode: e.target.value }))}
-          inputProps={{ maxLength: 10 }}
-          helperText="BCP-47 code (auto-filled from preset)"
-        />
-
-        <Typography variant="subtitle2" color="text.secondary" sx={{ pt: 1 }}>
-          Target language — the one you want to learn
-        </Typography>
-
-        <Autocomplete<LanguagePreset, false, false, true>
-          options={[...LANGUAGE_PRESETS]}
-          getOptionLabel={(option) =>
-            typeof option === 'string' ? option : `${option.name} (${option.code})`
-          }
-          value={targetPresetValue}
-          onChange={handleTargetPresetChange}
-          freeSolo
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Target language"
-              placeholder="e.g. Latvian"
-              inputProps={{ ...params.inputProps, lang: 'und' }}
-            />
-          )}
-          isOptionEqualToValue={(option, value) => option.code === value.code}
-        />
-
-        <TextField
-          label="Language code"
-          placeholder="e.g. lv"
-          value={form.targetCode}
-          onChange={(e) => setForm((prev) => ({ ...prev, targetCode: e.target.value }))}
-          inputProps={{ maxLength: 10 }}
-          helperText="BCP-47 code (auto-filled from preset)"
-        />
-      </Stack>
-
-      <Button
-        variant="contained"
-        size="large"
-        onClick={() => {
-          void handleSubmit()
+      {/* Header block — padding-top 72, horizontal 24 */}
+      <Box
+        sx={{
+          pt: '72px',
+          px: '24px',
         }}
-        disabled={submitting}
-        sx={{ borderRadius: 2, py: 1.5 }}
       >
-        {submitting ? 'Creating...' : 'Continue'}
-      </Button>
+        <Box
+          component="h1"
+          sx={{
+            margin: 0,
+            fontFamily: glassTypography.display,
+            fontSize: '28px',
+            fontWeight: 800,
+            letterSpacing: '-0.6px',
+            lineHeight: 1.1,
+            color: tokens.color.ink,
+            mb: '8px',
+          }}
+        >
+          Choose your language pair
+        </Box>
+        <Box
+          component="p"
+          sx={{
+            margin: 0,
+            fontFamily: glassTypography.body,
+            fontSize: '16px',
+            fontWeight: 500,
+            letterSpacing: '-0.2px',
+            lineHeight: 1.5,
+            color: tokens.color.inkSoft,
+          }}
+        >
+          Select the language you want to learn.
+        </Box>
+      </Box>
+
+      {/* Card list — padding-top 28, horizontal 16 */}
+      <Box
+        sx={{
+          pt: '28px',
+          px: '16px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '10px',
+        }}
+        role="radiogroup"
+        aria-label="Language pair selection"
+      >
+        {error && (
+          <Alert severity="error" sx={{ mb: 1 }}>
+            {error}
+          </Alert>
+        )}
+
+        {PRESET_PAIRS.map((preset, index) => {
+          const gradient = getPairGradient(
+            preset.targetCode,
+            tokens.color.pairGradients,
+            tokens.color.avatarGradient,
+          )
+          return (
+            <PairCard
+              key={preset.targetCode}
+              preset={preset}
+              isSelected={selectedPreset.targetCode === preset.targetCode}
+              onSelect={handleSelect}
+              gradient={gradient}
+              tokens={tokens}
+              isLast={index === PRESET_PAIRS.length - 1}
+            />
+          )
+        })}
+      </Box>
+
+      {/* Absolute Continue CTA — bottom 46, left/right 16 */}
+      <Box
+        sx={{
+          position: 'absolute',
+          bottom: '46px',
+          left: '16px',
+          right: '16px',
+        }}
+      >
+        <Btn
+          kind="filled"
+          size="lg"
+          full
+          onClick={() => {
+            void handleSubmit()
+          }}
+          disabled={submitting}
+        >
+          {submitting ? 'Creating…' : 'Continue'}
+        </Btn>
+      </Box>
     </Box>
   )
 }

--- a/src/features/onboarding/steps/TutorialStep.tsx
+++ b/src/features/onboarding/steps/TutorialStep.tsx
@@ -1,9 +1,24 @@
+/**
+ * TutorialStep — Step 4 of the onboarding flow (Liquid Glass restyle, issue #153).
+ *
+ * Layout: glass-card carousel. Each slide is a <Glass pad=22 floating strong>
+ * with an icon, headline, and body copy. Navigation: Back/Next buttons + slide dots.
+ *
+ * The carousel uses existing button-based navigation (no swipe introduced).
+ * All slide content and step transitions are untouched — render layer only.
+ *
+ * All values flow from tokens. No hardcoded colours or spacing.
+ */
+
 import { useState, useCallback } from 'react'
-import { Box, Typography, Button, Stack, Paper, MobileStepper } from '@mui/material'
-import KeyboardIcon from '@mui/icons-material/Keyboard'
-import TouchAppIcon from '@mui/icons-material/TouchApp'
-import EmojiEventsIcon from '@mui/icons-material/EmojiEvents'
-import AutorenewIcon from '@mui/icons-material/Autorenew'
+import { Box } from '@mui/material'
+import { Keyboard, PointerIcon, RefreshCcw, Trophy } from 'lucide-react'
+import { useTheme } from '@mui/material/styles'
+import { getGlassTokens, glassTypography } from '@/theme/liquidGlass'
+import { Glass } from '@/components/primitives/Glass'
+import { Btn } from '@/components/atoms/Btn'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface TutorialStepProps {
   readonly onComplete: () => void
@@ -15,36 +30,36 @@ interface TutorialSlide {
   readonly body: string
 }
 
+// ─── Constants ────────────────────────────────────────────────────────────────
+
 const SLIDES: readonly TutorialSlide[] = [
   {
-    icon: <KeyboardIcon sx={{ fontSize: 56, color: 'primary.main' }} />,
+    icon: <Keyboard size={48} strokeWidth={1.5} aria-hidden="true" />,
     title: 'Type mode',
     body: 'You see a word and type the translation. Lexio accepts minor typos so you can focus on learning, not spelling.',
   },
   {
-    icon: <TouchAppIcon sx={{ fontSize: 56, color: 'primary.main' }} />,
+    icon: <PointerIcon size={48} strokeWidth={1.5} aria-hidden="true" />,
     title: 'Choice mode',
     body: 'Pick the correct translation from four options. Great for building recognition quickly.',
   },
   {
-    icon: <AutorenewIcon sx={{ fontSize: 56, color: 'primary.main' }} />,
+    icon: <RefreshCcw size={48} strokeWidth={1.5} aria-hidden="true" />,
     title: 'Spaced repetition',
     body: 'Words you struggle with appear more often. Words you know well are reviewed less frequently. Your time is spent where it matters.',
   },
   {
-    icon: <EmojiEventsIcon sx={{ fontSize: 56, color: 'primary.main' }} />,
+    icon: <Trophy size={48} strokeWidth={1.5} aria-hidden="true" />,
     title: 'Daily goal and streaks',
     body: 'Set a daily word target and build a streak by hitting it every day. Consistency is the key to fluency.',
   },
 ]
 
-/**
- * Step 4 of the onboarding flow.
- * A brief visual walkthrough of the quiz mechanics:
- * type mode, choice mode, spaced repetition, and streaks.
- * Users can page through slides and finish with "Start learning!".
- */
+// ─── Component ────────────────────────────────────────────────────────────────
+
 export function TutorialStep({ onComplete }: TutorialStepProps) {
+  const theme = useTheme()
+  const tokens = getGlassTokens(theme.palette.mode)
   const [slideIndex, setSlideIndex] = useState(0)
   const isLastSlide = slideIndex === SLIDES.length - 1
   const slide = SLIDES[slideIndex]
@@ -67,94 +82,166 @@ export function TutorialStep({ onComplete }: TutorialStepProps) {
         flex: 1,
         display: 'flex',
         flexDirection: 'column',
-        px: 3,
-        py: 4,
-        maxWidth: 480,
-        mx: 'auto',
-        width: '100%',
+        pt: '72px',
+        px: '16px',
+        pb: '32px',
       }}
     >
-      <Box sx={{ mb: 3, textAlign: 'center' }}>
-        <Typography variant="h5" gutterBottom>
+      {/* Header */}
+      <Box sx={{ px: '8px', mb: '28px' }}>
+        <Box
+          component="h1"
+          sx={{
+            margin: 0,
+            fontFamily: glassTypography.display,
+            fontSize: '28px',
+            fontWeight: 800,
+            letterSpacing: '-0.6px',
+            lineHeight: 1.1,
+            color: tokens.color.ink,
+            mb: '8px',
+          }}
+        >
           How Lexio works
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
+        </Box>
+        <Box
+          component="p"
+          sx={{
+            margin: 0,
+            fontFamily: glassTypography.body,
+            fontSize: '16px',
+            fontWeight: 500,
+            letterSpacing: '-0.2px',
+            lineHeight: 1.5,
+            color: tokens.color.inkSoft,
+          }}
+        >
           A quick tour before you start learning.
-        </Typography>
+        </Box>
       </Box>
 
-      {/* Slide content */}
-      <Paper
-        variant="outlined"
+      {/* Slide — Glass pad=22 floating strong */}
+      <Glass
+        pad={22}
+        floating
+        strong
         sx={{
           flex: 1,
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
-          p: 4,
           textAlign: 'center',
-          borderRadius: 3,
-          gap: 2,
+          gap: '16px',
         }}
       >
-        {slide.icon}
-        <Typography variant="h6" fontWeight={700}>
-          {slide.title}
-        </Typography>
-        <Typography variant="body1" color="text.secondary" sx={{ lineHeight: 1.7 }}>
-          {slide.body}
-        </Typography>
-      </Paper>
-
-      {/* Slide navigation dots */}
-      <MobileStepper
-        variant="dots"
-        steps={SLIDES.length}
-        position="static"
-        activeStep={slideIndex}
-        nextButton={<Box sx={{ width: 48 }} />}
-        backButton={<Box sx={{ width: 48 }} />}
-        sx={{
-          justifyContent: 'center',
-          bgcolor: 'transparent',
-          py: 2,
-          '& .MuiMobileStepper-dotActive': {
-            bgcolor: 'primary.main',
-          },
-        }}
-      />
-
-      <Stack direction="row" spacing={2} justifyContent="space-between">
-        <Button
-          variant="outlined"
-          onClick={handleBack}
-          disabled={slideIndex === 0}
-          sx={{ flex: 1, py: 1.5, borderRadius: 2 }}
-        >
-          Back
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleNext}
+        {/* aria-live region so screen readers announce slide changes */}
+        <Box
+          component="section"
+          aria-live="polite"
+          aria-label={`Slide ${slideIndex + 1} of ${SLIDES.length}: ${slide.title}`}
           sx={{
-            flex: 2,
-            py: 1.5,
-            borderRadius: 2,
-            fontSize: isLastSlide ? '1rem' : undefined,
-            bgcolor: isLastSlide ? 'primary.main' : undefined,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '16px',
+            width: '100%',
           }}
         >
-          {isLastSlide ? 'Start learning!' : 'Next'}
-        </Button>
-      </Stack>
+          {/* Icon */}
+          <Box sx={{ color: tokens.color.accent }} aria-hidden="true">
+            {slide.icon}
+          </Box>
 
-      {/* Skip tutorial link */}
+          {/* Title */}
+          <Box
+            component="h2"
+            sx={{
+              margin: 0,
+              fontFamily: glassTypography.display,
+              fontSize: '22px',
+              fontWeight: 700,
+              letterSpacing: '-0.5px',
+              lineHeight: 1.1,
+              color: tokens.color.ink,
+            }}
+          >
+            {slide.title}
+          </Box>
+
+          {/* Body */}
+          <Box
+            component="p"
+            sx={{
+              margin: 0,
+              fontFamily: glassTypography.body,
+              fontSize: '16px',
+              fontWeight: 500,
+              letterSpacing: '-0.2px',
+              lineHeight: 1.6,
+              color: tokens.color.inkSoft,
+              maxWidth: '300px',
+            }}
+          >
+            {slide.body}
+          </Box>
+
+          {/* Slide dots within the card */}
+          <Box
+            role="tablist"
+            aria-label="Tutorial slides"
+            sx={{ display: 'flex', gap: '6px', mt: '8px' }}
+          >
+            {SLIDES.map((_, i) => (
+              <Box
+                key={i}
+                role="tab"
+                aria-selected={i === slideIndex}
+                aria-label={`Slide ${i + 1} of ${SLIDES.length}`}
+                sx={{
+                  width: i === slideIndex ? '24px' : '8px',
+                  height: '4px',
+                  borderRadius: '99px',
+                  backgroundColor: i === slideIndex ? tokens.color.accent : tokens.color.rule2,
+                  transition: 'width 200ms ease, background-color 200ms ease',
+                  '@media (prefers-reduced-motion: reduce)': {
+                    transition: 'none',
+                  },
+                }}
+              />
+            ))}
+          </Box>
+        </Box>
+      </Glass>
+
+      {/* Navigation buttons */}
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '12px',
+          mt: '16px',
+        }}
+      >
+        <Box sx={{ flex: 1 }}>
+          <Btn kind="glass" size="md" full onClick={handleBack} disabled={slideIndex === 0}>
+            Back
+          </Btn>
+        </Box>
+
+        <Box sx={{ flex: 2 }}>
+          <Btn kind="filled" size="md" full onClick={handleNext}>
+            {isLastSlide ? 'Start learning!' : 'Next'}
+          </Btn>
+        </Box>
+      </Box>
+
+      {/* Skip tutorial — only on non-last slides */}
       {!isLastSlide && (
-        <Box sx={{ textAlign: 'center', mt: 1 }}>
-          <Button variant="text" size="small" onClick={onComplete} sx={{ color: 'text.secondary' }}>
+        <Box sx={{ textAlign: 'center', mt: '12px' }}>
+          <Btn kind="glass" size="sm" onClick={onComplete}>
             Skip tutorial
-          </Button>
+          </Btn>
         </Box>
       )}
     </Box>

--- a/src/features/onboarding/steps/TutorialStep.tsx
+++ b/src/features/onboarding/steps/TutorialStep.tsx
@@ -7,6 +7,9 @@
  * The carousel uses existing button-based navigation (no swipe introduced).
  * All slide content and step transitions are untouched — render layer only.
  *
+ * Slide dots reuse <StepPagination totalSteps=4 label="Tutorial slides"> to
+ * keep the capsule dot logic in one place.
+ *
  * All values flow from tokens. No hardcoded colours or spacing.
  */
 
@@ -17,6 +20,8 @@ import { useTheme } from '@mui/material/styles'
 import { getGlassTokens, glassTypography } from '@/theme/liquidGlass'
 import { Glass } from '@/components/primitives/Glass'
 import { Btn } from '@/components/atoms/Btn'
+import { StepPagination } from '../components/StepPagination'
+import { StepHeader } from '../components/StepHeader'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -88,37 +93,11 @@ export function TutorialStep({ onComplete }: TutorialStepProps) {
       }}
     >
       {/* Header */}
-      <Box sx={{ px: '8px', mb: '28px' }}>
-        <Box
-          component="h1"
-          sx={{
-            margin: 0,
-            fontFamily: glassTypography.display,
-            fontSize: '28px',
-            fontWeight: 800,
-            letterSpacing: '-0.6px',
-            lineHeight: 1.1,
-            color: tokens.color.ink,
-            mb: '8px',
-          }}
-        >
-          How Lexio works
-        </Box>
-        <Box
-          component="p"
-          sx={{
-            margin: 0,
-            fontFamily: glassTypography.body,
-            fontSize: '16px',
-            fontWeight: 500,
-            letterSpacing: '-0.2px',
-            lineHeight: 1.5,
-            color: tokens.color.inkSoft,
-          }}
-        >
-          A quick tour before you start learning.
-        </Box>
-      </Box>
+      <StepHeader
+        title="How Lexio works"
+        subtitle="A quick tour before you start learning."
+        paddingX={8}
+      />
 
       {/* Slide — Glass pad=22 floating strong */}
       <Glass
@@ -186,31 +165,13 @@ export function TutorialStep({ onComplete }: TutorialStepProps) {
             {slide.body}
           </Box>
 
-          {/* Slide dots within the card */}
-          <Box
-            role="tablist"
-            aria-label="Tutorial slides"
-            sx={{ display: 'flex', gap: '6px', mt: '8px' }}
-          >
-            {SLIDES.map((_, i) => (
-              <Box
-                key={i}
-                role="tab"
-                aria-selected={i === slideIndex}
-                aria-label={`Slide ${i + 1} of ${SLIDES.length}`}
-                sx={{
-                  width: i === slideIndex ? '24px' : '8px',
-                  height: '4px',
-                  borderRadius: '99px',
-                  backgroundColor: i === slideIndex ? tokens.color.accent : tokens.color.rule2,
-                  transition: 'width 200ms ease, background-color 200ms ease',
-                  '@media (prefers-reduced-motion: reduce)': {
-                    transition: 'none',
-                  },
-                }}
-              />
-            ))}
-          </Box>
+          {/* Slide dots — reuses StepPagination for the capsule dot pattern */}
+          <StepPagination
+            activeStep={slideIndex}
+            totalSteps={SLIDES.length}
+            label="Tutorial slides"
+            sx={{ py: '4px', mt: '4px' }}
+          />
         </Box>
       </Glass>
 

--- a/src/features/onboarding/steps/WelcomeStep.tsx
+++ b/src/features/onboarding/steps/WelcomeStep.tsx
@@ -1,6 +1,23 @@
-import { Box, Typography, Button, CircularProgress } from '@mui/material'
-import AutoStoriesIcon from '@mui/icons-material/AutoStories'
-import BoltIcon from '@mui/icons-material/Bolt'
+/**
+ * WelcomeStep — Step 0 of the onboarding flow (Liquid Glass restyle, issue #153).
+ *
+ * Layout (top to bottom, centred):
+ *   - Uppercase label "WELCOME TO LEXIO" (uppercaseLabel role: 13/700 tracking 1)
+ *   - Headline "Learn any language, a word at a time." via <BigWord size=42>
+ *   - Subhead 16/500 inkSoft max-width 320
+ *   - CTA row: "Try it now" <Btn filled full lg> + "Set up my own" <Btn glass full lg>
+ *
+ * PaperSurface is NOT here — it wraps the whole OnboardingFlow in the parent.
+ * All values flow from tokens. No hardcoded colours or spacing.
+ */
+
+import { Box, CircularProgress } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { getGlassTokens, glassTypography } from '@/theme/liquidGlass'
+import { BigWord } from '@/components/atoms/BigWord'
+import { Btn } from '@/components/atoms/Btn'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface WelcomeStepProps {
   readonly onDemo: () => void
@@ -9,13 +26,23 @@ export interface WelcomeStepProps {
   readonly demoLoading?: boolean
 }
 
-/**
- * Combined Welcome step of the onboarding flow.
- * Offers two paths:
- *   - "Try it now" — instant demo with auto-created EN-LV pair and A1 pack
- *   - "Set up my own" — manual language pair creation (full 3-step flow)
- */
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Spec: 13/700 tracking 1 uppercase — matches the uppercaseLabel token. */
+const LABEL_ROLE = glassTypography.roles.uppercaseLabel
+
+/** Spec: BigWord size=42, headline text. */
+const HEADLINE_SIZE = 42
+
+/** Spec: subhead 16/500 inkSoft max-width 320. */
+const SUBHEAD_MAX_WIDTH = 320
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
 export function WelcomeStep({ onDemo, onManualSetup, demoLoading = false }: WelcomeStepProps) {
+  const theme = useTheme()
+  const tokens = getGlassTokens(theme.palette.mode)
+
   return (
     <Box
       sx={{
@@ -24,53 +51,79 @@ export function WelcomeStep({ onDemo, onManualSetup, demoLoading = false }: Welc
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        px: 4,
+        px: '24px',
         textAlign: 'center',
-        gap: 3,
+        gap: '24px',
       }}
     >
-      <AutoStoriesIcon sx={{ fontSize: 80, color: 'primary.main' }} />
-
-      <Box>
-        <Typography variant="h3" component="h1" gutterBottom>
-          Lexio
-        </Typography>
-        <Typography variant="h6" color="text.secondary" sx={{ fontWeight: 400, lineHeight: 1.5 }}>
-          Learn vocabulary in any language through active recall and spaced repetition.
-        </Typography>
+      {/* Uppercase eyebrow label */}
+      <Box
+        component="span"
+        sx={{
+          display: 'block',
+          fontFamily: glassTypography.body,
+          fontSize: `${LABEL_ROLE.size}px`,
+          fontWeight: LABEL_ROLE.weight,
+          letterSpacing: `${LABEL_ROLE.tracking}px`,
+          lineHeight: LABEL_ROLE.lineHeight,
+          textTransform: LABEL_ROLE.transform ?? 'uppercase',
+          color: tokens.color.inkSec,
+        }}
+      >
+        Welcome to Lexio
       </Box>
 
+      {/* Headline — BigWord size=42 */}
+      <BigWord size={HEADLINE_SIZE}>Learn any language, a word at a time.</BigWord>
+
+      {/* Subhead 16/500 inkSoft max-width 320 */}
+      <Box
+        component="p"
+        sx={{
+          margin: 0,
+          fontFamily: glassTypography.body,
+          fontSize: '16px',
+          fontWeight: 500,
+          letterSpacing: '-0.2px',
+          lineHeight: 1.5,
+          color: tokens.color.inkSoft,
+          maxWidth: `${SUBHEAD_MAX_WIDTH}px`,
+        }}
+      >
+        Active recall and spaced repetition — the most effective way to build lasting vocabulary.
+      </Box>
+
+      {/* CTA buttons */}
       <Box
         sx={{
           display: 'flex',
           flexDirection: 'column',
-          alignItems: 'center',
-          gap: 1.5,
-          mt: 2,
+          gap: '12px',
           width: '100%',
-          maxWidth: 320,
+          maxWidth: `${SUBHEAD_MAX_WIDTH}px`,
         }}
       >
-        <Button
-          variant="contained"
-          size="large"
+        <Btn
+          kind="filled"
+          size="lg"
+          full
           onClick={onDemo}
           disabled={demoLoading}
-          startIcon={demoLoading ? <CircularProgress size={20} color="inherit" /> : <BoltIcon />}
-          sx={{ px: 6, py: 1.5, borderRadius: 3, fontSize: '1.1rem', width: '100%' }}
+          aria-label={demoLoading ? 'Setting up…' : 'Try it now'}
         >
-          {demoLoading ? 'Setting up…' : 'Try it now'}
-        </Button>
+          {demoLoading ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <CircularProgress size={18} sx={{ color: '#ffffff' }} />
+              Setting up…
+            </Box>
+          ) : (
+            'Try it now'
+          )}
+        </Btn>
 
-        <Button
-          variant="outlined"
-          size="large"
-          onClick={onManualSetup}
-          disabled={demoLoading}
-          sx={{ px: 4, py: 1.5, borderRadius: 3, width: '100%' }}
-        >
+        <Btn kind="glass" size="lg" full onClick={onManualSetup} disabled={demoLoading}>
           Set up my own
-        </Button>
+        </Btn>
       </Box>
     </Box>
   )

--- a/src/theme/liquidGlass.ts
+++ b/src/theme/liquidGlass.ts
@@ -9,6 +9,27 @@
  * Do NOT change any numeric or color value without updating tokens.json first.
  */
 
+/**
+ * Language-pair gradient map for the onboarding LanguagePairStep.
+ *
+ * Each entry is a CSS gradient string (linear-gradient) keyed by the
+ * target-language BCP-47 code (lowercase). The values are per design spec.
+ *
+ * Fallback: when a code is not present in the map, callers should fall back
+ * to `avatarGradient` (blue-to-violet). This ensures the UI never breaks on
+ * unknown language codes (e.g. the default EN-LV pair where 'lv' is not in
+ * the spec's listed set).
+ */
+export interface PairGradientMap {
+  readonly es: string
+  readonly fr: string
+  /** Japanese pair — BCP-47 code 'ja' (not 'jp'). */
+  readonly ja: string
+  readonly de: string
+  /** Additional codes can be added here as new pairs are supported. */
+  readonly [code: string]: string
+}
+
 export interface GlassColorTokens {
   readonly bg: string
   readonly ink: string
@@ -43,6 +64,12 @@ export interface GlassColorTokens {
    * Value: linear-gradient(135deg, #FF9500 0%, #FF3B30 100%).
    */
   readonly streakGradient: string
+  /**
+   * Language-pair gradient map — used in the LanguagePairStep onboarding card.
+   * Keyed by target-language BCP-47 code (lowercase). Falls back to
+   * `avatarGradient` for any code not in the map (e.g. 'lv').
+   */
+  readonly pairGradients: PairGradientMap
 }
 
 export interface GlassLayerTokens {
@@ -196,6 +223,14 @@ export const lightGlass: GlassVariantTokens = {
     aiGradient: 'linear-gradient(135deg, #AF52DE 0%, #007AFF 100%)',
     // Streak hero gradient — always vivid orange-red regardless of theme
     streakGradient: 'linear-gradient(135deg, #FF9500 0%, #FF3B30 100%)',
+    // Language-pair gradient map. ES reuses streakGradient colors per spec.
+    // Fallback for unknown codes: use avatarGradient (#007AFF → #AF52DE).
+    pairGradients: {
+      es: 'linear-gradient(135deg, #FF9500 0%, #FF3B30 100%)',
+      fr: 'linear-gradient(135deg, #5856D6 0%, #0A84FF 100%)',
+      ja: 'linear-gradient(135deg, #FF2D55 0%, #AF52DE 100%)',
+      de: 'linear-gradient(135deg, #30D158 0%, #0A84FF 100%)',
+    },
   },
   glass: {
     bg: 'rgba(255,255,255,0.55)',
@@ -238,6 +273,15 @@ export const darkGlass: GlassVariantTokens = {
     aiGradient: 'linear-gradient(135deg, #BF5AF2 0%, #0A84FF 100%)',
     // Streak hero gradient — same on both variants per spec (always vivid orange-red)
     streakGradient: 'linear-gradient(135deg, #FF9500 0%, #FF3B30 100%)',
+    // Language-pair gradient map. Same values in dark mode — per design spec the
+    // pair gradients are vivid and do not change between light/dark.
+    // Fallback for unknown codes: use avatarGradient (#0A84FF → #BF5AF2).
+    pairGradients: {
+      es: 'linear-gradient(135deg, #FF9500 0%, #FF3B30 100%)',
+      fr: 'linear-gradient(135deg, #5856D6 0%, #0A84FF 100%)',
+      ja: 'linear-gradient(135deg, #FF2D55 0%, #AF52DE 100%)',
+      de: 'linear-gradient(135deg, #30D158 0%, #0A84FF 100%)',
+    },
   },
   glass: {
     bg: 'rgba(255,255,255,0.10)',


### PR DESCRIPTION
## Summary

- Restyle all 4 onboarding steps to use Liquid Glass design system
- Add `glassColors.pairGradients` token map (ES/FR/JA/DE) with documented `avatarGradient` fallback for unknown codes
- New `StepPagination` component replaces `MobileStepper` — 4 capsule dots, active/inactive states
- `OnboardingFlow` wrapped in `PaperSurface` for wallpaper + glass rendering

## Changes

- `src/theme/liquidGlass.ts`: Added `PairGradientMap` interface and `pairGradients` token to both light/dark variants
- `src/features/onboarding/components/StepPagination.tsx`: New component — capsule dots pagination
- `src/features/onboarding/components/StepPagination.test.tsx`: 6 unit tests
- `src/features/onboarding/OnboardingFlow.tsx`: PaperSurface wrap, StepPagination replaces MobileStepper
- `src/features/onboarding/steps/WelcomeStep.tsx`: uppercaseLabel, BigWord size=42, Btn filled/glass lg
- `src/features/onboarding/steps/LanguagePairStep.tsx`: Card-based selection, Glass cards with gradient squares + radio circles, absolute Continue CTA
- `src/features/onboarding/steps/AddWordsStep.tsx`: Library grouped-list pattern
- `src/features/onboarding/steps/TutorialStep.tsx`: Glass pad=22 floating strong slides, aria-live carousel
- `src/features/onboarding/OnboardingFlow.test.tsx`: Updated selectors for new markup
- `src/App.test.tsx`: Updated Welcome heading check
- `e2e/onboarding.spec.ts`: Updated selectors for new markup

## Amendment Reconciliation

- Onboarding is NOT a tab — PaperSurface wraps the `OnboardingFlow` container (not individual steps)
- No `<TabBar>` rendered during onboarding (existing behavior preserved)
- No new AppContent branch for onboarding
- `OnboardingFlow` state machine + step transitions untouched

## pairGradients map

| Code | Gradient |
|------|----------|
| `es` | #FF9500 → #FF3B30 |
| `fr` | #5856D6 → #0A84FF |
| `ja` | #FF2D55 → #AF52DE |
| `de` | #30D158 → #0A84FF |
| unknown (e.g. `lv`) | `avatarGradient` fallback |

## AddWordsStep approach

Reuses Library grouped-list pattern (`SectionHeader` + `Glass` + `GlassRow`). Does not use `useWords.addWord` inline — the step's purpose is to choose between starter pack vs. own words; actual word entry happens in LibraryScreen after onboarding.

## Pagination placement

`StepPagination` appears below all step content in `OnboardingFlow`, consistent across steps 1-3 of the manual flow.

## Testing

- All 1172 unit tests pass
- All 14 E2E tests pass
- Full quality gate: lint, format, typecheck, build all green

## Review

- Code review passed
- Reviewer-requested fix applied: Japanese gradient key renamed from `jp` to `ja` (BCP-47 code)

Closes #153