### PR TITLE
feat: rewrite landing page messaging for language learners (#123)

### DIFF
--- a/src/features/landing/LandingPage.test.tsx
+++ b/src/features/landing/LandingPage.test.tsx
@@ -38,6 +38,16 @@ describe('LandingPage', () => {
     expect(screen.getByText(/learn vocabulary in any language/i)).toBeInTheDocument()
   })
 
+  it('should render learner-focused hero subtitle', () => {
+    renderLanding()
+    expect(screen.getByText(/a simple way to practise vocabulary every day/i)).toBeInTheDocument()
+  })
+
+  it('should not render the old tech-story subtitle', () => {
+    renderLanding()
+    expect(screen.queryByText(/built entirely by autonomous ai agents/i)).not.toBeInTheDocument()
+  })
+
   it('should render the Try it now CTA button', () => {
     renderLanding()
     expect(screen.getByRole('button', { name: /try it now/i })).toBeInTheDocument()
@@ -68,20 +78,34 @@ describe('LandingPage', () => {
     expect(screen.getByText(/works offline/i)).toBeInTheDocument()
   })
 
-  it('should render the AI story section', () => {
+  it('should not render the AI story section', () => {
     renderLanding()
-    expect(screen.getByText(/one person.*zero hand-written code/i)).toBeInTheDocument()
+    expect(screen.queryByText(/one person.*zero hand-written code/i)).not.toBeInTheDocument()
   })
 
-  it('should render footer with attribution', () => {
+  it('should not render the stats block', () => {
     renderLanding()
-    expect(screen.getByText(/built with/i)).toBeInTheDocument()
+    expect(screen.queryByText(/96\+/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/108\+/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/human-written lines/i)).not.toBeInTheDocument()
+  })
+
+  it('should render "How it was built" link in footer pointing to /#/about', () => {
+    renderLanding()
+    const link = screen.getByRole('link', { name: /how it was built/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/#/about')
   })
 
   it('should render GitHub link in footer', () => {
     renderLanding()
     const githubLinks = screen.getAllByRole('link', { name: /github/i })
     expect(githubLinks.length).toBeGreaterThan(0)
+  })
+
+  it('should render the app mockup with Latvian diacritic word', () => {
+    renderLanding()
+    expect(screen.getByText('ābols')).toBeInTheDocument()
   })
 
   it('should render the h1 heading with accessible role', () => {
@@ -92,9 +116,9 @@ describe('LandingPage', () => {
     expect(heading.textContent).toBe('Lexio')
   })
 
-  it('should render section headings for the feature and AI story sections', () => {
+  it('should render section headings for the features section', () => {
     renderLanding()
     const h2Headings = screen.getAllByRole('heading', { level: 2 })
-    expect(h2Headings.length).toBeGreaterThanOrEqual(2)
+    expect(h2Headings.length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/src/features/landing/LandingPage.tsx
+++ b/src/features/landing/LandingPage.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   Button,
   Container,
-  Chip,
   Grid2 as Grid,
   Typography,
   Link,
@@ -130,8 +129,7 @@ function HeroSection(): React.JSX.Element {
             lineHeight: 1.7,
           }}
         >
-          Built entirely by autonomous AI agents. One person defined the vision. The code wrote
-          itself.
+          A simple way to practise vocabulary every day — no account needed.
         </Typography>
 
         <Stack
@@ -316,124 +314,6 @@ function FeaturesSection(): React.JSX.Element {
   )
 }
 
-/** The "Built by AI" story section. */
-function AiStorySection(): React.JSX.Element {
-  return (
-    <Box
-      component="section"
-      sx={{
-        py: { xs: 8, md: 10 },
-        borderTop: '1px solid',
-        borderColor: 'divider',
-      }}
-    >
-      <Container maxWidth="md">
-        <Box sx={{ textAlign: 'center', mb: 6 }}>
-          <Chip
-            label="How it was built"
-            size="small"
-            sx={{
-              mb: 3,
-              background: 'rgba(245,158,11,0.12)',
-              color: 'primary.main',
-              borderColor: 'primary.main',
-              border: '1px solid',
-            }}
-          />
-          <Typography component="h2" variant="h4" sx={{ fontWeight: 700, mb: 2 }}>
-            One person. Zero hand-written code.
-          </Typography>
-          <Typography
-            variant="body1"
-            sx={{ color: 'text.secondary', maxWidth: 540, mx: 'auto', lineHeight: 1.8 }}
-          >
-            Lexio is an experiment: what happens when you apply autonomous AI agents to the full
-            software development lifecycle?
-          </Typography>
-        </Box>
-
-        <Grid container spacing={3} sx={{ mb: 6 }}>
-          <Grid size={{ xs: 12, md: 6 }}>
-            <Paper
-              elevation={0}
-              sx={{
-                p: 3,
-                height: '100%',
-                borderRadius: 3,
-                border: '1px solid',
-                borderColor: 'divider',
-                background: 'rgba(255,255,255,0.02)',
-              }}
-            >
-              <Typography
-                component="h3"
-                variant="subtitle1"
-                sx={{ fontWeight: 700, mb: 1.5, color: 'primary.main' }}
-              >
-                Product Architect
-              </Typography>
-              <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.7 }}>
-                A single person defines requirements and user stories in Claude Chat. They describe
-                features, acceptance criteria, and product direction — then create GitHub issues.
-              </Typography>
-            </Paper>
-          </Grid>
-
-          <Grid size={{ xs: 12, md: 6 }}>
-            <Paper
-              elevation={0}
-              sx={{
-                p: 3,
-                height: '100%',
-                borderRadius: 3,
-                border: '1px solid',
-                borderColor: 'divider',
-                background: 'rgba(255,255,255,0.02)',
-              }}
-            >
-              <Typography
-                component="h3"
-                variant="subtitle1"
-                sx={{ fontWeight: 700, mb: 1.5, color: 'secondary.main' }}
-              >
-                Agent Team
-              </Typography>
-              <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.7 }}>
-                Claude CLI agents pick up issues autonomously: Developer writes the code, QA writes
-                and runs tests, Reviewer checks quality, Orchestrator opens and merges PRs.
-              </Typography>
-            </Paper>
-          </Grid>
-        </Grid>
-
-        <Box
-          sx={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: 3,
-            justifyContent: 'center',
-          }}
-        >
-          {[
-            { label: 'GitHub issues', value: '96+' },
-            { label: 'PRs merged', value: '108+' },
-            { label: 'Human-written lines', value: '0' },
-          ].map((stat) => (
-            <Box key={stat.label} sx={{ textAlign: 'center', minWidth: 100 }}>
-              <Typography variant="h4" sx={{ fontWeight: 700, color: 'primary.main' }}>
-                {stat.value}
-              </Typography>
-              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                {stat.label}
-              </Typography>
-            </Box>
-          ))}
-        </Box>
-      </Container>
-    </Box>
-  )
-}
-
 /** Footer with attribution and links. */
 function FooterSection(): React.JSX.Element {
   return (
@@ -452,13 +332,14 @@ function FooterSection(): React.JSX.Element {
           alignItems="center"
           justifyContent="space-between"
         >
-          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-            Built with{' '}
-            <Link href="https://www.anthropic.com/claude" target="_blank" rel="noopener noreferrer">
-              Claude
-            </Link>{' '}
-            by Anthropic. v{__APP_VERSION__}
-          </Typography>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Link href="/#/about" sx={{ color: 'text.secondary' }}>
+              <Typography variant="body2">How it was built</Typography>
+            </Link>
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+              · v{__APP_VERSION__}
+            </Typography>
+          </Stack>
 
           <Link
             href={GITHUB_URL}
@@ -477,7 +358,7 @@ function FooterSection(): React.JSX.Element {
 
 /**
  * Landing page rendered at the root route /.
- * Shows hero, feature highlights, AI story, and footer.
+ * Shows hero, feature highlights, and footer.
  * Does NOT include the app bar or bottom nav.
  */
 export function LandingPage(): React.JSX.Element {
@@ -491,7 +372,6 @@ export function LandingPage(): React.JSX.Element {
     >
       <HeroSection />
       <FeaturesSection />
-      <AiStorySection />
       <FooterSection />
     </Box>
   )


### PR DESCRIPTION
## Summary

- Replaces the hero subtitle (old: "Built entirely by autonomous AI agents...") with learner-focused copy: "A simple way to practise vocabulary every day — no account needed."
- Removes `AiStorySection` (the "One person. Zero hand-written code." block and 96+/108+ stats) from the landing page render
- Replaces footer "Built with Claude by Anthropic" attribution with a "How it was built" link pointing to `/#/about` (the About page shipped in PR #211)
- Keeps the GitHub link, app mockup (ābols → apple), all four feature cards, and both CTA buttons unchanged

## Changes

- `src/features/landing/LandingPage.tsx` — hero subtitle text, `AiStorySection` removed (function + render call), unused `Chip` import removed, footer link updated, JSDoc updated
- `src/features/landing/LandingPage.test.tsx` — removed stale AI-story test, added 4 new assertions (learner subtitle present, old subtitle absent, AI section absent, footer link with correct `href="/#/about"`)

## Testing

- `npm run lint` — pass
- `npm run format:check` — pass
- `npm test -- --run` — 1250 passed (baseline 1246 + 4 new)
- `npx tsc --noEmit` — pass
- `npm run build` — pass
- `npm run e2e` — 14/14 passed

## Review

- Code review passed (see issue #123 for reviewer comment)
- All 6 acceptance criteria verified

Closes #123