### PR TITLE
feat: add /about page with Built by AI story and stats (#125)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { createAppTheme } from './theme'
 import { LocalStorageService } from './services/storage'
 import { StorageContext } from './hooks/useStorage'
 import { LandingPage } from './features/landing'
+import { AboutPage } from './features/about'
 import { Sentry } from './services/sentry'
 import { BrandedLoader } from './components/BrandedLoader'
 import { useAnalytics } from './hooks/useAnalytics'
@@ -79,6 +80,19 @@ function LandingThemeWrapper(): React.JSX.Element {
 }
 
 /**
+ * Theme wrapper for the about page route.
+ * Uses the same dark theme as the landing page for visual consistency.
+ */
+function AboutThemeWrapper(): React.JSX.Element {
+  return (
+    <ThemeProvider theme={landingDarkTheme}>
+      <CssBaseline />
+      <AboutPage />
+    </ThemeProvider>
+  )
+}
+
+/**
  * Inner component mounted inside HashRouter so that useAnalytics can
  * access window.location.hash after the router initialises.
  */
@@ -96,6 +110,9 @@ export default function App() {
           <Routes>
             {/* Landing page — shown at the root hash route */}
             <Route path="/" element={<LandingThemeWrapper />} />
+
+            {/* About page — "Built by AI" story and dev stats for tech/GitHub visitors */}
+            <Route path="/about" element={<AboutThemeWrapper />} />
 
             {/* Main app — lazy-loaded so the bundle is not fetched on landing page visits */}
             <Route

--- a/src/features/about/AboutPage.test.tsx
+++ b/src/features/about/AboutPage.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '@mui/material'
+import { createAppTheme } from '@/theme'
+import { AboutPage } from './AboutPage'
+
+const darkTheme = createAppTheme('dark')
+
+function renderAboutPage() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider theme={darkTheme}>
+        <AboutPage />
+      </ThemeProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('AboutPage', () => {
+  it('should render the main heading', () => {
+    renderAboutPage()
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      /one person.*zero hand-written code/i,
+    )
+  })
+
+  it('should render the "How it was built" chip label', () => {
+    renderAboutPage()
+    expect(screen.getByText(/how it was built/i)).toBeInTheDocument()
+  })
+
+  it('should render the AI experiment description', () => {
+    renderAboutPage()
+    expect(screen.getByText(/autonomous ai agents/i)).toBeInTheDocument()
+  })
+
+  it('should render the Product Architect card', () => {
+    renderAboutPage()
+    expect(screen.getByText(/product architect/i)).toBeInTheDocument()
+  })
+
+  it('should render the Agent Team card', () => {
+    renderAboutPage()
+    expect(screen.getByText(/agent team/i)).toBeInTheDocument()
+  })
+
+  it('should render dev stats with labels', () => {
+    renderAboutPage()
+    // Use getAllByText because "GitHub issues" also appears in the Product Architect card body text
+    expect(screen.getAllByText(/github issues/i).length).toBeGreaterThan(0)
+    expect(screen.getByText(/prs merged/i)).toBeInTheDocument()
+    expect(screen.getByText(/human-written lines/i)).toBeInTheDocument()
+  })
+
+  it('should render a "Back to Lexio" navigation link pointing to /', () => {
+    renderAboutPage()
+    const backLink = screen.getByRole('link', { name: /back to lexio/i })
+    expect(backLink).toBeInTheDocument()
+    expect(backLink).toHaveAttribute('href', '/')
+  })
+
+  it('should render a GitHub link in the footer', () => {
+    renderAboutPage()
+    const githubLink = screen.getByRole('link', { name: /github/i })
+    expect(githubLink).toBeInTheDocument()
+    expect(githubLink).toHaveAttribute('href', 'https://github.com/mreppo/lexio')
+  })
+
+  it('should render the zero human-written lines stat', () => {
+    renderAboutPage()
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+})

--- a/src/features/about/AboutPage.tsx
+++ b/src/features/about/AboutPage.tsx
@@ -1,0 +1,197 @@
+import { Box, Chip, Container, Grid2 as Grid, Link, Paper, Stack, Typography } from '@mui/material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import GitHubIcon from '@mui/icons-material/GitHub'
+import { Link as RouterLink } from 'react-router-dom'
+
+/** Public GitHub repo URL for this project. */
+const GITHUB_URL = 'https://github.com/mreppo/lexio'
+
+/**
+ * Dev stats to display on the About page.
+ * Keep these as named constants so they are easy to update in one place.
+ */
+const DEV_STATS: ReadonlyArray<{ readonly label: string; readonly value: string }> = [
+  { label: 'GitHub issues', value: '182+' },
+  { label: 'PRs merged', value: '182+' },
+  { label: 'Human-written lines', value: '0' },
+]
+
+/**
+ * The "Built by AI" story section, explaining the experiment
+ * of building an app with autonomous AI agents.
+ */
+function AiStorySection(): React.JSX.Element {
+  return (
+    <Box component="section" sx={{ py: { xs: 6, md: 8 } }}>
+      <Container maxWidth="md">
+        <Box sx={{ textAlign: 'center', mb: 6 }}>
+          <Chip
+            label="How it was built"
+            size="small"
+            sx={{
+              mb: 3,
+              background: 'rgba(245,158,11,0.12)',
+              color: 'primary.main',
+              borderColor: 'primary.main',
+              border: '1px solid',
+            }}
+          />
+          <Typography component="h1" variant="h4" sx={{ fontWeight: 700, mb: 2 }}>
+            One person. Zero hand-written code.
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{ color: 'text.secondary', maxWidth: 540, mx: 'auto', lineHeight: 1.8 }}
+          >
+            Lexio is an experiment: what happens when you apply autonomous AI agents to the full
+            software development lifecycle?
+          </Typography>
+        </Box>
+
+        <Grid container spacing={3} sx={{ mb: 6 }}>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Paper
+              elevation={0}
+              sx={{
+                p: 3,
+                height: '100%',
+                borderRadius: 3,
+                border: '1px solid',
+                borderColor: 'divider',
+                background: 'rgba(255,255,255,0.02)',
+              }}
+            >
+              <Typography
+                component="h2"
+                variant="subtitle1"
+                sx={{ fontWeight: 700, mb: 1.5, color: 'primary.main' }}
+              >
+                Product Architect
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.7 }}>
+                A single person defines requirements and user stories in Claude Chat. They describe
+                features, acceptance criteria, and product direction — then create GitHub issues.
+              </Typography>
+            </Paper>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Paper
+              elevation={0}
+              sx={{
+                p: 3,
+                height: '100%',
+                borderRadius: 3,
+                border: '1px solid',
+                borderColor: 'divider',
+                background: 'rgba(255,255,255,0.02)',
+              }}
+            >
+              <Typography
+                component="h2"
+                variant="subtitle1"
+                sx={{ fontWeight: 700, mb: 1.5, color: 'secondary.main' }}
+              >
+                Agent Team
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.7 }}>
+                Claude CLI agents pick up issues autonomously: Developer writes the code, QA writes
+                and runs tests, Reviewer checks quality, Orchestrator opens and merges PRs.
+              </Typography>
+            </Paper>
+          </Grid>
+        </Grid>
+
+        {/* Dev stats — easy to update in DEV_STATS above */}
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 3,
+            justifyContent: 'center',
+          }}
+        >
+          {DEV_STATS.map((stat) => (
+            <Box key={stat.label} sx={{ textAlign: 'center', minWidth: 100 }}>
+              <Typography variant="h4" sx={{ fontWeight: 700, color: 'primary.main' }}>
+                {stat.value}
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                {stat.label}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </Container>
+    </Box>
+  )
+}
+
+/** Footer with GitHub link. */
+function AboutFooter(): React.JSX.Element {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        py: 4,
+        borderTop: '1px solid',
+        borderColor: 'divider',
+      }}
+    >
+      <Container maxWidth="md">
+        <Stack direction="row" justifyContent="center">
+          <Link
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.secondary' }}
+          >
+            <GitHubIcon fontSize="small" />
+            <Typography variant="body2">GitHub</Typography>
+          </Link>
+        </Stack>
+      </Container>
+    </Box>
+  )
+}
+
+/**
+ * About page rendered at /#/about.
+ * Contains the "Built by AI" story and dev stats.
+ * Targets the tech/GitHub audience — English only, no i18n needed.
+ */
+export function AboutPage(): React.JSX.Element {
+  return (
+    <Box
+      component="main"
+      sx={{
+        minHeight: '100vh',
+        background: 'linear-gradient(180deg, #0d1529 0%, #0a0f1a 40%, #0a0f1a 100%)',
+      }}
+    >
+      {/* Back navigation */}
+      <Box sx={{ pt: 3, pb: 1 }}>
+        <Container maxWidth="md">
+          <Link
+            component={RouterLink}
+            to="/"
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 0.5,
+              color: 'text.secondary',
+              textDecoration: 'none',
+              '&:hover': { color: 'text.primary' },
+            }}
+          >
+            <ArrowBackIcon fontSize="small" />
+            <Typography variant="body2">Back to Lexio</Typography>
+          </Link>
+        </Container>
+      </Box>
+
+      <AiStorySection />
+      <AboutFooter />
+    </Box>
+  )
+}

