### PR TITLE
feat: calibrate MINUTES_PER_WORD from real session data (#198)

### DIFF
--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -211,6 +211,7 @@ function AppContent(): React.JSX.Element {
                 activePair={activePair}
                 settings={settings}
                 todayStats={dashboardData.todayStats}
+                recentStats={dashboardData.recentStats}
                 wordProgressList={dashboardData.wordProgressList}
                 words={dashboardData.words}
                 totalWords={dashboardData.totalWords}

--- a/src/features/dashboard/components/DashboardScreen.test.tsx
+++ b/src/features/dashboard/components/DashboardScreen.test.tsx
@@ -94,6 +94,7 @@ function buildProps(overrides: Partial<DashboardScreenProps> = {}): DashboardScr
     activePair,
     settings: defaultSettings,
     todayStats: null,
+    recentStats: [],
     wordProgressList: [],
     words: [],
     totalWords: 0,

--- a/src/features/dashboard/components/DashboardScreen.tsx
+++ b/src/features/dashboard/components/DashboardScreen.tsx
@@ -32,14 +32,12 @@ import { SectionHeader } from '@/components/composites/SectionHeader'
 import { getGlassTokens, glassTypography } from '@/theme/liquidGlass'
 import { useTheme } from '@mui/material/styles'
 import { useWordOfTheDay } from '../hooks/useWordOfTheDay'
+import { useMinutesPerWord } from '../hooks/useMinutesPerWord'
 import { speak } from '@/utils/tts'
 import { MASTERED_THRESHOLD } from '@/features/words/buckets'
 import { computeDueCount } from '@/features/words/utils/dueWords'
 
 // ─── Constants ────────────────────────────────────────────────────────────────
-
-/** Approx. minutes per word for the "≈ Nmin" subtext estimate. */
-const MINUTES_PER_WORD = 0.5
 
 /** Bottom spacer height in px, per design spec. */
 const BOTTOM_SPACER_PX = 140
@@ -53,6 +51,8 @@ export interface DashboardScreenProps {
   readonly settings: UserSettings
   /** Today's daily stats (null if no session today). */
   readonly todayStats: DailyStats | null
+  /** Recent daily stats used to compute the rolling minutes-per-word estimate. */
+  readonly recentStats: readonly DailyStats[]
   /** Progress records for all words in the active pair. */
   readonly wordProgressList: readonly WordProgress[]
   /** All words in the active pair (needed for Word of the Day). */
@@ -157,6 +157,8 @@ interface HeroCardProps {
   readonly dueCount: number
   readonly wordsReviewedToday: number
   readonly dailyGoal: number
+  /** Calibrated rolling average of minutes per word (falls back to 0.5 when no data). */
+  readonly minutesPerWord: number
   readonly loading: boolean
   readonly onStartQuiz: () => void
 }
@@ -166,6 +168,7 @@ function HeroCard({
   dueCount,
   wordsReviewedToday,
   dailyGoal,
+  minutesPerWord,
   loading,
   onStartQuiz,
 }: HeroCardProps): React.JSX.Element {
@@ -173,7 +176,7 @@ function HeroCard({
   const tokens = getGlassTokens(theme.palette.mode)
 
   const progressValue = dailyGoal > 0 ? Math.min(1, wordsReviewedToday / dailyGoal) : 0
-  const estimatedMinutes = Math.round(dueCount * MINUTES_PER_WORD)
+  const estimatedMinutes = Math.round(dueCount * minutesPerWord)
   const noPair = activePair === null
   const allCaughtUp = !noPair && dueCount === 0
 
@@ -558,6 +561,7 @@ export function DashboardScreen({
   activePair,
   settings,
   todayStats,
+  recentStats,
   wordProgressList,
   words,
   totalWords,
@@ -579,6 +583,9 @@ export function DashboardScreen({
   const masteredCount = useMemo(() => computeMasteredCount(wordProgressList), [wordProgressList])
 
   const accuracy = useMemo(() => computeAccuracy(todayStats), [todayStats])
+
+  // Rolling minutes-per-word estimate — calibrated from actual session history.
+  const minutesPerWord = useMinutesPerWord(recentStats)
 
   const { word: wotdWord } = useWordOfTheDay(
     dateKey,
@@ -622,6 +629,7 @@ export function DashboardScreen({
           dueCount={dueCount}
           wordsReviewedToday={wordsReviewedToday}
           dailyGoal={settings.dailyGoal}
+          minutesPerWord={minutesPerWord}
           loading={loading}
           onStartQuiz={onStartQuiz}
         />

--- a/src/features/dashboard/hooks/useMinutesPerWord.test.ts
+++ b/src/features/dashboard/hooks/useMinutesPerWord.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import type { DailyStats } from '@/types'
+import { computeMinutesPerWord, DEFAULT_MINUTES_PER_WORD } from './useMinutesPerWord'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeDay(
+  date: string,
+  wordsReviewed: number,
+  durationMs?: number,
+  correct = wordsReviewed,
+): DailyStats {
+  return {
+    date,
+    wordsReviewed,
+    correctCount: correct,
+    incorrectCount: wordsReviewed - correct,
+    streakDays: 1,
+    ...(durationMs !== undefined ? { durationMs } : {}),
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('computeMinutesPerWord', () => {
+  it('should return DEFAULT_MINUTES_PER_WORD when given an empty array', () => {
+    expect(computeMinutesPerWord([])).toBe(DEFAULT_MINUTES_PER_WORD)
+  })
+
+  it('should return DEFAULT_MINUTES_PER_WORD when no days have durationMs', () => {
+    const stats: DailyStats[] = [makeDay('2026-04-01', 10), makeDay('2026-04-02', 20)]
+    expect(computeMinutesPerWord(stats)).toBe(DEFAULT_MINUTES_PER_WORD)
+  })
+
+  it('should return DEFAULT_MINUTES_PER_WORD when durationMs is 0', () => {
+    const stats: DailyStats[] = [makeDay('2026-04-01', 10, 0)]
+    expect(computeMinutesPerWord(stats)).toBe(DEFAULT_MINUTES_PER_WORD)
+  })
+
+  it('should return DEFAULT_MINUTES_PER_WORD when wordsReviewed is 0', () => {
+    const stats: DailyStats[] = [makeDay('2026-04-01', 0, 60_000)]
+    expect(computeMinutesPerWord(stats)).toBe(DEFAULT_MINUTES_PER_WORD)
+  })
+
+  it('should compute correct minutes-per-word from a single day', () => {
+    // 10 words in 5 minutes (300 000 ms) = 0.5 min/word
+    const stats: DailyStats[] = [makeDay('2026-04-01', 10, 300_000)]
+    expect(computeMinutesPerWord(stats)).toBeCloseTo(0.5, 5)
+  })
+
+  it('should compute correct rolling average across multiple days', () => {
+    // Day 1: 10 words in 5 min  →  300 000 ms
+    // Day 2: 20 words in 6 min  →  360 000 ms
+    // Total: 30 words in 11 min  →  avg = 11/30 ≈ 0.3667 min/word
+    const stats: DailyStats[] = [
+      makeDay('2026-04-01', 10, 300_000),
+      makeDay('2026-04-02', 20, 360_000),
+    ]
+    const expected = (300_000 + 360_000) / 30 / 60_000
+    expect(computeMinutesPerWord(stats)).toBeCloseTo(expected, 5)
+  })
+
+  it('should skip days missing durationMs and include only timed days', () => {
+    // Day 1: no durationMs (pre-feature data) — must be skipped
+    // Day 2: 10 words in 5 min → 0.5 min/word
+    const stats: DailyStats[] = [
+      makeDay('2026-04-01', 15), // no durationMs
+      makeDay('2026-04-02', 10, 300_000), // timed
+    ]
+    expect(computeMinutesPerWord(stats)).toBeCloseTo(0.5, 5)
+  })
+
+  it('should handle a single very fast session (10 s total for 10 words = 0.0167 min/word)', () => {
+    const stats: DailyStats[] = [makeDay('2026-04-01', 10, 10_000)]
+    expect(computeMinutesPerWord(stats)).toBeCloseTo(10_000 / 10 / 60_000, 5)
+  })
+
+  it('should return DEFAULT_MINUTES_PER_WORD as a fallback value of 0.5', () => {
+    expect(DEFAULT_MINUTES_PER_WORD).toBe(0.5)
+  })
+})

--- a/src/features/dashboard/hooks/useMinutesPerWord.ts
+++ b/src/features/dashboard/hooks/useMinutesPerWord.ts
@@ -1,0 +1,70 @@
+/**
+ * useMinutesPerWord - computes a rolling average of minutes-per-word from
+ * recent session history.
+ *
+ * Uses the last ROLLING_SESSION_DAYS days of DailyStats. Each day's entry
+ * contributes to the aggregate only when both durationMs and wordsReviewed
+ * are present and non-zero (older entries that predate the durationMs field
+ * are silently skipped to preserve backward compatibility).
+ *
+ * Falls back to DEFAULT_MINUTES_PER_WORD when there is insufficient data
+ * (e.g. first launch, new language pair, or no timed sessions yet).
+ */
+
+import { useMemo } from 'react'
+import type { DailyStats } from '@/types'
+
+/** Number of recent days to include in the rolling average. */
+export const ROLLING_SESSION_DAYS = 10
+
+/**
+ * Fallback estimate used when no timed session data is available.
+ * 0.5 min (30 s) per word is a reasonable first-launch guess.
+ */
+export const DEFAULT_MINUTES_PER_WORD = 0.5
+
+/**
+ * Computes a rolling minutes-per-word estimate from an array of DailyStats.
+ *
+ * Pure function — exposed for unit testing without React.
+ *
+ * @param recentStats - DailyStats records (order and count determined by caller).
+ * @returns Minutes per word, or DEFAULT_MINUTES_PER_WORD when data is absent.
+ */
+export function computeMinutesPerWord(recentStats: readonly DailyStats[]): number {
+  let totalMs = 0
+  let totalWords = 0
+
+  for (const day of recentStats) {
+    if (day.durationMs !== undefined && day.durationMs > 0 && day.wordsReviewed > 0) {
+      totalMs += day.durationMs
+      totalWords += day.wordsReviewed
+    }
+  }
+
+  if (totalWords === 0) return DEFAULT_MINUTES_PER_WORD
+
+  return totalMs / totalWords / 60_000
+}
+
+/**
+ * React hook that memoises the minutes-per-word estimate.
+ *
+ * @param recentStats - DailyStats for the last ROLLING_SESSION_DAYS days,
+ *                      as returned by useDashboard / storage.getRecentDailyStats.
+ */
+export function useMinutesPerWord(recentStats: readonly DailyStats[]): number {
+  // Stable serialised key so the memoisation responds to value changes, not
+  // reference changes (the dashboard re-fetches produce new array instances).
+  const statsKey = recentStats
+    .slice(0, ROLLING_SESSION_DAYS)
+    .map((s) => `${s.date}:${s.durationMs ?? ''}:${s.wordsReviewed}`)
+    .join('|')
+
+  return useMemo(
+    () => computeMinutesPerWord(recentStats.slice(0, ROLLING_SESSION_DAYS)),
+    // statsKey is a compact, stable representation of the relevant slice.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [statsKey],
+  )
+}

--- a/src/features/quiz/components/ActiveQuizView.tsx
+++ b/src/features/quiz/components/ActiveQuizView.tsx
@@ -20,12 +20,14 @@ interface ActiveQuizViewProps {
   readonly sessionLevels?: readonly CefrLevel[]
   /**
    * Called once when the session transitions to 'finished'.
-   * Receives the final wordsReviewed, correctCount, and bestSessionStreak.
+   * Receives the final wordsReviewed, correctCount, bestSessionStreak, and
+   * durationMs (wall-clock time from 'question' phase start to 'finished').
    */
   readonly onSessionFinished: (
     wordsReviewed: number,
     correctCount: number,
     bestSessionStreak: number,
+    durationMs: number,
   ) => void
 }
 
@@ -44,9 +46,19 @@ export function ActiveQuizView({
   const onFinishedRef = useRef(onSessionFinished)
   onFinishedRef.current = onSessionFinished
 
+  // Wall-clock start time, recorded when the first question phase begins.
+  // Used to compute durationMs passed to updateDailyStatsAfterSession for
+  // rolling minutes-per-word calibration.
+  const sessionStartMs = useRef<number | null>(null)
+
   useEffect(() => {
+    if (phase === 'question' && sessionStartMs.current === null) {
+      sessionStartMs.current = Date.now()
+    }
+
     if (phase === 'finished') {
-      onFinishedRef.current(wordsCompleted, correctCount, bestSessionStreak)
+      const durationMs = sessionStartMs.current !== null ? Date.now() - sessionStartMs.current : 0
+      onFinishedRef.current(wordsCompleted, correctCount, bestSessionStreak, durationMs)
     }
     // wordsCompleted, correctCount, and bestSessionStreak are stable at the moment
     // phase becomes 'finished', so including them is correct and avoids stale reads.

--- a/src/features/quiz/components/QuizHub.tsx
+++ b/src/features/quiz/components/QuizHub.tsx
@@ -199,7 +199,12 @@ export function QuizHub({
   }, [wordsReviewedToday, settings.dailyGoal])
 
   const handleSessionFinished = useCallback(
-    (wordsReviewed: number, correctCount: number, bestSessionStreak: number): void => {
+    (
+      wordsReviewed: number,
+      correctCount: number,
+      bestSessionStreak: number,
+      durationMs: number,
+    ): void => {
       setSessionResult({ wordsReviewed, correctCount, bestSessionStreak })
       // Notify parent about the completed session (used for install-banner engagement tracking).
       onSessionComplete?.(wordsReviewed)
@@ -210,6 +215,7 @@ export function QuizHub({
         wordsReviewed,
         correctCount,
         settings.dailyGoal,
+        durationMs,
       ).then(setStreakDays)
 
       // Calculate post-session total for today.

--- a/src/services/spacedRepetition.ts
+++ b/src/services/spacedRepetition.ts
@@ -356,6 +356,8 @@ async function updateDailyStats(
     incorrectCount: (existing?.incorrectCount ?? 0) + (correct ? 0 : 1),
     // streakDays is managed separately (based on daily goal completion)
     streakDays: existing?.streakDays ?? 0,
+    // Preserve durationMs if it was already set by the session-end path
+    ...(existing?.durationMs !== undefined ? { durationMs: existing.durationMs } : {}),
   }
 
   await storage.saveDailyStats(updated)

--- a/src/services/streakService.ts
+++ b/src/services/streakService.ts
@@ -161,6 +161,9 @@ export function calculateBestStreak(
  * @param wordsReviewed - Words reviewed in the completed session.
  * @param correctCount  - Correct answers in the completed session.
  * @param dailyGoal     - Minimum words per day for the goal to be met.
+ * @param durationMs    - Session wall-clock duration in milliseconds (for
+ *                        rolling minutes-per-word calibration). Accumulated
+ *                        across sessions within the same day.
  * @returns The updated streak count for today.
  */
 export async function updateDailyStatsAfterSession(
@@ -168,6 +171,7 @@ export async function updateDailyStatsAfterSession(
   wordsReviewed: number,
   correctCount: number,
   dailyGoal: number,
+  durationMs?: number,
 ): Promise<number> {
   const today = todayDateString()
 
@@ -177,6 +181,9 @@ export async function updateDailyStatsAfterSession(
   const updatedWordsReviewed = (existing?.wordsReviewed ?? 0) + wordsReviewed
   const updatedCorrect = (existing?.correctCount ?? 0) + correctCount
   const updatedIncorrect = (existing?.incorrectCount ?? 0) + (wordsReviewed - correctCount)
+  // Accumulate duration across sessions on the same day.
+  const updatedDurationMs =
+    durationMs !== undefined ? (existing?.durationMs ?? 0) + durationMs : existing?.durationMs
 
   // Fetch enough history to compute current streak.
   const recentStats = await storage.getRecentDailyStats(STREAK_SCAN_DAYS)
@@ -189,6 +196,7 @@ export async function updateDailyStatsAfterSession(
     correctCount: updatedCorrect,
     incorrectCount: updatedIncorrect,
     streakDays: 0, // placeholder - filled below
+    ...(updatedDurationMs !== undefined ? { durationMs: updatedDurationMs } : {}),
   }
   statsMap.set(today, todayEntry)
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -112,6 +112,12 @@ export interface DailyStats {
   readonly correctCount: number
   readonly incorrectCount: number
   readonly streakDays: number
+  /**
+   * Total time spent reviewing in milliseconds for this day.
+   * Optional for backward compatibility with records written before this field
+   * was added. Missing means the session was not timed (pre-feature data).
+   */
+  readonly durationMs?: number
 }
 
 export interface StarterPack {


### PR DESCRIPTION
## Summary

- Instruments session wall-clock timing in `ActiveQuizView` (start on first question, capture on finished)
- Persists `durationMs` in `DailyStats` via `updateDailyStatsAfterSession` (accumulated per day)
- Replaces the hard-coded `MINUTES_PER_WORD = 0.5` constant in `DashboardScreen` with a rolling 10-day average computed by the new `useMinutesPerWord` hook
- Falls back to `DEFAULT_MINUTES_PER_WORD = 0.5` when no timed session data exists (first launch / new pair)

## Prerequisite check

**Session duration was not previously tracked.** This PR implements both the prerequisite (instrument timing → persist `durationMs`) and the main feature (rolling average) atomically, eliminating the need for a separate prerequisite issue.

## Changes

- `src/types/index.ts` — add optional `durationMs?: number` to `DailyStats` (backward compat)
- `src/services/streakService.ts` — `updateDailyStatsAfterSession` accumulates `durationMs`
- `src/services/spacedRepetition.ts` — `updateDailyStats` (per-attempt path) preserves `durationMs`
- `src/features/quiz/components/ActiveQuizView.tsx` — track session start/end, pass `durationMs` to `onSessionFinished`
- `src/features/quiz/components/QuizHub.tsx` — forward `durationMs` to `updateDailyStatsAfterSession`
- `src/features/dashboard/hooks/useMinutesPerWord.ts` — new hook + `computeMinutesPerWord` pure fn
- `src/features/dashboard/hooks/useMinutesPerWord.test.ts` — 9 unit tests (new file)
- `src/features/dashboard/components/DashboardScreen.tsx` — remove constant, use `useMinutesPerWord`
- `src/features/dashboard/components/DashboardScreen.test.tsx` — add `recentStats: []` to `buildProps`
- `src/AppContent.tsx` — pass `recentStats` to `DashboardScreen`

## Testing

- 9 new unit tests covering all branches of `computeMinutesPerWord`
- 1237/1237 unit tests pass
- 14/14 E2E tests pass
- TypeScript strict, zero lint errors, prettier clean, production build succeeds

## Review

Code review passed — no blocking findings.

Closes #198