### PR TITLE
docs: reconcile tokens.json with liquidGlass.ts — 5 drift points (#194)

### DIFF
--- a/docs/design/liquid-glass/tokens.json
+++ b/docs/design/liquid-glass/tokens.json
@@ -7,7 +7,8 @@
       "bg": "#F4F2EE",
       "ink": "#111114",
       "inkSoft": "rgba(30,30,36,0.75)",
-      "inkSec": "rgba(30,30,36,0.55)",
+      "inkSec": "rgba(30,30,36,0.70)",
+      "$inkSec_comment": "Raised from 0.55 to 0.70 for WCAG AA contrast on light bg #F4F2EE. At 0.55 the effective colour is ~#7E7D7F (~3.6:1, FAIL). At 0.70 it is ~#5E5D5D (~5.3:1, PASS). Dark variant stays at 0.55 — on bg #0A0A10 it already passes AA.",
       "inkFaint": "rgba(30,30,36,0.28)",
       "rule2": "rgba(0,0,0,0.08)",
       "accent": "#007AFF",
@@ -17,7 +18,16 @@
       "warn": "#FF9500",
       "red": "#FF3B30",
       "violet": "#AF52DE",
-      "pink": "#FF2D55"
+      "pink": "#FF2D55",
+      "avatarGradient": "linear-gradient(135deg, #007AFF 0%, #AF52DE 100%)",
+      "aiGradient": "linear-gradient(135deg, #AF52DE 0%, #007AFF 100%)",
+      "streakGradient": "linear-gradient(135deg, #FF9500 0%, #FF3B30 100%)",
+      "pairGradients": {
+        "es": "linear-gradient(135deg, #FF9500 0%, #FF3B30 100%)",
+        "fr": "linear-gradient(135deg, #5856D6 0%, #0A84FF 100%)",
+        "ja": "linear-gradient(135deg, #FF2D55 0%, #AF52DE 100%)",
+        "de": "linear-gradient(135deg, #30D158 0%, #0A84FF 100%)"
+      }
     },
     "glass": {
       "bg": "rgba(255,255,255,0.55)",
@@ -46,7 +56,16 @@
       "warn": "#FF9F0A",
       "red": "#FF453A",
       "violet": "#BF5AF2",
-      "pink": "#FF375F"
+      "pink": "#FF375F",
+      "avatarGradient": "linear-gradient(135deg, #0A84FF 0%, #BF5AF2 100%)",
+      "aiGradient": "linear-gradient(135deg, #BF5AF2 0%, #0A84FF 100%)",
+      "streakGradient": "linear-gradient(135deg, #FF9500 0%, #FF3B30 100%)",
+      "pairGradients": {
+        "es": "linear-gradient(135deg, #FF9500 0%, #FF3B30 100%)",
+        "fr": "linear-gradient(135deg, #5856D6 0%, #0A84FF 100%)",
+        "ja": "linear-gradient(135deg, #FF2D55 0%, #AF52DE 100%)",
+        "de": "linear-gradient(135deg, #30D158 0%, #0A84FF 100%)"
+      }
     },
     "glass": {
       "bg": "rgba(255,255,255,0.10)",
@@ -74,7 +93,7 @@
     "tabBottom": 30
   },
   "typography": {
-    "display": "-apple-system, \"SF Pro Display\", \"Helvetica Neue\", system-ui, sans-serif",
+    "display": "-apple-system, \"SF Pro Display\", \"Helvetica Neue\", Inter, system-ui, sans-serif",
     "body": "-apple-system, \"SF Pro Text\", system-ui, sans-serif",
     "mono": "\"SF Mono\", ui-monospace, monospace",
     "roles": {


### PR DESCRIPTION
## Summary

Syncs `docs/design/liquid-glass/tokens.json` to match the authoritative values already in `src/theme/liquidGlass.ts`, making the file's own header comment truthful again.

Five drift points addressed:
- `lightGlass.color.inkSec`: updated from `rgba(30,30,36,0.55)` to `rgba(30,30,36,0.70)` with a `$inkSec_comment` explaining the WCAG AA rationale (3.6:1 → 5.3:1; dark stays at 0.55)
- `typography.display`: added `Inter` between `"Helvetica Neue"` and `system-ui` to match the TS file
- `avatarGradient`, `aiGradient`, `streakGradient`: added to both `lightGlass.color` and `darkGlass.color`
- `pairGradients` (`es`/`fr`/`ja`/`de`): added to both variants

## Changes

- `docs/design/liquid-glass/tokens.json` — JSON source-of-truth update only, no TS changes

## Testing

- All 1200 tests pass
- Build succeeds
- All 5 acceptance criteria from issue verified via Python sanity check
- No visual regression (JSON-only change)

## Review

- Code review approved — no issues found

Closes #194