### PR TITLE
fix: settings drill-down sub-screens render full-bleed (#193)

### DIFF
--- a/src/features/settings/components/SettingsScreen.test.tsx
+++ b/src/features/settings/components/SettingsScreen.test.tsx
@@ -520,6 +520,56 @@ describe('SettingsScreen', () => {
     expect(storage.saveWordProgress).not.toHaveBeenCalled()
   })
 
+  // ── Sub-screen layout and accessibility (issue #193) ────────────────────────
+
+  it('should hide sub-screen from accessibility tree when not visible', () => {
+    renderSettings(storage)
+    // All sub-screens start off-screen — they must be aria-hidden so their
+    // headings do not collide with main settings headings in the a11y tree.
+    const allDialogs = screen.getAllByRole('dialog', { hidden: true })
+    // 5 sub-screens: quiz-mode, theme, daily-goal, show-hint, reminder
+    expect(allDialogs.length).toBe(5)
+    // Each hidden sub-screen must have aria-hidden="true"
+    for (const dialog of allDialogs) {
+      expect(dialog).toHaveAttribute('aria-hidden', 'true')
+    }
+  })
+
+  it('should set aria-hidden=false on sub-screen when visible', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+    await user.click(screen.getByRole('button', { name: /quiz mode/i }))
+    await waitFor(() => {
+      // The dialog should be visible (aria-hidden=false) and findable without hidden:true
+      expect(screen.getByRole('dialog', { name: 'Quiz mode' })).toBeInTheDocument()
+    })
+    const dialog = screen.getByRole('dialog', { name: 'Quiz mode' })
+    // aria-hidden must be false (or absent) when visible — not "true"
+    expect(dialog).not.toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('should render sub-screen with position:fixed for full-bleed coverage', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+    await user.click(screen.getByRole('button', { name: /quiz mode/i }))
+    await waitFor(() => screen.getByRole('dialog', { name: 'Quiz mode' }))
+    const dialog = screen.getByRole('dialog', { name: 'Quiz mode' })
+    // position:fixed ensures the sub-screen is anchored to the viewport
+    // (not to a positioned ancestor), giving full-bleed coverage above the TabBar.
+    expect(dialog).toHaveStyle({ position: 'fixed' })
+  })
+
+  it('should render edge-to-edge header (h2) inside sub-screen, not floating pill NavBar', async () => {
+    const user = userEvent.setup()
+    renderSettings(storage)
+    await user.click(screen.getByRole('button', { name: /quiz mode/i }))
+    await waitFor(() => screen.getByRole('dialog', { name: 'Quiz mode' }))
+    const subScreen = screen.getByRole('dialog', { name: 'Quiz mode' })
+    // The sub-screen header renders a plain h2 element — not the floating glass pill NavBar
+    const headerEl = within(subScreen).getByRole('heading', { name: 'Quiz mode' })
+    expect(headerEl.tagName.toLowerCase()).toBe('h2')
+  })
+
   it('should call saveWordProgress for each word with progress on reset confirm', async () => {
     const user = userEvent.setup()
     const word = createMockWord({ id: 'w1', pairId: 'p1' })

--- a/src/features/settings/components/SettingsScreen.tsx
+++ b/src/features/settings/components/SettingsScreen.tsx
@@ -206,6 +206,83 @@ function OptionRow({
   )
 }
 
+// ─── Sub-screen Header ────────────────────────────────────────────────────────
+
+interface SubScreenHeaderProps {
+  readonly title: string
+  readonly onBack: () => void
+}
+
+/**
+ * Edge-to-edge iOS-style header for drill-down sub-screens.
+ *
+ * Unlike the floating-pill NavBar (used on main tabs), this header spans the
+ * full viewport width and sits flush with the top edge. It respects the
+ * device safe-area-inset-top so the status bar is not obscured on notched
+ * devices. A hairline bottom border separates it from the scrollable content.
+ */
+function SubScreenHeader({ title, onBack }: SubScreenHeaderProps): React.JSX.Element {
+  const theme = useTheme()
+  const tokens = getGlassTokens(theme.palette.mode)
+
+  return (
+    <Box
+      component="header"
+      sx={{
+        // Flush with the top edge; safe-area-inset-top clears notch/status bar.
+        paddingTop: 'env(safe-area-inset-top, 0px)',
+        px: '16px',
+        borderBottom: `0.5px solid ${tokens.color.rule2}`,
+        // Use the same opaque background as the sub-screen so the header blends in.
+        background: tokens.wallpaper,
+        backgroundColor: tokens.color.bg,
+      }}
+    >
+      {/* Navigation row: back button — centered title — (empty trailing slot) */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          height: '52px',
+          position: 'relative',
+        }}
+      >
+        {/* Back button — left-anchored */}
+        <Box sx={{ flexShrink: 0 }}>
+          <BackButton label="Settings" onClick={onBack} />
+        </Box>
+
+        {/* Title — absolutely centered so it doesn't shift with back-button width */}
+        <Box
+          component="h2"
+          sx={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            textAlign: 'center',
+            // Prevent overlap with back button (back button ≈ 100px wide)
+            px: '100px',
+            margin: 0,
+            fontFamily: glassTypography.body,
+            fontSize: '17px',
+            fontWeight: 700,
+            letterSpacing: '-0.3px',
+            color: tokens.color.ink,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            // Pointer events off on the title span — the back button behind it
+            // must still be tappable.
+            pointerEvents: 'none',
+          }}
+        >
+          {title}
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
 // ─── Drill-down Sub-screen Wrapper ────────────────────────────────────────────
 
 interface SubScreenProps {
@@ -217,6 +294,16 @@ interface SubScreenProps {
 
 /**
  * Wraps drill-down sub-screen content with iOS-style slide-from-right transition.
+ *
+ * Rendering notes:
+ * - position:fixed + inset:0 anchors to the viewport, ensuring full-bleed
+ *   coverage regardless of any positioned ancestor in the component tree.
+ *   Previously position:absolute was used, but #185 removed the relative
+ *   anchor, causing the sub-screen to resolve against an unintended ancestor.
+ * - zIndex:30 sits above the TabBar (zIndex:20), fully covering tab icons.
+ * - The wallpaper gradient background is fully opaque — no parent content
+ *   or TabBar icons bleed through.
+ * - overflowY:auto gives the sub-screen its own independent scroll region.
  */
 function SubScreen({ title, onBack, visible, children }: SubScreenProps): React.JSX.Element {
   const theme = useTheme()
@@ -227,20 +314,31 @@ function SubScreen({ title, onBack, visible, children }: SubScreenProps): React.
       role="dialog"
       aria-label={title}
       aria-modal="false"
+      // Hide from the accessibility tree when off-screen: prevents heading/element
+      // collisions with the main settings list (both share h2 headings) and avoids
+      // screen readers reading content that is not visible to the user.
+      aria-hidden={!visible}
       sx={{
-        position: 'absolute',
+        // Full-bleed: anchored to the viewport, not the nearest positioned ancestor.
+        position: 'fixed',
         inset: 0,
-        zIndex: 10,
-        background: tokens.color.bg,
+        // Above TabBar (zIndex:20) — fully covers tab icons.
+        zIndex: 30,
+        // Opaque wallpaper background — no semi-transparent glass bleed-through.
+        background: tokens.wallpaper,
+        backgroundColor: tokens.color.bg,
+        color: tokens.color.ink,
         transform: visible ? 'translateX(0)' : 'translateX(100%)',
         transition: 'transform 280ms cubic-bezier(0.4, 0, 0.2, 1)',
         '@media (prefers-reduced-motion: reduce)': {
           transition: 'none',
         },
+        // Sub-screen owns its own scroll region.
         overflowY: 'auto',
+        overflowX: 'hidden',
       }}
     >
-      <NavBar title={title} leading={<BackButton label="Settings" onClick={onBack} />} />
+      <SubScreenHeader title={title} onBack={onBack} />
       <Box sx={{ px: '16px', pb: `${TAB_BAR_SPACER}px` }}>{children}</Box>
     </Box>
   )


### PR DESCRIPTION
## Summary

Fixes 4 interacting bugs in `SettingsScreen.tsx` that caused the Settings drill-down sub-screens (Quiz mode, Theme, Daily goal, Show hint, Reminder) to render as small floating cards instead of full-bleed screens.

## Root causes fixed

1. **Position anchor lost** — `position:absolute` on SubScreen had no valid anchor after #185 removed `position:relative` from the app shell. Fixed by switching to `position:fixed; inset:0` (viewport-anchored, truly full-bleed).

2. **Wrong NavBar primitive** — the floating glass-pill NavBar was rendered inside the sub-screen. Replaced with a new `SubScreenHeader`: edge-to-edge flush header (no glass pill) with centered `h2` title and left-anchored back chevron.

3. **Semi-transparent background** — background was `tokens.color.bg` (solid fallback), but sub-screen content can bleed through. Now uses `background: tokens.wallpaper + backgroundColor: tokens.color.bg` — fully opaque, mirrors `PaperSurface`.

4. **No safe-area handling** — `SubScreenHeader` now adds `paddingTop: env(safe-area-inset-top, 0px)` so status bar is not obscured on notched devices.

**Bonus:** `aria-hidden={!visible}` on `SubScreen` hides off-screen sub-screens from the accessibility tree, preventing heading collisions with the main settings list and preventing screen readers from announcing invisible content.

## Changes

- `src/features/settings/components/SettingsScreen.tsx` — SubScreen and SubScreenHeader components refactored
- `src/features/settings/components/SettingsScreen.test.tsx` — 4 new targeted tests for the acceptance criteria

## Testing

- All 1200 unit tests pass
- All 14 E2E tests pass
- `npm run lint` — clean
- `npm run format:check` — clean
- `npx tsc --noEmit` — clean
- `npm run build` — clean

## Review

- Code review approved (no issues found)

Closes #193