### PR TITLE
feat: standardise hero chip labels across all three dashboard states (#197)

### DIFF
--- a/src/features/dashboard/components/DashboardScreen.test.tsx
+++ b/src/features/dashboard/components/DashboardScreen.test.tsx
@@ -167,6 +167,48 @@ describe('DashboardScreen', () => {
       expect(screen.getByRole('button', { name: /start review/i })).toBeDisabled()
     })
 
+    // ── Hero chip label rule (Option A — state-specific) ─────────────────────
+
+    it('should show "GET STARTED" chip when no active pair is selected', () => {
+      renderWithTheme(<DashboardScreen {...buildProps({ activePair: null })} />)
+      expect(screen.getByText('GET STARTED')).toBeInTheDocument()
+    })
+
+    it('should show "DUE TODAY" chip when words are due', () => {
+      renderWithTheme(
+        <DashboardScreen
+          {...buildProps({
+            activePair,
+            words: [learningWord],
+            wordProgressList: [learningProgress],
+            totalWords: 1,
+          })}
+        />,
+      )
+      expect(screen.getByText('DUE TODAY')).toBeInTheDocument()
+    })
+
+    it('should show "ALL DONE" chip when all words are caught up', () => {
+      const caughtUpWord: Word = { ...learningWord, id: 'w-caught-up' }
+      const caughtUpProgress: WordProgress = {
+        ...learningProgress,
+        wordId: 'w-caught-up',
+        nextReview: Date.now() + 1_000_000_000,
+        confidence: 0.3,
+      }
+      renderWithTheme(
+        <DashboardScreen
+          {...buildProps({
+            activePair,
+            words: [caughtUpWord],
+            wordProgressList: [caughtUpProgress],
+            totalWords: 1,
+          })}
+        />,
+      )
+      expect(screen.getByText('ALL DONE')).toBeInTheDocument()
+    })
+
     it('should show progress bar when words are due', () => {
       renderWithTheme(
         <DashboardScreen

--- a/src/features/dashboard/components/DashboardScreen.tsx
+++ b/src/features/dashboard/components/DashboardScreen.tsx
@@ -177,6 +177,15 @@ function HeroCard({
   const noPair = activePair === null
   const allCaughtUp = !noPair && dueCount === 0
 
+  /*
+   * Hero chip label rule (Option A — state-specific):
+   *   - No active pair selected  →  "GET STARTED"  (invite to onboard)
+   *   - Words due today           →  "DUE TODAY"    (primary action prompt)
+   *   - All words caught up       →  "ALL DONE"     (positive reinforcement)
+   * Each label is semantically tied to its state so the eyebrow always
+   * reflects the current context rather than using a generic fallback.
+   */
+
   return (
     <Box sx={{ px: '16px' }}>
       <Glass pad={22} floating strong>
@@ -191,7 +200,7 @@ function HeroCard({
         ) : noPair ? (
           // Empty state: no active pair
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Chip tone="accent">DUE TODAY</Chip>
+            <Chip tone="accent">GET STARTED</Chip>
             <BigWord size={38} color={tokens.color.inkSoft}>
               Pick a language pair to start
             </BigWord>
@@ -202,7 +211,7 @@ function HeroCard({
         ) : allCaughtUp ? (
           // Empty state: nothing due
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Chip tone="accent">TODAY</Chip>
+            <Chip tone="accent">ALL DONE</Chip>
             <BigWord size={52} color={tokens.color.ok}>
               All caught up!
             </BigWord>


### PR DESCRIPTION
## Summary

- Hero chip label now follows **Option A** (state-specific labels) consistently across all three HeroCard states
- No active pair → **GET STARTED** (invites user to onboard)
- Words due today → **DUE TODAY** (primary action prompt — unchanged)
- All words caught up → **ALL DONE** (positive reinforcement, was **TODAY**)
- Rule is documented in a comment block above the `return` statement

## Changes

- `src/features/dashboard/components/DashboardScreen.tsx` — updated chip labels + added rule comment
- `src/features/dashboard/components/DashboardScreen.test.tsx` — added 3 tests covering each chip state

## Testing

- All 25 DashboardScreen unit tests pass (3 new chip label tests added)
- lint, format:check, tsc, build all pass
- All 14 E2E tests pass

## Review

- Code review passed (no architectural concerns, pure label copy change with comment)

Closes #197