### PR TITLE
fix(a11y): complete #155 AC - Lighthouse 0.87 → 1.00 (#181)

### DIFF
--- a/e2e/quiz.spec.ts
+++ b/e2e/quiz.spec.ts
@@ -63,8 +63,8 @@ test('complete a type-mode quiz session', async ({ page }) => {
   // Answer 3 questions with a deliberately wrong answer so feedback always shows
   // the "Next word" button (correct answers auto-advance in 700ms).
   for (let i = 0; i < 3; i++) {
-    // Wait for the question word heading to appear.
-    await page.locator('[aria-label^="Translate:"]').waitFor({ timeout: 10_000 })
+    // Wait for the h1 question heading (term word) to appear.
+    await page.getByRole('heading', { level: 1 }).waitFor({ timeout: 10_000 })
 
     const input = page.getByRole('textbox')
     await input.fill('zzzzzzzzz') // deliberately wrong — guarantees feedback shows "Next word"

--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -202,6 +202,7 @@ function AppContent(): React.JSX.Element {
            * It is now uniform: all tabs render TabBar here, externally.
            */}
           <Box
+            component="main"
             sx={{
               position: 'relative',
               minHeight: '100dvh',

--- a/src/components/atoms/BigWord.test.tsx
+++ b/src/components/atoms/BigWord.test.tsx
@@ -14,6 +14,17 @@ describe('BigWord', () => {
     expect(screen.getByText('efímero')).toBeInTheDocument()
   })
 
+  it('should default to a non-heading span element', () => {
+    renderWithTheme(<BigWord>efímero</BigWord>)
+    // Default component is 'span' — not a heading
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument()
+  })
+
+  it('should render as h1 when component prop is h1', () => {
+    renderWithTheme(<BigWord component="h1">ābols</BigWord>)
+    expect(screen.getByRole('heading', { level: 1, name: 'ābols' })).toBeInTheDocument()
+  })
+
   it('should render a number', () => {
     renderWithTheme(<BigWord>14</BigWord>)
     expect(screen.getByText('14')).toBeInTheDocument()

--- a/src/components/atoms/BigWord.tsx
+++ b/src/components/atoms/BigWord.tsx
@@ -28,6 +28,12 @@ export interface BigWordProps {
   readonly weight?: number
   /** Text color. Defaults to ink token. */
   readonly color?: string
+  /**
+   * HTML element rendered by the Box. Defaults to 'span'.
+   * Pass 'h1' when BigWord is the primary heading on a screen
+   * (e.g. quiz term, onboarding welcome headline).
+   */
+  readonly component?: React.ElementType
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -42,6 +48,7 @@ export function BigWord({
   size = 44,
   weight = 800,
   color,
+  component = 'span',
 }: BigWordProps): React.JSX.Element {
   const theme = useTheme()
   const tokens = getGlassTokens(theme.palette.mode)
@@ -51,7 +58,7 @@ export function BigWord({
 
   return (
     <Box
-      component="span"
+      component={component}
       sx={{
         display: 'block',
         fontFamily: glassTypography.display,

--- a/src/components/atoms/LargeTitle.test.tsx
+++ b/src/components/atoms/LargeTitle.test.tsx
@@ -14,6 +14,11 @@ describe('LargeTitle', () => {
     expect(screen.getByRole('heading', { name: 'Today' })).toBeInTheDocument()
   })
 
+  it('should render as an h1 element', () => {
+    renderWithTheme(<LargeTitle>Progress</LargeTitle>)
+    expect(screen.getByRole('heading', { level: 1, name: 'Progress' })).toBeInTheDocument()
+  })
+
   it('should render any text content', () => {
     renderWithTheme(<LargeTitle>Progress</LargeTitle>)
     expect(screen.getByText('Progress')).toBeInTheDocument()

--- a/src/components/composites/NavBar.test.tsx
+++ b/src/components/composites/NavBar.test.tsx
@@ -49,4 +49,16 @@ describe('NavBar', () => {
     renderWithTheme(<NavBar title="Light mode" />, 'light')
     expect(screen.getByText('Light mode')).toBeInTheDocument()
   })
+
+  it('should not render a heading in compact variant (title is not a heading tag)', () => {
+    renderWithTheme(<NavBar title="Quiz" />)
+    // The compact pill title must NOT be a heading — headings belong to screen content
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument()
+  })
+
+  it('should render the large variant title as an h1', () => {
+    renderWithTheme(<NavBar large prominentTitle="Today" />)
+    // Large mode uses LargeTitle which renders as h1
+    expect(screen.getByRole('heading', { level: 1, name: 'Today' })).toBeInTheDocument()
+  })
 })

--- a/src/components/composites/SectionHeader.test.tsx
+++ b/src/components/composites/SectionHeader.test.tsx
@@ -14,9 +14,14 @@ describe('SectionHeader', () => {
     expect(screen.getByText('Daily practice')).toBeInTheDocument()
   })
 
-  it('should render as an h2 element', () => {
+  it('should render as an h2 element by default', () => {
     renderWithTheme(<SectionHeader>Quiz</SectionHeader>)
     expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument()
+  })
+
+  it('should render as h3 when component prop is h3', () => {
+    renderWithTheme(<SectionHeader component="h3">Deep section</SectionHeader>)
+    expect(screen.getByRole('heading', { level: 3, name: 'Deep section' })).toBeInTheDocument()
   })
 
   it('should apply uppercase CSS via text-transform (content is passed through as-is)', () => {

--- a/src/components/composites/SectionHeader.tsx
+++ b/src/components/composites/SectionHeader.tsx
@@ -20,17 +20,27 @@ export interface SectionHeaderProps {
   readonly children: React.ReactNode
   /** Optional sx overrides for positioning / margin. */
   readonly sx?: SxProps<Theme>
+  /**
+   * HTML element rendered by the Box. Defaults to 'h2'.
+   * All callers currently land on h2 (correct after a LargeTitle h1).
+   * Override to 'h3' when nesting inside a section that already has an h2.
+   */
+  readonly component?: React.ElementType
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function SectionHeader({ children, sx }: SectionHeaderProps): React.JSX.Element {
+export function SectionHeader({
+  children,
+  sx,
+  component = 'h2',
+}: SectionHeaderProps): React.JSX.Element {
   const theme = useTheme()
   const tokens = getGlassTokens(theme.palette.mode)
 
   return (
     <Box
-      component="h2"
+      component={component}
       sx={{
         // Reset heading margin (browser default adds top margin)
         margin: 0,

--- a/src/features/landing/LandingPage.tsx
+++ b/src/features/landing/LandingPage.tsx
@@ -107,6 +107,7 @@ function HeroSection(): React.JSX.Element {
         </Typography>
 
         <Typography
+          component="h2"
           variant="h5"
           sx={{
             color: 'text.primary',
@@ -151,6 +152,12 @@ function HeroSection(): React.JSX.Element {
               borderRadius: 3,
               minWidth: 180,
               boxShadow: '0 0 24px rgba(245,158,11,0.35)',
+              // #0A84FF (dark-mode primary) gives only 3.65:1 with white.
+              // Override to use the amber accent from the brand gradient so
+              // the landing-page CTA has sufficient contrast (≥ 4.5:1).
+              backgroundColor: '#f59e0b',
+              color: '#0a0f1a',
+              '&:hover': { backgroundColor: '#d97706' },
             }}
           >
             Try it now
@@ -288,7 +295,7 @@ function FeaturesSection(): React.JSX.Element {
               >
                 <Box sx={{ flexShrink: 0, mt: 0.25 }}>{f.icon}</Box>
                 <Box>
-                  <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
+                  <Typography component="h3" variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
                     {f.title}
                   </Typography>
                   <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.6 }}>
@@ -359,6 +366,7 @@ function AiStorySection(): React.JSX.Element {
               }}
             >
               <Typography
+                component="h3"
                 variant="subtitle1"
                 sx={{ fontWeight: 700, mb: 1.5, color: 'primary.main' }}
               >
@@ -384,6 +392,7 @@ function AiStorySection(): React.JSX.Element {
               }}
             >
               <Typography
+                component="h3"
                 variant="subtitle1"
                 sx={{ fontWeight: 700, mb: 1.5, color: 'secondary.main' }}
               >
@@ -474,6 +483,7 @@ function FooterSection(): React.JSX.Element {
 export function LandingPage(): React.JSX.Element {
   return (
     <Box
+      component="main"
       sx={{
         minHeight: '100vh',
         background: 'linear-gradient(180deg, #0d1529 0%, #0a0f1a 40%, #0a0f1a 100%)',

--- a/src/features/onboarding/steps/WelcomeStep.tsx
+++ b/src/features/onboarding/steps/WelcomeStep.tsx
@@ -73,8 +73,10 @@ export function WelcomeStep({ onDemo, onManualSetup, demoLoading = false }: Welc
         Welcome to Lexio
       </Box>
 
-      {/* Headline — BigWord size=42 */}
-      <BigWord size={HEADLINE_SIZE}>Learn any language, a word at a time.</BigWord>
+      {/* Headline — BigWord size=42, h1 because it is the primary heading on this screen */}
+      <BigWord size={HEADLINE_SIZE} component="h1">
+        Learn any language, a word at a time.
+      </BigWord>
 
       {/* Subhead 16/500 inkSoft max-width 320 */}
       <Box

--- a/src/features/quiz/components/ChoiceQuizContent.tsx
+++ b/src/features/quiz/components/ChoiceQuizContent.tsx
@@ -283,14 +283,9 @@ export function ChoiceQuizContent({
         {/* LangPair — centered */}
         <LangPair from={fromCode.toUpperCase()} to={toCode.toUpperCase()} />
 
-        {/* Term — BigWord size=66, mt=14 */}
-        <Box
-          sx={{ mt: '14px' }}
-          role="heading"
-          aria-level={2}
-          aria-label={`Translate: ${questionText}`}
-        >
-          <BigWord size={66} weight={800}>
+        {/* Term — h1 because it is the primary content heading for this screen */}
+        <Box sx={{ mt: '14px' }}>
+          <BigWord size={66} weight={800} component="h1">
             {questionText}
           </BigWord>
         </Box>

--- a/src/features/quiz/components/DailyProgressCard.tsx
+++ b/src/features/quiz/components/DailyProgressCard.tsx
@@ -184,7 +184,7 @@ export function DailyProgressCard({
             </Box>
           )}
 
-          {/* Words learned */}
+          {/* Words learned — inkSec ensures WCAG AA contrast at 12px */}
           {totalWords > 0 && (
             <Box
               component="span"
@@ -193,7 +193,7 @@ export function DailyProgressCard({
                 fontSize: '12px',
                 fontWeight: 500,
                 lineHeight: 1.2,
-                color: tokens.color.inkFaint,
+                color: tokens.color.inkSec,
               }}
             >
               {wordsLearned} / {totalWords} learned

--- a/src/features/quiz/components/TypeQuizContent.test.tsx
+++ b/src/features/quiz/components/TypeQuizContent.test.tsx
@@ -126,10 +126,11 @@ describe('TypeQuizContent - prompt area', () => {
     expect(screen.getByText('māja')).toBeInTheDocument()
   })
 
-  it('should render the aria-label on the term heading', () => {
+  it('should render the term as an h1 heading', () => {
     const session = makeSession()
     renderContent(session)
-    expect(screen.getByRole('heading', { name: /Translate: māja/i })).toBeInTheDocument()
+    // Term is the primary heading on the quiz screen — rendered as h1
+    expect(screen.getByRole('heading', { level: 1, name: /māja/i })).toBeInTheDocument()
   })
 
   it('should render "Translate to English" subtitle', () => {

--- a/src/features/quiz/components/TypeQuizContent.tsx
+++ b/src/features/quiz/components/TypeQuizContent.tsx
@@ -363,14 +363,9 @@ export function TypeQuizContent({ session, pair, settings }: TypeQuizContentProp
           {partOfSpeech !== null && <Chip tone="accent">{partOfSpeech}</Chip>}
         </Box>
 
-        {/* Term */}
-        <Box
-          sx={{ mt: '12px' }}
-          role="heading"
-          aria-level={2}
-          aria-label={`Translate: ${questionText}`}
-        >
-          <BigWord size={64} weight={800}>
+        {/* Term — h1 because it is the primary content heading for this screen */}
+        <Box sx={{ mt: '12px' }}>
+          <BigWord size={64} weight={800} component="h1">
             {questionText}
           </BigWord>
         </Box>


### PR DESCRIPTION
## Summary

Completes the accessibility AC from #155 that was closed without Lighthouse verification. The deployed build scored 0.87 with three audits failing. This PR brings the score to **1.00** in both light and dark modes.

## Root Cause

Lighthouse scans the landing page (`/lexio/`) — not the app screens — first. All three audit failures were on the landing page, with additional structural issues in the app screens.

## Changes

### Fix 1: `<main>` landmark (`landmark-one-main`)
- `src/AppContent.tsx`: positioned-ancestor `<Box>` → `<Box component="main">`
- `src/features/landing/LandingPage.tsx`: outer wrapper `<Box>` → `<Box component="main">`

### Fix 2: Heading order (`heading-order`)
- `src/components/atoms/BigWord.tsx`: add optional `component` prop (default `'span'`)
- `src/components/composites/SectionHeader.tsx`: add optional `component` prop (default `'h2'`)
- `src/features/quiz/components/TypeQuizContent.tsx`: replace `role="heading" aria-level={2}` ARIA workaround with `<BigWord component="h1">`
- `src/features/quiz/components/ChoiceQuizContent.tsx`: same fix
- `src/features/onboarding/steps/WelcomeStep.tsx`: `<BigWord component="h1">` for headline
- `src/features/landing/LandingPage.tsx`: h5 subtitle → `component="h2"`; feature/AI-story card titles → `component="h3"`

### Fix 3: Color contrast (`color-contrast`)
- `src/features/quiz/components/DailyProgressCard.tsx`: "N / total learned" label changed from `inkFaint` (~1.79:1) to `inkSec` (~5.78:1)
- `src/features/landing/LandingPage.tsx`: "Try it now" CTA changed from `#0A84FF`/white (3.65:1 FAIL) to amber `#f59e0b`/`#0a0f1a` (8.92:1 PASS) — matches existing brand gradient colors

### Supporting changes
- `e2e/quiz.spec.ts`: update locator from old `[aria-label^="Translate:"]` to `getByRole('heading', { level: 1 })`
- 6 new unit tests for semantic element assertions on BigWord, SectionHeader, LargeTitle, NavBar

## Lighthouse Scores

| Audit | Before | After (local preview, light) | After (local preview, dark) |
|-------|--------|-----|------|
| Overall a11y | 0.87 | **1.00** | **1.00** |
| `color-contrast` | 0 | **1.00** | **1.00** |
| `heading-order` | 0 | **1.00** | **1.00** |
| `landmark-one-main` | 0 | **1.00** | **1.00** |

## Per-Screen Heading Inventory

| Screen | h1 | h2 | Notes |
|--------|-----|-----|-------|
| Landing | "Lexio" | "Learn vocabulary..." + "Everything you need..." + "One person..." | h3: feature/AI cards |
| Dashboard | NavBar "Today" | SectionHeaders | One h1 |
| Quiz Hub | NavBar "Practice" | — | Mode cards are buttons, not headings |
| Type Quiz | BigWord term | — | One h1, no other headings |
| Choice Quiz | BigWord term | — | One h1, no other headings |
| Library | NavBar "Library" | Letter groups (SectionHeader) | One h1 |
| AddWord Modal | "New Word" | "Part of speech", "Example", "AI autofill" | Modal treated as independent page |
| Stats | NavBar "Progress" | SectionHeaders | One h1 |
| Settings | NavBar "Settings" | SectionHeaders | One h1 |
| WelcomeStep | BigWord headline | — | Eyebrow label is `<span>` |
| LanguagePairStep | StepHeader title | — | One h1 |
| AddWordsStep | StepHeader title | "Get started" (SectionHeader) | One h1 |
| TutorialStep | "How Lexio works" | Slide titles | h2 inside h1 section |

## Testing

- All tests pass: 1187/1187 unit + 14/14 E2E
- TypeScript strict: no errors
- Build: success
- Lint + format: pass

Closes #181