### PR TITLE
fix: Liquid Glass dark mode verification pass (#154)

### DIFF
--- a/src/features/words/components/AddWordModal.tsx
+++ b/src/features/words/components/AddWordModal.tsx
@@ -41,7 +41,7 @@ import { useTheme } from '@mui/material/styles'
 import { PaperSurface } from '@/components/primitives/PaperSurface'
 import { Glass } from '@/components/primitives/Glass'
 import { SectionHeader } from '@/components/composites/SectionHeader'
-import { getGlassTokens, glassTypography, glassShadows } from '@/theme/liquidGlass'
+import { getGlassTokens, glassTypography, glassShadows, aiCircleShadow } from '@/theme/liquidGlass'
 import { CARET_BLINK_KEYFRAMES } from '@/theme/animations'
 import { useWords } from '../useWords'
 import type { PartOfSpeech } from '../partOfSpeech'
@@ -462,8 +462,8 @@ function AiUpsellCard(): React.JSX.Element {
               height: '38px',
               borderRadius: '50%',
               background: tokens.color.aiGradient,
-              // Shadow: 0 4px 12px rgba(175,82,222,0.4) per spec
-              boxShadow: '0 4px 12px rgba(175,82,222,0.4)',
+              // Shadow uses mode-specific violet: light #AF52DE, dark #BF5AF2 at 0.4 alpha
+              boxShadow: aiCircleShadow(theme.palette.mode),
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',

--- a/src/theme/liquidGlass.ts
+++ b/src/theme/liquidGlass.ts
@@ -168,6 +168,18 @@ export interface GlassShadowTokens {
    * Alias of filterActive; both resolve to the same value.
    */
   readonly pillActive: string
+  /**
+   * AI upsell circle shadow (light mode) — violet glow at 0.4 alpha.
+   * Light: rgba(175,82,222,0.4) derived from lightGlass violet #AF52DE.
+   * Use `aiCircleShadow(mode)` helper for the mode-correct value.
+   */
+  readonly aiCircleLight: string
+  /**
+   * AI upsell circle shadow (dark mode) — violet glow at 0.4 alpha.
+   * Dark: rgba(191,90,242,0.4) derived from darkGlass violet #BF5AF2.
+   * Use `aiCircleShadow(mode)` helper for the mode-correct value.
+   */
+  readonly aiCircleDark: string
 }
 
 export interface GlassMotionTokens {
@@ -385,6 +397,21 @@ export const glassShadows: GlassShadowTokens = {
   filterActive: '0 4px 14px rgba(0,0,0,0.18)',
   // Named alias so Library (and future screens) can reference by semantic name.
   pillActive: '0 4px 14px rgba(0,0,0,0.18)',
+  // AI upsell circle shadows — violet glow, mode-dependent.
+  // Light: #AF52DE = rgb(175,82,222). Dark: #BF5AF2 = rgb(191,90,242).
+  aiCircleLight: '0 4px 12px rgba(175,82,222,0.4)',
+  aiCircleDark: '0 4px 12px rgba(191,90,242,0.4)',
+}
+
+/**
+ * Returns the AI upsell circle shadow for the given mode.
+ * The shadow uses the mode-specific violet color at 0.4 alpha.
+ *
+ * Light: #AF52DE → rgba(175,82,222,0.4)
+ * Dark:  #BF5AF2 → rgba(191,90,242,0.4)
+ */
+export function aiCircleShadow(mode: 'light' | 'dark'): string {
+  return mode === 'dark' ? glassShadows.aiCircleDark : glassShadows.aiCircleLight
 }
 
 /** Shared motion tokens. */

--- a/src/utils/animation.ts
+++ b/src/utils/animation.ts
@@ -56,12 +56,15 @@ export const PULSE_KEYFRAMES = `
 
 /**
  * Glow pulse keyframe for streak indicator.
+ * Color matches the lightGlass warn token (#FF9500 = rgb(255,149,0)).
+ * This keyframe is injected as a static CSS string, so the value is fixed here
+ * in liquidGlass.ts terms — the streak hero is always vivid orange per spec.
  */
 export const GLOW_KEYFRAMES = `
   @keyframes lexio-glow {
-    0%   { box-shadow: 0 0 0 0 rgba(255, 167, 38, 0.4); }
-    50%  { box-shadow: 0 0 0 6px rgba(255, 167, 38, 0); }
-    100% { box-shadow: 0 0 0 0 rgba(255, 167, 38, 0); }
+    0%   { box-shadow: 0 0 0 0 rgba(255,149,0,0.4); }
+    50%  { box-shadow: 0 0 0 6px rgba(255,149,0,0); }
+    100% { box-shadow: 0 0 0 0 rgba(255,149,0,0); }
   }
 ` as const
 


### PR DESCRIPTION
## Summary

Dark mode verification and fix-up pass for the Liquid Glass design system. This PR is a targeted audit + narrow token fix — no screen rebuilds, no structure changes.

## Audit Findings

### Hex Color Audit (`rg '#[0-9A-Fa-f]{6}' src/`)

All `#ffffff` occurrences outside `liquidGlass.ts` are **intentional** — white text or icons on colored surfaces (accent fills, ok/red feedback circles, gradient tiles) that are always vivid regardless of mode.

Two issues found and fixed:

| Issue | Location | Fix |
|-------|----------|-----|
| `rgba(175,82,222,0.4)` hardcoded — uses light-mode violet (#AF52DE) in both modes | `AddWordModal.tsx:466` | Replaced with `aiCircleShadow(theme.palette.mode)` |
| `rgba(255,167,38,...)` glow keyframe — wrong amber shade vs warn token #FF9500 | `animation.ts:62-64` | Corrected to `rgba(255,149,0,...)` matching `#FF9500 = rgb(255,149,0)` |

### rgba Audit (`rg 'rgb[a]?\(' src/`)

All static `rgba(...)` in components use mode-switched `rgba(255,255,255,0.0N)` / `rgba(0,0,0,0.0N)` patterns for subtle hover fills. No unexpected hardcoded values.

## Changes

- **`src/theme/liquidGlass.ts`** — Added `aiCircleLight` + `aiCircleDark` tokens to `GlassShadowTokens` and `glassShadows`. Added `aiCircleShadow(mode)` helper (parallel to existing `okAlpha`).
- **`src/features/words/components/AddWordModal.tsx`** — AI upsell circle shadow uses `aiCircleShadow(theme.palette.mode)` instead of hardcoded light-mode violet rgba.
- **`src/utils/animation.ts`** — GLOW_KEYFRAMES color corrected to match `warn` token `#FF9500`.

## Contrast Verification (Dark Mode)

Darkest wallpaper region: `#0A0A10` (linear-gradient base stop in `darkGlass.wallpaper`)

| Token | Value | Contrast on #0A0A10 | WCAG AA |
|-------|-------|---------------------|---------|
| `ink` | `#FFFFFF` | **21:1** | PASS |
| `inkSoft` | `rgba(255,255,255,0.82)` → ~#D1D1D1 | **~13.1:1** | PASS |
| `inkSec` | `rgba(255,255,255,0.55)` → ~#8C8C8C | **~6.7:1** | PASS |
| `inkFaint` | `rgba(255,255,255,0.28)` → ~#474747 | **~1.9:1** | Decorative only (chevrons/dividers) |

No token value adjustments needed — all body text roles exceed 4.5:1.

## Gradient Tiles

`streakGradient`, `avatarGradient`, `aiGradient`, and all `pairGradients` are **identical** in `lightGlass` and `darkGlass` per spec. Gradient tiles stay vivid in dark mode. ✓

## Theme Toggle

`useThemeMode` hook verified unchanged and correct:
- System → listens to `prefers-color-scheme` media query (live updates)
- Light/Dark → explicit override wins; no media query listener
- Changes persist via `StorageService`

## Testing

- `npm run lint` — 0 errors
- `npm run format:check` — all formatted
- `npx tsc --noEmit` — no type errors
- `npm test -- --run` — 1175 tests, 81 files, all pass
- `npm run build` — succeeds
- `npm run e2e` — 14 E2E tests pass

## Review

Code review approved. Changes are minimum viable diffs: token additions + two component one-liners.

Closes #154