### PR TITLE
feat: Liquid Glass accessibility pass (Reduce Transparency/Motion, contrast, tap targets) (#155)

### DIFF
--- a/src/components/atoms/Btn.tsx
+++ b/src/components/atoms/Btn.tsx
@@ -47,6 +47,10 @@ interface SizeConfig {
 }
 
 const SIZE_CONFIG: Readonly<Record<BtnSize, SizeConfig>> = {
+  // sm height is 36px visually; min-height 44 extends the tap target to meet
+  // WCAG 2.5.5 without changing the visual appearance at 100% zoom.
+  // The filled/white variants add extra top/bottom padding via min-height.
+  // The glass variant wraps in a Glass primitive — the button inside gets min-height.
   sm: { height: 36, fontSize: 15, paddingX: 14 },
   md: { height: 50, fontSize: 17, paddingX: 20 },
   lg: { height: 56, fontSize: 17, paddingX: 24 },
@@ -95,6 +99,9 @@ export function Btn({
           justifyContent: 'center',
           gap: '8px',
           height,
+          // sm (36px) is below 44px — enforce minimum tap target height.
+          // md/lg are already ≥44px so minHeight has no visual effect there.
+          minHeight: 44,
           width: full ? '100%' : 'auto',
           paddingX: `${paddingX}px`,
           backgroundColor: tokens.color.accent,
@@ -131,6 +138,8 @@ export function Btn({
           justifyContent: 'center',
           gap: '8px',
           height,
+          // sm (36px) is below 44px — enforce minimum tap target height.
+          minHeight: 44,
           width: full ? '100%' : 'auto',
           paddingX: `${paddingX}px`,
           backgroundColor: '#ffffff',
@@ -175,6 +184,8 @@ export function Btn({
             justifyContent: 'center',
             gap: '8px',
             height,
+            // sm (36px) is below 44px — enforce minimum tap target height.
+            minHeight: 44,
             width: '100%',
             paddingX: `${paddingX}px`,
             backgroundColor: 'transparent',

--- a/src/components/atoms/FilterPill.tsx
+++ b/src/components/atoms/FilterPill.tsx
@@ -51,7 +51,10 @@ export function FilterPill({
         sx={{
           display: 'inline-flex',
           alignItems: 'center',
-          padding: '8px 14px',
+          // Vertical padding 10px gives height ≥ 34+10+10 = at least the text
+          // height + padding. min-height 44 ensures WCAG 2.5.5 compliance.
+          minHeight: 44,
+          padding: '10px 14px',
           borderRadius: `${glassRadius.pill}px`,
           // Solid ink fill — dark text in light mode (#000 in dark, ink token is white)
           backgroundColor: tokens.color.ink,
@@ -90,7 +93,10 @@ export function FilterPill({
           sx={{
             display: 'inline-flex',
             alignItems: 'center',
-            padding: '8px 14px',
+            // min-height 44 extends the tap target without changing visual pill size.
+            // The Glass wrapper clips the blur surface; padding expands the hit area.
+            minHeight: 44,
+            padding: '10px 14px',
             backgroundColor: 'transparent',
             color: tokens.color.ink,
             border: 'none',

--- a/src/components/atoms/Toggle.tsx
+++ b/src/components/atoms/Toggle.tsx
@@ -15,6 +15,11 @@
  * Accessibility:
  *   role="switch" + aria-checked so assistive technologies report on/off state.
  *   aria-label is required when there is no visible label for the toggle.
+ *
+ * Tap target:
+ *   The outer wrapper has minWidth/minHeight 44×44 (WCAG 2.5.5). The visual
+ *   rail remains 51×31; the extra hit area is transparent padding that does
+ *   not change the visual footprint at 100% zoom.
  */
 
 import { Box } from '@mui/material'
@@ -28,6 +33,8 @@ export interface ToggleProps {
   readonly onChange?: (next: boolean) => void
   /** Accessible label — required when no surrounding text describes the control. */
   readonly 'aria-label'?: string
+  /** id of an element that labels this switch (alternative to aria-label). */
+  readonly 'aria-labelledby'?: string
   readonly disabled?: boolean
 }
 
@@ -43,6 +50,8 @@ const THUMB_INSET = 2
 const THUMB_TRANSLATE_ON = RAIL_WIDTH - THUMB_SIZE - THUMB_INSET * 2 // = 20
 const OFF_BACKGROUND = 'rgba(120,120,128,0.32)'
 const THUMB_SHADOW = '0 3px 8px rgba(0,0,0,0.15)'
+// Vertical padding to reach 44px minimum hit area (WCAG 2.5.5)
+const HIT_AREA_PAD_Y = Math.max(0, Math.floor((44 - RAIL_HEIGHT) / 2)) // = 6
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -50,6 +59,7 @@ export function Toggle({
   on,
   onChange,
   'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
   disabled = false,
 }: ToggleProps): React.JSX.Element {
   const theme = useTheme()
@@ -73,10 +83,17 @@ export function Toggle({
   }
 
   return (
+    /*
+     * Outer hit-area wrapper: transparent padding to reach ≥44×44 px.
+     * Does NOT change the visual footprint of the 51×31 rail at 100% zoom.
+     * role="switch" + ARIA on the outer element so the full tap area is
+     * the accessible control boundary.
+     */
     <Box
       role="switch"
       aria-checked={on}
       aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
       aria-disabled={disabled}
       tabIndex={disabled ? -1 : 0}
       onClick={handleClick}
@@ -85,38 +102,56 @@ export function Toggle({
         position: 'relative',
         display: 'inline-flex',
         alignItems: 'center',
-        width: RAIL_WIDTH,
-        height: RAIL_HEIGHT,
-        borderRadius: 99,
-        backgroundColor: railBg,
-        // Background does NOT use backdrop-filter, so this is safe to transition
-        transition: `background-color ${glassMotion.toggle}`,
+        justifyContent: 'center',
+        // Extend hit area to 44px height without changing visual rail height
+        minWidth: RAIL_WIDTH,
+        minHeight: 44,
+        paddingTop: `${HIT_AREA_PAD_Y}px`,
+        paddingBottom: `${HIT_AREA_PAD_Y}px`,
         flexShrink: 0,
         cursor: disabled ? 'not-allowed' : 'pointer',
         opacity: disabled ? 0.5 : 1,
-        // Reduce Motion: turn off background colour transition
-        '@media (prefers-reduced-motion: reduce)': {
-          transition: 'none',
-          '& > div': { transition: 'none' },
-        },
+        background: 'none',
+        border: 'none',
       }}
     >
-      {/* Thumb — plain div, no backdrop-filter, safe to animate transform */}
+      {/* Inner rail — the visible 51×31 element */}
       <Box
         sx={{
-          position: 'absolute',
-          top: THUMB_INSET,
-          left: THUMB_INSET,
-          width: THUMB_SIZE,
-          height: THUMB_SIZE,
-          borderRadius: 999,
-          backgroundColor: '#ffffff',
-          boxShadow: THUMB_SHADOW,
-          // GPU-composited path: transform not left
-          transform: `translateX(${thumbTranslate})`,
-          transition: `transform ${glassMotion.toggle}`,
+          position: 'relative',
+          display: 'inline-flex',
+          alignItems: 'center',
+          width: RAIL_WIDTH,
+          height: RAIL_HEIGHT,
+          borderRadius: 99,
+          backgroundColor: railBg,
+          // Background does NOT use backdrop-filter, so this is safe to transition
+          transition: `background-color ${glassMotion.toggle}`,
+          flexShrink: 0,
+          // Reduce Motion: turn off background colour transition
+          '@media (prefers-reduced-motion: reduce)': {
+            transition: 'none',
+            '& > div': { transition: 'none' },
+          },
         }}
-      />
+      >
+        {/* Thumb — plain div, no backdrop-filter, safe to animate transform */}
+        <Box
+          sx={{
+            position: 'absolute',
+            top: THUMB_INSET,
+            left: THUMB_INSET,
+            width: THUMB_SIZE,
+            height: THUMB_SIZE,
+            borderRadius: 999,
+            backgroundColor: '#ffffff',
+            boxShadow: THUMB_SHADOW,
+            // GPU-composited path: transform not left
+            transform: `translateX(${thumbTranslate})`,
+            transition: `transform ${glassMotion.toggle}`,
+          }}
+        />
+      </Box>
     </Box>
   )
 }

--- a/src/features/quiz/components/TypeQuizContent.tsx
+++ b/src/features/quiz/components/TypeQuizContent.tsx
@@ -406,7 +406,23 @@ export function TypeQuizContent({ session, pair, settings }: TypeQuizContentProp
             },
           }}
         >
-          <Glass pad={18} floating strong>
+          {/*
+           * focus-within ring: when the hidden <input> inside receives focus,
+           * the Glass card gets a visible accent outline so keyboard users
+           * see which surface has focus. The hidden input has outline:none to
+           * prevent the ring from appearing on the invisible element itself.
+           */}
+          <Glass
+            pad={18}
+            floating
+            strong
+            sx={{
+              '&:focus-within': {
+                outline: `2px solid var(--lexio-accent, #007AFF)`,
+                outlineOffset: '2px',
+              },
+            }}
+          >
             {/* ── Success state ── */}
             {isSuccess && (
               <Box
@@ -620,7 +636,11 @@ export function TypeQuizContent({ session, pair, settings }: TypeQuizContentProp
               sx={{
                 background: 'none',
                 border: 'none',
-                padding: '4px 0 4px 12px',
+                // min 44×44 tap target (WCAG 2.5.5): visual text is ~20px tall,
+                // padding extends the hit area without changing visual size.
+                minWidth: 44,
+                minHeight: 44,
+                padding: '12px 0 12px 12px',
                 cursor: 'pointer',
                 fontFamily: glassTypography.body,
                 fontSize: glassTypography.roles.quizHint.size,
@@ -628,6 +648,8 @@ export function TypeQuizContent({ session, pair, settings }: TypeQuizContentProp
                 letterSpacing: glassTypography.roles.quizHint.tracking,
                 color: tokens.color.accent,
                 lineHeight: 1,
+                display: 'inline-flex',
+                alignItems: 'center',
               }}
             >
               Skip

--- a/src/features/words/components/AddWordModal.tsx
+++ b/src/features/words/components/AddWordModal.tsx
@@ -216,8 +216,25 @@ function InputGlassCard({
   const textColor = valueColor ?? tokens.color.ink
 
   return (
-    <Glass pad={16} floating sx={{ marginBottom }}>
-      {/* Uppercase label: 12/700 inkSec */}
+    /*
+     * focus-within ring: the <input> inside has outline:none (it is visually
+     * replaced by the custom caret display). The Glass card shows a visible
+     * focus ring via :focus-within so keyboard users see where focus is.
+     */
+    <Glass
+      pad={16}
+      floating
+      sx={{
+        marginBottom,
+        '&:focus-within': {
+          outline: `2px solid var(--lexio-accent, #007AFF)`,
+          outlineOffset: '2px',
+        },
+      }}
+    >
+      {/* Uppercase label: 12/700 inkSec — NOT aria-hidden; it is meaningful text.
+          The input below also has its own aria-label matching this label text,
+          so screen readers will announce the label via the input. */}
       <Box
         component="span"
         sx={{
@@ -231,7 +248,6 @@ function InputGlassCard({
           textTransform: 'uppercase',
           marginBottom: '8px',
         }}
-        aria-hidden="true"
       >
         {label}
       </Box>
@@ -701,7 +717,20 @@ export function AddWordModal({
           {/* Example */}
           <SectionHeader>Example</SectionHeader>
           <Box sx={{ px: '16px' }}>
-            <Glass pad={16} floating>
+            {/*
+             * focus-within ring: the <input> has outline:none (custom caret UI).
+             * The Glass card shows a visible ring when the input is focused.
+             */}
+            <Glass
+              pad={16}
+              floating
+              sx={{
+                '&:focus-within': {
+                  outline: `2px solid var(--lexio-accent, #007AFF)`,
+                  outlineOffset: '2px',
+                },
+              }}
+            >
               <Box
                 component="input"
                 type="text"

--- a/src/features/words/components/LibraryScreen.tsx
+++ b/src/features/words/components/LibraryScreen.tsx
@@ -263,7 +263,22 @@ function SearchField({ value, onChange, totalWordCount }: SearchFieldProps): Rea
 
   return (
     <Box sx={{ px: '16px' }}>
-      <Glass pad={0} floating radius={16}>
+      {/*
+       * focus-within ring: the search <input> has outline:none to avoid
+       * the browser's default ring on the transparent input element.
+       * The Glass card shows a visible accent ring when the input is focused.
+       */}
+      <Glass
+        pad={0}
+        floating
+        radius={16}
+        sx={{
+          '&:focus-within': {
+            outline: `2px solid var(--lexio-accent, #007AFF)`,
+            outlineOffset: '2px',
+          },
+        }}
+      >
         <Box
           sx={{
             display: 'flex',

--- a/src/theme/a11y.test.ts
+++ b/src/theme/a11y.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Accessibility smoke tests for issue #155.
+ *
+ * Verifies that:
+ *   - pxToRem conversion produces correct values (Dynamic Type / 200% zoom)
+ *   - createAppTheme sets the CSS variable for focus-visible ring
+ *   - Typography body1 / button sizes are expressed in rem, not px
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createAppTheme } from './theme'
+
+describe('pxToRem (typography)', () => {
+  it('should emit rem values for body1 fontSize', () => {
+    const theme = createAppTheme('light')
+    // body role is 17px → 17/16 = 1.0625rem
+    expect(theme.typography.body1.fontSize).toBe('1.0625rem')
+  })
+
+  it('should emit rem values for button fontSize', () => {
+    const theme = createAppTheme('light')
+    // button role is 17px → 1.0625rem
+    expect(theme.typography.button.fontSize).toBe('1.0625rem')
+  })
+
+  it('should emit rem values for h1 (largeTitle: 36px)', () => {
+    const theme = createAppTheme('light')
+    // largeTitle is 36px → 36/16 = 2.25rem
+    expect(theme.typography.h1?.fontSize).toBe('2.25rem')
+  })
+
+  it('should produce identical values in dark mode', () => {
+    const lightTheme = createAppTheme('light')
+    const darkTheme = createAppTheme('dark')
+    expect(lightTheme.typography.body1.fontSize).toBe(darkTheme.typography.body1.fontSize)
+  })
+})
+
+describe('focus-visible accent CSS variable', () => {
+  let originalSetProperty: typeof document.body.style.setProperty
+
+  beforeEach(() => {
+    originalSetProperty = document.body.style.setProperty.bind(document.body.style)
+  })
+
+  afterEach(() => {
+    document.body.style.setProperty = originalSetProperty
+  })
+
+  it('should set --lexio-accent on body when creating light theme', () => {
+    createAppTheme('light')
+    const val = document.body.style.getPropertyValue('--lexio-accent')
+    // lightGlass accent is #007AFF
+    expect(val).toBe('#007AFF')
+  })
+
+  it('should set --lexio-accent on body when creating dark theme', () => {
+    createAppTheme('dark')
+    const val = document.body.style.getPropertyValue('--lexio-accent')
+    // darkGlass accent is #0A84FF
+    expect(val).toBe('#0A84FF')
+  })
+})

--- a/src/theme/liquidGlass.ts
+++ b/src/theme/liquidGlass.ts
@@ -218,7 +218,13 @@ export const lightGlass: GlassVariantTokens = {
     bg: '#F4F2EE',
     ink: '#111114',
     inkSoft: 'rgba(30,30,36,0.75)',
-    inkSec: 'rgba(30,30,36,0.55)',
+    /**
+     * inkSec raised from 0.55 → 0.70 for WCAG AA contrast on light surfaces.
+     * At 0.55 on bg #F4F2EE the effective colour is ~#7E7D7F (≈3.6:1 — FAIL).
+     * At 0.70 the effective colour is ~#5E5D5D (≈5.3:1 — PASS).
+     * Dark variant remains 0.55 — on the dark bg #0A0A10 it already passes AA.
+     */
+    inkSec: 'rgba(30,30,36,0.70)',
     inkFaint: 'rgba(30,30,36,0.28)',
     rule2: 'rgba(0,0,0,0.08)',
     accent: '#007AFF',

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -3,9 +3,22 @@ import type { ThemePreference } from '@/types'
 import { getGlassTokens, glassRadius, glassTypography, glassShadows } from './liquidGlass'
 
 /**
+ * Convert a px value to rem based on 16px root font-size.
+ * This ensures MUI Typography variants respect the browser's base font-size
+ * setting (Dynamic Type / user font scaling at 200% zoom). Visual sizes at
+ * 100% zoom are unchanged — 17px → 1.0625rem looks identical at 100%.
+ */
+function pxToRem(px: number): string {
+  return `${px / 16}rem`
+}
+
+/**
  * Build MUI typography config from Liquid Glass typography tokens.
  * Display font (SF Pro Display / Inter) for headings; body font (SF Pro Text / Inter) for body.
  * Typography tokens are shared between light and dark variants.
+ *
+ * Font sizes use rem (not px) so they scale with the user's browser font-size
+ * preference. Visual sizes at 100% browser zoom are identical to the px values.
  */
 function buildTypography() {
   return {
@@ -13,14 +26,14 @@ function buildTypography() {
     h1: {
       fontFamily: glassTypography.display,
       fontWeight: glassTypography.roles.largeTitle.weight,
-      fontSize: `${glassTypography.roles.largeTitle.size}px`,
+      fontSize: pxToRem(glassTypography.roles.largeTitle.size),
       letterSpacing: `${glassTypography.roles.largeTitle.tracking}px`,
       lineHeight: glassTypography.roles.largeTitle.lineHeight,
     },
     h2: {
       fontFamily: glassTypography.display,
       fontWeight: glassTypography.roles.title.weight,
-      fontSize: `${glassTypography.roles.title.size}px`,
+      fontSize: pxToRem(glassTypography.roles.title.size),
       letterSpacing: `${glassTypography.roles.title.tracking}px`,
       lineHeight: glassTypography.roles.title.lineHeight,
     },
@@ -43,13 +56,13 @@ function buildTypography() {
       fontWeight: glassTypography.roles.title.weight,
     },
     body1: {
-      fontSize: `${glassTypography.roles.body.size}px`,
+      fontSize: pxToRem(glassTypography.roles.body.size),
       fontWeight: glassTypography.roles.body.weight,
       letterSpacing: `${glassTypography.roles.body.tracking}px`,
       lineHeight: glassTypography.roles.body.lineHeight,
     },
     body2: {
-      fontSize: `${glassTypography.roles.copy.size}px`,
+      fontSize: pxToRem(glassTypography.roles.copy.size),
       fontWeight: glassTypography.roles.copy.weight,
       letterSpacing: `${glassTypography.roles.copy.tracking}px`,
       lineHeight: glassTypography.roles.copy.lineHeight,
@@ -57,12 +70,12 @@ function buildTypography() {
     button: {
       fontFamily: glassTypography.body,
       fontWeight: glassTypography.roles.button.weight,
-      fontSize: `${glassTypography.roles.button.size}px`,
+      fontSize: pxToRem(glassTypography.roles.button.size),
       letterSpacing: `${glassTypography.roles.button.tracking}px`,
       textTransform: 'none' as const,
     },
     caption: {
-      fontSize: `${glassTypography.roles.caption.size}px`,
+      fontSize: pxToRem(glassTypography.roles.caption.size),
       fontWeight: glassTypography.roles.caption.weight,
       letterSpacing: `${glassTypography.roles.caption.tracking}px`,
       lineHeight: glassTypography.roles.caption.lineHeight,
@@ -80,7 +93,7 @@ function buildComponents(tokens: ReturnType<typeof getGlassTokens>) {
           borderRadius: glassRadius.btn,
           minHeight: 44,
           fontWeight: glassTypography.roles.button.weight,
-          fontSize: `${glassTypography.roles.button.size}px`,
+          fontSize: pxToRem(glassTypography.roles.button.size),
           letterSpacing: `${glassTypography.roles.button.tracking}px`,
           textTransform: 'none' as const,
           // Enter/exit use opacity/transform only — no animating on blurred surfaces.
@@ -150,7 +163,7 @@ function buildComponents(tokens: ReturnType<typeof getGlassTokens>) {
         root: {
           borderRadius: glassRadius.pill,
           fontWeight: glassTypography.roles.micro.weight,
-          fontSize: `${glassTypography.roles.micro.size}px`,
+          fontSize: pxToRem(glassTypography.roles.micro.size),
           letterSpacing: `${glassTypography.roles.micro.tracking}px`,
           height: 26,
         },
@@ -175,13 +188,59 @@ function buildComponents(tokens: ReturnType<typeof getGlassTokens>) {
           /* Bottom padding is handled per-component (e.g. BottomNav) so that
              backgrounds can extend to the physical edge while content stays clear. */
         }
+        /*
+         * Global focus-visible ring — 2px accent outline, 2px offset.
+         * Applied to every interactive element via :focus-visible so keyboard
+         * users always have a clear visual indicator. :focus-visible only fires
+         * for keyboard navigation (not mouse clicks), so the ring does not
+         * disrupt pointer-driven interaction.
+         *
+         * The accent color is injected at build time via the CSS custom property
+         * set on :root in index.html, but since we're in a JS theme we use the
+         * color token directly. The actual value is overridden per-mode in
+         * createAppTheme via the --lexio-accent CSS variable set on <body>.
+         * Fallback (#007AFF) matches the light-mode accent token.
+         *
+         * Do NOT override this with outline:none anywhere — it is a hard
+         * accessibility requirement (WCAG 2.4.7 / 2.4.11).
+         */
+        *:focus-visible {
+          outline: 2px solid var(--lexio-accent, #007AFF);
+          outline-offset: 2px;
+        }
+        /* MUI's default focus-visible handling sometimes injects outline:0 on
+           specific components. Restore it for button and anchor elements. */
+        button:focus-visible,
+        a:focus-visible,
+        [role="button"]:focus-visible,
+        [role="switch"]:focus-visible,
+        [role="radio"]:focus-visible,
+        [tabindex]:focus-visible {
+          outline: 2px solid var(--lexio-accent, #007AFF) !important;
+          outline-offset: 2px !important;
+        }
       `,
     },
   }
 }
 
+/**
+ * Inject the --lexio-accent CSS custom property onto <body> so the global
+ * :focus-visible rule in MuiCssBaseline can use the mode-correct accent colour
+ * without needing a JS dependency in the CSS string.
+ *
+ * Called by createAppTheme each time the mode changes. Safe to call on every
+ * render because it only touches one CSS custom property on <body>.
+ */
+function setAccentCssVar(accent: string): void {
+  if (typeof document !== 'undefined') {
+    document.body.style.setProperty('--lexio-accent', accent)
+  }
+}
+
 export function createAppTheme(mode: 'light' | 'dark'): Theme {
   const tokens = getGlassTokens(mode)
+  setAccentCssVar(tokens.color.accent)
 
   return createTheme({
     palette: {


### PR DESCRIPTION
## Summary

Final accessibility pass on the Liquid Glass redesign. This closes the last sub-issue of epic #141.

All fixes are minimum-viable — no screen restructures, no redesigns.

## Audit findings and fixes

| Area | Finding | Fix |
|------|---------|-----|
| Focus ring (global) | No global :focus-visible rule existed — custom Box-button elements could silently lose the ring | Added `*:focus-visible { outline: 2px solid var(--lexio-accent) }` in MuiCssBaseline; accent CSS variable set per mode via `setAccentCssVar()` |
| Focus ring (inputs) | Visually-hidden inputs have `outline:none` (correct) but parent Glass cards had no focus indicator | Added `:focus-within` outline on Glass cards in TypeQuizContent, AddWordModal (×2), LibraryScreen SearchField |
| Tap targets: Toggle | Rail height 31px < 44px minimum | Outer wrapper `minHeight:44` + transparent padding; visual rail unchanged |
| Tap targets: FilterPill | Height ~34px < 44px | `minHeight:44` + raised padding to 10px |
| Tap targets: Btn sm | Height 36px < 44px | `minHeight:44` on all 3 Btn variant inner elements |
| Tap targets: Skip button | Padding 4px only → ~21px tap height | `minHeight:44` + `padding:12px 0 12px 12px` |
| Contrast (light mode) | `inkSec` rgba(30,30,36,0.55) on `#F4F2EE` → effective ~3.6:1 (FAIL AA) | Raised lightGlass `inkSec` alpha 0.55→0.70 → ~5.3:1 (PASS). Dark mode unchanged. |
| Forms: aria-hidden on labels | AddWordModal uppercase label spans had `aria-hidden="true"` (incorrect — meaningful text) | Removed `aria-hidden` from label spans |
| Dynamic Type / 200% zoom | MUI theme typography used `px` font-sizes, preventing browser font-size scaling | Added `pxToRem()` helper; all `buildTypography()` + MuiButton/MuiChip font-sizes now emit `rem` |
| Icons | TabBar icons already `aria-hidden`; GlassIcon functional buttons already have `aria-label` | Toggle: added optional `aria-labelledby` prop |

## Reduce Transparency status (per-screen)

All glass surfaces flow through `<Glass>` which already has correct `@media (prefers-reduced-transparency: reduce)` guards (backdrop-filter removed, solid bg, rule2 hairline). Additional surfaces with inline blur (Chip, FilterPill inactive, PoSChipRow, ScoreChip) all have their own guards.

## Contrast ratios (light mode, worst cases)

| Token | Value | Effective on #F4F2EE | Ratio | Status |
|-------|-------|----------------------|-------|--------|
| ink | #111114 | — | ~18:1 | PASS |
| inkSoft | rgba(30,30,36,0.75) | ~#535252 | ~6.6:1 | PASS |
| inkSec | rgba(30,30,36,**0.70**) | ~#5E5D5D | ~**5.3:1** | PASS (was 3.6:1) |

## Testing

- All tests pass: 1181 unit tests (82 files) + 6 new a11y tests
- E2E: 14/14 pass
- Build: pass, lint: pass, type-check: pass

## Review

Code review passed — APPROVED.

## Closes

Closes #155

This is the **final sub-issue** of epic #141 (Liquid Glass redesign). All 14 sub-issues are now complete.