### PR TITLE
refactor: simplify autoDemoRef URL parsing — drop dead search fallback (#201)

### DIFF
--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -38,18 +38,14 @@ function AppContent(): React.JSX.Element {
    * Read once on mount via a ref so it's stable across renders.
    * When true, the OnboardingFlow will auto-trigger the instant demo path.
    *
-   * With HashRouter the query string is encoded in the hash fragment
-   * (e.g. #/app?demo=true), so we parse from window.location.hash rather
-   * than window.location.search.
+   * With HashRouter the query string lives inside the hash fragment
+   * (e.g. `#/app?demo=true`), so we parse from window.location.hash.
    */
   const autoDemoRef = useRef(
     (() => {
-      // Extract everything after the first '?' in the hash fragment.
       const hash = window.location.hash // e.g. "#/app?demo=true"
       const qIndex = hash.indexOf('?')
-      const hashSearch = qIndex >= 0 ? hash.slice(qIndex) : ''
-      // Also check the regular search for direct navigation scenarios.
-      const search = window.location.search || hashSearch
+      const search = qIndex >= 0 ? hash.slice(qIndex) : ''
       return new URLSearchParams(search).get('demo') === 'true'
     })(),
   )


### PR DESCRIPTION
## Summary

Removes the dead `window.location.search` fallback from the `autoDemoRef` IIFE in `AppContent.tsx`. Under HashRouter, `?demo=true` always lives in `window.location.hash` — the search fallback was never reachable in production and mislead readers into thinking there might be a second routing strategy.

## Changes

- `src/AppContent.tsx` — drop `window.location.search || hashSearch` OR expression, rename `hashSearch` to `search`, update JSDoc comment with concrete URL example

## Testing

- All 1200 tests pass
- Build succeeds
- TypeScript clean
- Hash-fragment parsing behaviour is functionally identical

## Review

- Code review approved — no issues found

Closes #201