### PR TITLE
refactor: extract computeDueCount to shared util — one source of truth (#196)

### DIFF
--- a/src/features/dashboard/components/DashboardScreen.tsx
+++ b/src/features/dashboard/components/DashboardScreen.tsx
@@ -34,6 +34,7 @@ import { useTheme } from '@mui/material/styles'
 import { useWordOfTheDay } from '../hooks/useWordOfTheDay'
 import { speak } from '@/utils/tts'
 import { MASTERED_THRESHOLD } from '@/features/words/buckets'
+import { computeDueCount } from '@/features/words/utils/dueWords'
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -67,26 +68,6 @@ export interface DashboardScreenProps {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/**
- * Compute how many words are due right now (nextReview <= Date.now()).
- * Words with no progress record are also due (never reviewed).
- */
-function computeDueCount(words: readonly Word[], progressList: readonly WordProgress[]): number {
-  const now = Date.now()
-  const progressMap = new Map<string, WordProgress>()
-  for (const p of progressList) {
-    progressMap.set(p.wordId, p)
-  }
-  let count = 0
-  for (const word of words) {
-    const progress = progressMap.get(word.id)
-    if (progress === undefined || progress.nextReview <= now) {
-      count++
-    }
-  }
-  return count
-}
 
 /** Count mastered words (confidence >= MASTERED_THRESHOLD). */
 function computeMasteredCount(progressList: readonly WordProgress[]): number {

--- a/src/features/quiz/components/QuizHub.tsx
+++ b/src/features/quiz/components/QuizHub.tsx
@@ -35,34 +35,11 @@ import { getWordsLearnedForPair } from '@/services/wordsLearnedService'
 import { PaperSurface } from '@/components/primitives'
 import { NavBar } from '@/components/composites'
 import { getGlassTokens } from '@/theme/liquidGlass'
+import { computeDueCount } from '@/features/words/utils/dueWords'
 import { QuizModeSelector } from './QuizModeSelector'
 import { SessionSummary } from './SessionSummary'
 import { ActiveQuizView } from './ActiveQuizView'
 import { GoalCelebration } from './GoalCelebration'
-
-// ─── Due-count helper (mirrors DashboardScreen.computeDueCount) ───────────────
-
-/**
- * Compute how many words are due right now (nextReview <= Date.now()).
- * Words with no progress record are also due (never reviewed).
- * Mirrors the same logic in DashboardScreen — not extracted to a shared
- * util yet to avoid premature abstraction (the dashboard imports it locally too).
- */
-function computeDueCount(words: readonly Word[], progressList: readonly WordProgress[]): number {
-  const now = Date.now()
-  const progressMap = new Map<string, WordProgress>()
-  for (const p of progressList) {
-    progressMap.set(p.wordId, p)
-  }
-  let count = 0
-  for (const word of words) {
-    const progress = progressMap.get(word.id)
-    if (progress === undefined || progress.nextReview <= now) {
-      count++
-    }
-  }
-  return count
-}
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 

--- a/src/features/words/utils/dueWords.test.ts
+++ b/src/features/words/utils/dueWords.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import type { Word, WordProgress } from '@/types'
+import { computeDueCount } from './dueWords'
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+const NOW = 1_700_000_000_000 // fixed reference timestamp for deterministic tests
+
+function makeWord(id: string): Word {
+  return {
+    id,
+    pairId: 'pair-1',
+    source: 'word',
+    target: 'vārds',
+    notes: null,
+    tags: [],
+    createdAt: 1000,
+    isFromPack: false,
+  }
+}
+
+function makeProgress(wordId: string, nextReview: number): WordProgress {
+  return {
+    wordId,
+    correctCount: 3,
+    incorrectCount: 1,
+    streak: 1,
+    lastReviewed: NOW - 100_000,
+    nextReview,
+    confidence: 0.5,
+    history: [],
+  }
+}
+
+// ─── computeDueCount ─────────────────────────────────────────────────────────
+
+describe('computeDueCount', () => {
+  it('should return 0 for an empty word list', () => {
+    expect(computeDueCount([], [], NOW)).toBe(0)
+  })
+
+  it('should count all words as due when no progress records exist', () => {
+    const words = [makeWord('w1'), makeWord('w2'), makeWord('w3')]
+    expect(computeDueCount(words, [], NOW)).toBe(3)
+  })
+
+  it('should count a word as due when nextReview is exactly now', () => {
+    const words = [makeWord('w1')]
+    const progress = [makeProgress('w1', NOW)]
+    expect(computeDueCount(words, progress, NOW)).toBe(1)
+  })
+
+  it('should count a word as due when nextReview is in the past', () => {
+    const words = [makeWord('w1')]
+    const progress = [makeProgress('w1', NOW - 1)]
+    expect(computeDueCount(words, progress, NOW)).toBe(1)
+  })
+
+  it('should not count a word as due when nextReview is in the future', () => {
+    const words = [makeWord('w1')]
+    const progress = [makeProgress('w1', NOW + 1)]
+    expect(computeDueCount(words, progress, NOW)).toBe(0)
+  })
+
+  it('should correctly count a mix of due and not-due words', () => {
+    const words = [makeWord('w1'), makeWord('w2'), makeWord('w3'), makeWord('w4')]
+    const progress = [
+      makeProgress('w1', NOW - 60_000), // due (past)
+      makeProgress('w2', NOW), // due (exactly now)
+      makeProgress('w3', NOW + 60_000), // not due (future)
+      // w4 has no progress — always due
+    ]
+    expect(computeDueCount(words, progress, NOW)).toBe(3)
+  })
+
+  it('should handle all words being due', () => {
+    const words = [makeWord('w1'), makeWord('w2')]
+    const progress = [makeProgress('w1', NOW - 1000), makeProgress('w2', NOW - 2000)]
+    expect(computeDueCount(words, progress, NOW)).toBe(2)
+  })
+
+  it('should handle all words being not due', () => {
+    const words = [makeWord('w1'), makeWord('w2')]
+    const progress = [makeProgress('w1', NOW + 1_000_000), makeProgress('w2', NOW + 2_000_000)]
+    expect(computeDueCount(words, progress, NOW)).toBe(0)
+  })
+
+  it('should accept an injectable now parameter for deterministic results', () => {
+    const words = [makeWord('w1')]
+    const futureReview = NOW + 1000
+    const progress = [makeProgress('w1', futureReview)]
+
+    // At NOW: not due
+    expect(computeDueCount(words, progress, NOW)).toBe(0)
+    // At futureReview: exactly due
+    expect(computeDueCount(words, progress, futureReview)).toBe(1)
+    // After futureReview: still due
+    expect(computeDueCount(words, progress, futureReview + 1)).toBe(1)
+  })
+})

--- a/src/features/words/utils/dueWords.ts
+++ b/src/features/words/utils/dueWords.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared utility for computing due-word counts.
+ *
+ * Extracted from DashboardScreen and QuizHub where the same function was
+ * defined inline in both files. A word is "due" when its nextReview
+ * timestamp is at or before the current time, OR when it has no progress
+ * record at all (never reviewed).
+ */
+
+import type { Word, WordProgress } from '@/types'
+
+/**
+ * Compute how many words are due right now (nextReview <= now).
+ * Words with no progress record are also due (never reviewed).
+ *
+ * @param words        - All words in the active pair.
+ * @param progressList - All progress records for the active pair.
+ * @param now          - The reference timestamp in ms. Defaults to Date.now().
+ *                       Injectable for deterministic unit tests.
+ */
+export function computeDueCount(
+  words: readonly Word[],
+  progressList: readonly WordProgress[],
+  now: number = Date.now(),
+): number {
+  const progressMap = new Map<string, WordProgress>()
+  for (const p of progressList) {
+    progressMap.set(p.wordId, p)
+  }
+
+  let count = 0
+  for (const word of words) {
+    const progress = progressMap.get(word.id)
+    if (progress === undefined || progress.nextReview <= now) {
+      count++
+    }
+  }
+  return count
+}


### PR DESCRIPTION
## Summary

Eliminates the duplicate `computeDueCount` function defined in both `DashboardScreen.tsx` and `QuizHub.tsx` by extracting it to a single shared utility.

The new function adds an injectable `now` parameter (defaults to `Date.now()`) so tests can run deterministically without mocking globals.

## Changes

- `src/features/words/utils/dueWords.ts` (new) — single `computeDueCount` implementation
- `src/features/words/utils/dueWords.test.ts` (new) — 9 unit tests
- `src/features/dashboard/components/DashboardScreen.tsx` — local function removed, import added
- `src/features/quiz/components/QuizHub.tsx` — local function and its "mirrors DashboardScreen" comment removed, import added

## Testing

- 1209 tests pass (83 files, 9 new tests for dueWords)
- TypeScript strict — no errors
- Build succeeds
- No behaviour change at runtime — callers omit `now` and get `Date.now()` as before

## Review

- Code review approved — no issues found

Closes #196