### PR TITLE
refactor: make all UserSettings fields required, centralise defaults (#199)

### DIFF
--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -17,6 +17,7 @@ import type { AppTab } from './components/composites'
 import { useServiceWorker } from './hooks/useServiceWorker'
 import { useInstallPrompt } from './hooks/useInstallPrompt'
 import type { LanguagePair, UserSettings } from './types'
+import { defaultUserSettings } from './types'
 
 /**
  * Inner app component that consumes the storage context.
@@ -66,14 +67,10 @@ function AppContent(): React.JSX.Element {
    */
   const [quizAutoStart, setQuizAutoStart] = useState(false)
 
-  const [settings, setSettings] = useState<UserSettings>({
-    activePairId: null,
-    quizMode: 'type',
-    dailyGoal: 20,
-    theme: 'system',
-    typoTolerance: 1,
-    selectedLevels: [],
-  })
+  // defaultUserSettings provides the full guaranteed shape before storage.getSettings()
+  // resolves asynchronously. All four formerly-optional fields now have explicit defaults
+  // here, so consumers never see undefined during the async loading window.
+  const [settings, setSettings] = useState<UserSettings>(defaultUserSettings)
 
   // Load settings on mount.
   useEffect(() => {

--- a/src/features/dashboard/components/DashboardScreen.test.tsx
+++ b/src/features/dashboard/components/DashboardScreen.test.tsx
@@ -32,6 +32,9 @@ const defaultSettings: UserSettings = {
   typoTolerance: 1,
   selectedLevels: [],
   displayName: null,
+  soundEffects: false,
+  autoPlayPronunciation: false,
+  showHintTimeout: 10,
 }
 
 const activePair: LanguagePair = {

--- a/src/features/settings/components/SettingsScreen.tsx
+++ b/src/features/settings/components/SettingsScreen.tsx
@@ -388,14 +388,15 @@ export function SettingsScreen({
 
   // ── Derived values ───────────────────────────────────────────────────────────
 
-  const displayName = settings.displayName ?? null
+  // All four fields are now required on UserSettings — no ?? fallbacks needed.
+  const {
+    displayName,
+    soundEffects,
+    autoPlayPronunciation,
+    showHintTimeout: showHintSeconds,
+  } = settings
   const avatarInitial = displayName ? displayName.charAt(0).toUpperCase() : 'L'
   const profileName = displayName ?? 'Lexio user'
-  const soundEffects = settings.soundEffects ?? false
-  const autoPlayPronunciation = settings.autoPlayPronunciation ?? false
-
-  // showHintTimeout: stored as number of seconds; 0 means "Off"
-  const showHintSeconds = settings.showHintTimeout ?? 10
   const showHintLabel = SHOW_HINT_LABELS[String(showHintSeconds)] ?? `After ${showHintSeconds}s`
 
   // ── Sub-screen navigation ────────────────────────────────────────────────────

--- a/src/services/storage/LocalStorageService.test.ts
+++ b/src/services/storage/LocalStorageService.test.ts
@@ -187,6 +187,10 @@ describe('LocalStorageService', () => {
       expect(settings.dailyGoal).toBe(20)
       expect(settings.theme).toBe('dark')
       expect(settings.typoTolerance).toBe(1)
+      expect(settings.displayName).toBeNull()
+      expect(settings.soundEffects).toBe(false)
+      expect(settings.autoPlayPronunciation).toBe(false)
+      expect(settings.showHintTimeout).toBe(10)
     })
 
     it('should persist and retrieve custom settings', async () => {
@@ -198,10 +202,36 @@ describe('LocalStorageService', () => {
         typoTolerance: 2,
         selectedLevels: ['B1', 'B2'],
         displayName: null,
+        soundEffects: false,
+        autoPlayPronunciation: false,
+        showHintTimeout: 10,
       }
       await service.saveSettings(settings)
       const retrieved = await service.getSettings()
       expect(retrieved).toEqual(settings)
+    })
+
+    it('should back-fill missing fields from legacy stored settings', async () => {
+      // Simulate a legacy snapshot that predates soundEffects/autoPlayPronunciation/showHintTimeout.
+      // These fields were previously optional, so old localStorage data won't have them.
+      const legacy = {
+        activePairId: null,
+        quizMode: 'type',
+        dailyGoal: 30,
+        theme: 'light',
+        typoTolerance: 0,
+        selectedLevels: [],
+        displayName: null,
+      }
+      localStorage.setItem('lexio:settings', JSON.stringify(legacy))
+      const settings = await service.getSettings()
+      // Stored values are preserved
+      expect(settings.quizMode).toBe('type')
+      expect(settings.dailyGoal).toBe(30)
+      // Absent fields are filled from defaultUserSettings
+      expect(settings.soundEffects).toBe(false)
+      expect(settings.autoPlayPronunciation).toBe(false)
+      expect(settings.showHintTimeout).toBe(10)
     })
   })
 
@@ -308,6 +338,9 @@ describe('LocalStorageService', () => {
         typoTolerance: 0,
         selectedLevels: [],
         displayName: null,
+        soundEffects: false,
+        autoPlayPronunciation: false,
+        showHintTimeout: 10,
       }
       const dailyStats: DailyStats = {
         date: '2026-03-01',
@@ -374,6 +407,10 @@ describe('LocalStorageService', () => {
         theme: 'light',
         typoTolerance: 1,
         selectedLevels: [],
+        displayName: null,
+        soundEffects: false,
+        autoPlayPronunciation: false,
+        showHintTimeout: 10,
       })
       // Add a non-lexio key to ensure it survives
       localStorage.setItem('other-app:key', 'should-survive')
@@ -400,6 +437,9 @@ describe('LocalStorageService', () => {
         typoTolerance: 1,
         selectedLevels: [],
         displayName: null,
+        soundEffects: false,
+        autoPlayPronunciation: false,
+        showHintTimeout: 10,
       })
     })
 

--- a/src/services/storage/LocalStorageService.ts
+++ b/src/services/storage/LocalStorageService.ts
@@ -1,5 +1,6 @@
 import type { StorageService } from './StorageService'
 import type { LanguagePair, Word, WordProgress, UserSettings, DailyStats } from '@/types'
+import { defaultUserSettings } from '@/types'
 
 const KEYS = {
   LANGUAGE_PAIRS: 'lexio:language-pairs',
@@ -8,16 +9,6 @@ const KEYS = {
   SETTINGS: 'lexio:settings',
   DAILY_STATS_PREFIX: 'lexio:daily-stats:',
 } as const
-
-const DEFAULT_SETTINGS: UserSettings = {
-  activePairId: null,
-  quizMode: 'mixed',
-  dailyGoal: 20,
-  theme: 'dark',
-  typoTolerance: 1,
-  selectedLevels: [],
-  displayName: null,
-}
 
 function readJson<T>(key: string): T | null {
   const raw = localStorage.getItem(key)
@@ -141,9 +132,11 @@ export class LocalStorageService implements StorageService {
 
   async getSettings(): Promise<UserSettings> {
     const stored = readJson<Partial<UserSettings>>(KEYS.SETTINGS)
-    if (stored === null) return DEFAULT_SETTINGS
-    // Migrate existing settings that predate the selectedLevels field.
-    return { ...DEFAULT_SETTINGS, ...stored }
+    if (stored === null) return defaultUserSettings
+    // Spread-merge so any field absent from a legacy serialised snapshot falls
+    // back to the canonical default. This handles all past and future migrations
+    // without a version bump — new required fields simply pick up their default.
+    return { ...defaultUserSettings, ...stored }
   }
 
   async saveSettings(settings: UserSettings): Promise<void> {

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -66,6 +66,10 @@ export function createMockSettings(overrides: Partial<UserSettings> = {}): UserS
     theme: 'dark',
     typoTolerance: 1,
     selectedLevels: [],
+    displayName: null,
+    soundEffects: false,
+    autoPlayPronunciation: false,
+    showHintTimeout: 10,
     ...overrides,
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,27 +58,52 @@ export interface UserSettings {
    */
   readonly selectedLevels: readonly CefrLevel[]
   /**
-   * Optional display name for the avatar placeholder.
+   * Display name for the avatar placeholder.
    * Null means not set — the app falls back to the initial "L" for Lexio.
    * This is a placeholder for future auth integration.
    */
-  readonly displayName?: string | null
+  readonly displayName: string | null
   /**
    * Sound effects toggle — whether UI sound effects are enabled.
    * Defaults to false (no sounds in MVP). Persisted via StorageService.
    */
-  readonly soundEffects?: boolean
+  readonly soundEffects: boolean
   /**
    * Auto-play pronunciation toggle — whether to auto-play audio after each answer.
    * TTS implementation is out of scope for MVP; only the preference is stored.
    */
-  readonly autoPlayPronunciation?: boolean
+  readonly autoPlayPronunciation: boolean
   /**
    * Show hint timeout in seconds — how long to wait before showing the hint during quiz.
    * 0 means "Off" (never show hint). Defaults to 10.
    * Valid values: 0, 5, 10, 15, 30.
    */
-  readonly showHintTimeout?: number
+  readonly showHintTimeout: number
+}
+
+/**
+ * Canonical default values for all UserSettings fields.
+ *
+ * Single source of truth used by:
+ *   - AppContent initial state (before async storage.getSettings() resolves)
+ *   - LocalStorageService.getSettings() migration spread
+ *   - Test fixtures via createMockSettings()
+ *
+ * Keeping defaults here prevents the "double source of truth" problem: any
+ * new field added to UserSettings must also appear here, and TypeScript will
+ * enforce it because UserSettings is now fully required.
+ */
+export const defaultUserSettings: UserSettings = {
+  activePairId: null,
+  quizMode: 'mixed',
+  dailyGoal: 20,
+  theme: 'dark',
+  typoTolerance: 1,
+  selectedLevels: [],
+  displayName: null,
+  soundEffects: false,
+  autoPlayPronunciation: false,
+  showHintTimeout: 10,
 }
 
 export interface DailyStats {


### PR DESCRIPTION
## Summary

Applies **Option A** from issue #199: all four previously-optional `UserSettings` fields are now required, with a single exported `defaultUserSettings` constant serving as the canonical source of truth for defaults.

## Shape decision

**Option A chosen.** Rationale: explicit required fields give TypeScript a guaranteed shape at every consumer, eliminate `?.` fallback chains in `SettingsScreen`, and prevent future fields from being silently omitted from initial state. The migration spread in `getSettings()` already handles legacy localStorage data without a version bump.

## Changes

- **`src/types/index.ts`** — Drop `?` from `displayName`, `soundEffects`, `autoPlayPronunciation`, `showHintTimeout`; export `defaultUserSettings` constant
- **`src/services/storage/LocalStorageService.ts`** — Remove local `DEFAULT_SETTINGS`; import and use `defaultUserSettings`; update migration comment
- **`src/AppContent.tsx`** — Replace inline 6-field initial state with `defaultUserSettings`; add comment explaining async loading pattern
- **`src/features/settings/components/SettingsScreen.tsx`** — Remove `??` fallback chains for all 4 formerly-optional fields
- **`src/test/fixtures.ts`** — Add 4 required fields to `createMockSettings()`
- **`src/services/storage/LocalStorageService.test.ts`** — Add assertions for new fields; add legacy migration test
- **`src/features/dashboard/components/DashboardScreen.test.tsx`** — Fix inline `defaultSettings` fixture

## Testing

- All 1225 unit tests pass
- All 14 E2E tests pass
- `npm run lint` clean (0 errors)
- `npm run format:check` clean
- `npx tsc --noEmit` clean
- `npm run build` succeeds

## Review

Code review passed — see issue comments.

Closes #199