### PR TITLE
chore: migrate MUI Dialog TransitionComponent and Checkbox inputProps to slots API (#191)

### DIFF
--- a/src/features/words/components/ImportWordsDialog.tsx
+++ b/src/features/words/components/ImportWordsDialog.tsx
@@ -249,7 +249,7 @@ export function ImportWordsDialog({
       fullScreen
       aria-modal="true"
       aria-label="Import words"
-      TransitionComponent={SlideUpTransition}
+      slots={{ transition: SlideUpTransition }}
       slotProps={{
         paper: {
           sx: {
@@ -504,7 +504,7 @@ function StepPreview({
                       checked={isSelected}
                       onChange={() => onToggleRow(row.lineNumber)}
                       size="small"
-                      inputProps={{ 'aria-label': `Toggle row ${row.lineNumber}` }}
+                      slotProps={{ input: { 'aria-label': `Toggle row ${row.lineNumber}` } }}
                     />
                   </TableCell>
                   <TableCell sx={{ fontFamily: glassTypography.body }}>{row.source}</TableCell>

--- a/src/features/words/components/WordFormDialog.tsx
+++ b/src/features/words/components/WordFormDialog.tsx
@@ -471,7 +471,7 @@ export function WordFormDialog({
       fullScreen
       aria-modal="true"
       aria-label={isEdit ? 'Edit word' : 'Add word'}
-      TransitionComponent={SlideUpTransition}
+      slots={{ transition: SlideUpTransition }}
       slotProps={{
         paper: {
           sx: {


### PR DESCRIPTION
## Summary

- Resolve 3 TS6385 deprecation warnings from MUI v6→v7 slot API migration
- Pure type-level cleanup; no runtime behaviour change

## Changes

- `src/features/words/components/ImportWordsDialog.tsx` — `TransitionComponent={SlideUpTransition}` → `slots={{ transition: SlideUpTransition }}` (Dialog); `inputProps={{ 'aria-label': ... }}` → `slotProps={{ input: { 'aria-label': ... } }}` (Checkbox)
- `src/features/words/components/WordFormDialog.tsx` — `TransitionComponent={SlideUpTransition}` → `slots={{ transition: SlideUpTransition }}` (Dialog)

## Testing

- `npx tsc --noEmit` — completely silent (TS6385 warnings gone)
- `npm run lint` — zero errors
- `npm run format:check` — pass
- `npm test -- --run` — 1196/1196 tests pass
- `npm run build` — production build succeeds
- `npm run e2e` — 14/14 Playwright tests pass (dialog open/close flows verified)

## Review

- Code review approved: slot names match MUI v7 API, no behavioural change

Closes #191