--- a/src/features/about/index.ts
+++ b/src/features/about/index.ts
@@ -1,0 +1,1 @@
+export { AboutPage } from './AboutPage'


### PR DESCRIPTION
## Summary

- Creates `src/features/about/AboutPage.tsx` — a new page with the "Built by AI" story, developer stats, a "Back to Lexio" back-link, and a GitHub footer link
- Creates `src/features/about/index.ts` barrel export
- Adds `/#/about` route in `App.tsx` wrapped in the same `landingDarkTheme` as the landing page

## Changes

- `src/features/about/AboutPage.tsx` — new About page component with `AiStorySection`, `AboutFooter`, and back navigation
- `src/features/about/index.ts` — barrel export
- `src/features/about/AboutPage.test.tsx` — 9 new unit tests
- `src/App.tsx` — `AboutThemeWrapper` component + `/about` route

## Testing

- All 1246 tests pass (1237 baseline + 9 new)
- `npm run lint` — 0 errors
- `npm run format:check` — PASS
- `npx tsc --noEmit` — 0 type errors
- `npm run build` — production build succeeds
- `npm run e2e` — 14/14 e2e tests pass

## Acceptance Criteria Verified

- [x] `/#/about` route exists and renders the AI story + stats
- [x] Page uses the same dark theme as the landing page
- [x] "Back to Lexio" link navigates to `/#/`
- [x] GitHub link present
- [x] No regressions in existing routes (`/`, `/app`)
- [x] Stats numbers in named `DEV_STATS` constant — easy to update

## Review

- Code review passed (Reviewer Agent)

Closes #125