### PR TITLE
feat: add LV/EN language toggle to landing page with auto-detection (#124)

### DIFF
--- a/src/features/landing/LandingPage.test.tsx
+++ b/src/features/landing/LandingPage.test.tsx
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { ThemeProvider } from '@mui/material'
 import { createAppTheme } from '@/theme'
 import { LandingPage } from './LandingPage'
+import { StorageContext } from '@/hooks/useStorage'
+import type { StorageService } from '@/services/storage/StorageService'
 
 const mockNavigate = vi.fn()
 
@@ -17,28 +19,67 @@ vi.mock('react-router-dom', async (importOriginal) => {
 
 const darkTheme = createAppTheme('dark')
 
-function renderLanding() {
+/** Builds a minimal StorageService mock with controllable getItem behaviour. */
+function makeMockStorage(persistedLang: string | null = null): StorageService {
+  return {
+    getItem: vi.fn().mockResolvedValue(persistedLang),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+    // Remaining methods — not exercised by landing page tests.
+    getLanguagePairs: vi.fn().mockResolvedValue([]),
+    getLanguagePair: vi.fn().mockResolvedValue(null),
+    saveLanguagePair: vi.fn().mockResolvedValue(undefined),
+    deleteLanguagePair: vi.fn().mockResolvedValue(undefined),
+    getWords: vi.fn().mockResolvedValue([]),
+    getWord: vi.fn().mockResolvedValue(null),
+    saveWord: vi.fn().mockResolvedValue(undefined),
+    saveWords: vi.fn().mockResolvedValue(undefined),
+    deleteWord: vi.fn().mockResolvedValue(undefined),
+    getWordProgress: vi.fn().mockResolvedValue(null),
+    getAllProgress: vi.fn().mockResolvedValue([]),
+    saveWordProgress: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+    getDailyStats: vi.fn().mockResolvedValue(null),
+    getDailyStatsRange: vi.fn().mockResolvedValue([]),
+    saveDailyStats: vi.fn().mockResolvedValue(undefined),
+    getRecentDailyStats: vi.fn().mockResolvedValue([]),
+    exportAll: vi.fn().mockResolvedValue('{}'),
+    importAll: vi.fn().mockResolvedValue(undefined),
+    clearAll: vi.fn().mockResolvedValue(undefined),
+  } as unknown as StorageService
+}
+
+function renderLanding(storage: StorageService = makeMockStorage()) {
   return render(
-    <MemoryRouter>
-      <ThemeProvider theme={darkTheme}>
-        <LandingPage />
-      </ThemeProvider>
-    </MemoryRouter>,
+    <StorageContext.Provider value={storage}>
+      <MemoryRouter>
+        <ThemeProvider theme={darkTheme}>
+          <LandingPage />
+        </ThemeProvider>
+      </MemoryRouter>
+    </StorageContext.Provider>,
   )
 }
 
 describe('LandingPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: English browser locale so auto-detection yields 'en'.
+    Object.defineProperty(navigator, 'language', { value: 'en-GB', configurable: true })
+  })
+
   it('should render the app name', () => {
     renderLanding()
     expect(screen.getAllByText('Lexio').length).toBeGreaterThan(0)
   })
 
-  it('should render hero tagline', () => {
+  it('should render hero tagline in English by default', () => {
     renderLanding()
     expect(screen.getByText(/learn vocabulary in any language/i)).toBeInTheDocument()
   })
 
-  it('should render learner-focused hero subtitle', () => {
+  it('should render learner-focused hero subtitle in English by default', () => {
     renderLanding()
     expect(screen.getByText(/a simple way to practise vocabulary every day/i)).toBeInTheDocument()
   })
@@ -48,12 +89,12 @@ describe('LandingPage', () => {
     expect(screen.queryByText(/built entirely by autonomous ai agents/i)).not.toBeInTheDocument()
   })
 
-  it('should render the Try it now CTA button', () => {
+  it('should render the Try it now CTA button in English', () => {
     renderLanding()
     expect(screen.getByRole('button', { name: /try it now/i })).toBeInTheDocument()
   })
 
-  it('should render the Set up your own CTA button', () => {
+  it('should render the Set up your own CTA button in English', () => {
     renderLanding()
     expect(screen.getByRole('button', { name: /set up your own/i })).toBeInTheDocument()
   })
@@ -70,7 +111,7 @@ describe('LandingPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/app')
   })
 
-  it('should render feature highlights section', () => {
+  it('should render feature highlights section in English', () => {
     renderLanding()
     expect(screen.getByText(/spaced repetition/i)).toBeInTheDocument()
     expect(screen.getByText(/multiple quiz modes/i)).toBeInTheDocument()
@@ -110,7 +151,6 @@ describe('LandingPage', () => {
 
   it('should render the h1 heading with accessible role', () => {
     renderLanding()
-    // h1 is the app name
     const heading = screen.getByRole('heading', { level: 1 })
     expect(heading).toBeInTheDocument()
     expect(heading.textContent).toBe('Lexio')
@@ -120,5 +160,104 @@ describe('LandingPage', () => {
     renderLanding()
     const h2Headings = screen.getAllByRole('heading', { level: 2 })
     expect(h2Headings.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('LandingPage — language toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(navigator, 'language', { value: 'en-GB', configurable: true })
+  })
+
+  it('should render EN and LV toggle buttons', () => {
+    renderLanding()
+    expect(screen.getByRole('button', { name: 'EN' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'LV' })).toBeInTheDocument()
+  })
+
+  it('should switch all text to Latvian when LV is clicked', async () => {
+    renderLanding()
+    fireEvent.click(screen.getByRole('button', { name: 'LV' }))
+    await waitFor(() => {
+      expect(screen.getByText(/Apgūsti vārdnīcu jebkurā valodā/i)).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /Izmēģini tagad/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Iestatīt pašam/i })).toBeInTheDocument()
+  })
+
+  it('should switch back to English when EN is clicked after LV', () => {
+    renderLanding()
+    fireEvent.click(screen.getByRole('button', { name: 'LV' }))
+    fireEvent.click(screen.getByRole('button', { name: 'EN' }))
+    expect(screen.getByText(/learn vocabulary in any language/i)).toBeInTheDocument()
+  })
+
+  it('should persist language choice via storage.setItem when toggled', async () => {
+    const storage = makeMockStorage()
+    renderLanding(storage)
+    fireEvent.click(screen.getByRole('button', { name: 'LV' }))
+    await waitFor(() => {
+      expect(storage.setItem).toHaveBeenCalledWith('lexio-landing-lang', 'lv')
+    })
+  })
+
+  it('should use persisted LV language on mount', async () => {
+    const storage = makeMockStorage('lv')
+    renderLanding(storage)
+    await waitFor(() => {
+      expect(screen.getByText(/Apgūsti vārdnīcu jebkurā valodā/i)).toBeInTheDocument()
+    })
+  })
+
+  it('should use persisted EN language on mount even when browser is LV', async () => {
+    Object.defineProperty(navigator, 'language', { value: 'lv-LV', configurable: true })
+    const storage = makeMockStorage('en')
+    renderLanding(storage)
+    // Initially browser detection may yield LV, but persisted 'en' overrides it.
+    await waitFor(() => {
+      expect(screen.getByText(/learn vocabulary in any language/i)).toBeInTheDocument()
+    })
+  })
+
+  it('should auto-detect Latvian from navigator.language when no persisted value', async () => {
+    Object.defineProperty(navigator, 'language', { value: 'lv-LV', configurable: true })
+    const storage = makeMockStorage(null)
+    renderLanding(storage)
+    // With LV browser locale and no persisted value, the hook should stay on LV.
+    await waitFor(() => {
+      expect(screen.getByText(/Apgūsti vārdnīcu jebkurā valodā/i)).toBeInTheDocument()
+    })
+  })
+
+  it('should navigate to /app?demo=true from Latvian version when CTA clicked', async () => {
+    renderLanding()
+    fireEvent.click(screen.getByRole('button', { name: 'LV' }))
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Izmēģini tagad/i })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /Izmēģini tagad/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/app?demo=true')
+  })
+})
+
+describe('useLandingI18n — unit coverage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render Latvian feature titles when language is LV', async () => {
+    Object.defineProperty(navigator, 'language', { value: 'lv', configurable: true })
+    renderLanding(makeMockStorage(null))
+    await waitFor(() => {
+      expect(screen.getByText(/Intervālu atkārtošana/i)).toBeInTheDocument()
+    })
+  })
+
+  it('should render Latvian footer link when language is LV', async () => {
+    const storage = makeMockStorage('lv')
+    renderLanding(storage)
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /Kā tas tika izveidots/i })).toBeInTheDocument()
+    })
   })
 })

--- a/src/features/landing/LandingPage.tsx
+++ b/src/features/landing/LandingPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import {
   Box,
   Button,
+  ButtonGroup,
   Container,
   Grid2 as Grid,
   Typography,
@@ -16,38 +17,107 @@ import BarChartIcon from '@mui/icons-material/BarChart'
 import WifiOffIcon from '@mui/icons-material/WifiOff'
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
 import GitHubIcon from '@mui/icons-material/GitHub'
+import { useLandingI18n } from './useLandingI18n'
+import type { LandingTranslations } from './useLandingI18n'
 
 /** Public GitHub repo URL for this project. */
 const GITHUB_URL = 'https://github.com/mreppo/lexio'
 
 declare const __APP_VERSION__: string
 
-// Feature highlights shown in the second section of the landing page.
-const FEATURES: Array<{ icon: React.ReactNode; title: string; body: string }> = [
-  {
-    icon: <SchoolIcon fontSize="medium" sx={{ color: 'primary.main' }} />,
-    title: 'Spaced repetition',
-    body: 'Words you struggle with appear more often. Words you know drift into the background.',
-  },
-  {
-    icon: <TuneIcon fontSize="medium" sx={{ color: 'primary.main' }} />,
-    title: 'Multiple quiz modes',
-    body: 'Type the answer or pick from multiple choices. Mix both for variety.',
-  },
-  {
-    icon: <BarChartIcon fontSize="medium" sx={{ color: 'primary.main' }} />,
-    title: 'Progress and streaks',
-    body: 'Track daily streaks, confidence per word, and your overall learning curve.',
-  },
-  {
-    icon: <WifiOffIcon fontSize="medium" sx={{ color: 'primary.main' }} />,
-    title: 'Works offline',
-    body: 'Installable on your home screen. All data stays local — no account required.',
-  },
+// Icon set for each feature — order must match the translations.features array.
+const FEATURE_ICONS: ReadonlyArray<React.ReactNode> = [
+  <SchoolIcon key="school" fontSize="medium" sx={{ color: 'primary.main' }} />,
+  <TuneIcon key="tune" fontSize="medium" sx={{ color: 'primary.main' }} />,
+  <BarChartIcon key="bar-chart" fontSize="medium" sx={{ color: 'primary.main' }} />,
+  <WifiOffIcon key="wifi-off" fontSize="medium" sx={{ color: 'primary.main' }} />,
 ]
 
+/**
+ * Pill-style EN | LV language toggle shown in the top-right corner.
+ * Uses a ButtonGroup with two compact buttons to keep the control minimal.
+ */
+function LangToggle({
+  lang,
+  onToggle,
+}: {
+  lang: 'en' | 'lv'
+  onToggle: () => void
+}): React.JSX.Element {
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        top: { xs: 12, sm: 16 },
+        right: { xs: 12, sm: 20 },
+        zIndex: 1200,
+      }}
+    >
+      <ButtonGroup
+        size="small"
+        aria-label="Language toggle"
+        sx={{
+          borderRadius: 6,
+          overflow: 'hidden',
+          border: '1px solid',
+          borderColor: 'rgba(255,255,255,0.18)',
+          backdropFilter: 'blur(8px)',
+          backgroundColor: 'rgba(10,15,26,0.7)',
+        }}
+      >
+        <Button
+          onClick={lang === 'lv' ? onToggle : undefined}
+          disableRipple={lang === 'en'}
+          aria-pressed={lang === 'en'}
+          sx={{
+            px: 1.5,
+            py: 0.5,
+            minWidth: 40,
+            fontSize: '0.7rem',
+            fontWeight: 700,
+            letterSpacing: '0.08em',
+            color: lang === 'en' ? '#f59e0b' : 'text.secondary',
+            backgroundColor: lang === 'en' ? 'rgba(245,158,11,0.12)' : 'transparent',
+            border: 'none',
+            borderRadius: 0,
+            cursor: lang === 'en' ? 'default' : 'pointer',
+            '&:hover': {
+              backgroundColor: lang === 'en' ? 'rgba(245,158,11,0.12)' : 'rgba(255,255,255,0.06)',
+            },
+          }}
+        >
+          EN
+        </Button>
+        <Button
+          onClick={lang === 'en' ? onToggle : undefined}
+          disableRipple={lang === 'lv'}
+          aria-pressed={lang === 'lv'}
+          sx={{
+            px: 1.5,
+            py: 0.5,
+            minWidth: 40,
+            fontSize: '0.7rem',
+            fontWeight: 700,
+            letterSpacing: '0.08em',
+            color: lang === 'lv' ? '#f59e0b' : 'text.secondary',
+            backgroundColor: lang === 'lv' ? 'rgba(245,158,11,0.12)' : 'transparent',
+            border: 'none',
+            borderRadius: 0,
+            cursor: lang === 'lv' ? 'default' : 'pointer',
+            '&:hover': {
+              backgroundColor: lang === 'lv' ? 'rgba(245,158,11,0.12)' : 'rgba(255,255,255,0.06)',
+            },
+          }}
+        >
+          LV
+        </Button>
+      </ButtonGroup>
+    </Box>
+  )
+}
+
 /** The hero section with app title, tagline, and CTAs. */
-function HeroSection(): React.JSX.Element {
+function HeroSection({ t }: { t: LandingTranslations }): React.JSX.Element {
   const navigate = useNavigate()
 
   const handleTryNow = useCallback(() => {
@@ -116,7 +186,7 @@ function HeroSection(): React.JSX.Element {
             mx: 'auto',
           }}
         >
-          Learn vocabulary in any language
+          {t.heroTagline}
         </Typography>
 
         <Typography
@@ -129,7 +199,7 @@ function HeroSection(): React.JSX.Element {
             lineHeight: 1.7,
           }}
         >
-          A simple way to practise vocabulary every day — no account needed.
+          {t.heroSubtitle}
         </Typography>
 
         <Stack
@@ -158,7 +228,7 @@ function HeroSection(): React.JSX.Element {
               '&:hover': { backgroundColor: '#d97706' },
             }}
           >
-            Try it now
+            {t.tryItNow}
           </Button>
 
           <Button
@@ -173,7 +243,7 @@ function HeroSection(): React.JSX.Element {
               minWidth: 180,
             }}
           >
-            Set up your own
+            {t.setUpYourOwn}
           </Button>
         </Stack>
       </Container>
@@ -254,7 +324,7 @@ function AppMockup(): React.JSX.Element {
 }
 
 /** Feature highlights grid. */
-function FeaturesSection(): React.JSX.Element {
+function FeaturesSection({ t }: { t: LandingTranslations }): React.JSX.Element {
   return (
     <Box component="section" sx={{ py: { xs: 8, md: 10 } }}>
       <Container maxWidth="md">
@@ -263,17 +333,17 @@ function FeaturesSection(): React.JSX.Element {
           variant="h4"
           sx={{ fontWeight: 700, textAlign: 'center', mb: 1 }}
         >
-          Everything you need to learn
+          {t.featuresSectionTitle}
         </Typography>
         <Typography
           variant="body1"
           sx={{ color: 'text.secondary', textAlign: 'center', mb: 6, maxWidth: 480, mx: 'auto' }}
         >
-          A focused tool that does one thing well.
+          {t.featuresSectionSubtitle}
         </Typography>
 
         <Grid container spacing={3}>
-          {FEATURES.map((f) => (
+          {t.features.map((f, i) => (
             <Grid key={f.title} size={{ xs: 12, sm: 6 }}>
               <Paper
                 elevation={0}
@@ -291,7 +361,7 @@ function FeaturesSection(): React.JSX.Element {
                   '&:hover': { borderColor: 'primary.main' },
                 }}
               >
-                <Box sx={{ flexShrink: 0, mt: 0.25 }}>{f.icon}</Box>
+                <Box sx={{ flexShrink: 0, mt: 0.25 }}>{FEATURE_ICONS[i]}</Box>
                 <Box>
                   <Typography component="h3" variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
                     {f.title}
@@ -315,7 +385,7 @@ function FeaturesSection(): React.JSX.Element {
 }
 
 /** Footer with attribution and links. */
-function FooterSection(): React.JSX.Element {
+function FooterSection({ t }: { t: LandingTranslations }): React.JSX.Element {
   return (
     <Box
       component="footer"
@@ -334,7 +404,7 @@ function FooterSection(): React.JSX.Element {
         >
           <Stack direction="row" spacing={1} alignItems="center">
             <Link href="/#/about" sx={{ color: 'text.secondary' }}>
-              <Typography variant="body2">How it was built</Typography>
+              <Typography variant="body2">{t.footerHowBuilt}</Typography>
             </Link>
             <Typography variant="body2" sx={{ color: 'text.secondary' }}>
               · v{__APP_VERSION__}
@@ -359,9 +429,12 @@ function FooterSection(): React.JSX.Element {
 /**
  * Landing page rendered at the root route /.
  * Shows hero, feature highlights, and footer.
+ * Includes a LV/EN language toggle pill in the top-right corner.
  * Does NOT include the app bar or bottom nav.
  */
 export function LandingPage(): React.JSX.Element {
+  const { t, lang, toggle } = useLandingI18n()
+
   return (
     <Box
       component="main"
@@ -370,9 +443,10 @@ export function LandingPage(): React.JSX.Element {
         background: 'linear-gradient(180deg, #0d1529 0%, #0a0f1a 40%, #0a0f1a 100%)',
       }}
     >
-      <HeroSection />
-      <FeaturesSection />
-      <FooterSection />
+      <LangToggle lang={lang} onToggle={toggle} />
+      <HeroSection t={t} />
+      <FeaturesSection t={t} />
+      <FooterSection t={t} />
     </Box>
   )
 }

--- a/src/features/landing/useLandingI18n.ts
+++ b/src/features/landing/useLandingI18n.ts
@@ -1,0 +1,133 @@
+import { useState, useCallback, useEffect } from 'react'
+import { useStorage } from '@/hooks/useStorage'
+
+/** Supported landing page languages. */
+export type LandingLang = 'en' | 'lv'
+
+/** Storage key for persisting the user's language choice. */
+const LANG_STORAGE_KEY = 'lexio-landing-lang'
+
+/**
+ * All translatable strings used on the landing page.
+ * New strings must be added to both EN and LV entries simultaneously.
+ */
+export interface LandingTranslations {
+  readonly heroTagline: string
+  readonly heroSubtitle: string
+  readonly tryItNow: string
+  readonly setUpYourOwn: string
+  readonly featuresSectionTitle: string
+  readonly featuresSectionSubtitle: string
+  readonly features: readonly {
+    readonly title: string
+    readonly body: string
+  }[]
+  readonly footerHowBuilt: string
+}
+
+const translations: Record<LandingLang, LandingTranslations> = {
+  en: {
+    heroTagline: 'Learn vocabulary in any language',
+    heroSubtitle: 'A simple way to practise vocabulary every day — no account needed.',
+    tryItNow: 'Try it now',
+    setUpYourOwn: 'Set up your own',
+    featuresSectionTitle: 'Everything you need to learn',
+    featuresSectionSubtitle: 'A focused tool that does one thing well.',
+    features: [
+      {
+        title: 'Spaced repetition',
+        body: 'Words you struggle with appear more often. Words you know drift into the background.',
+      },
+      {
+        title: 'Multiple quiz modes',
+        body: 'Type the answer or pick from multiple choices. Mix both for variety.',
+      },
+      {
+        title: 'Progress and streaks',
+        body: 'Track daily streaks, confidence per word, and your overall learning curve.',
+      },
+      {
+        title: 'Works offline',
+        body: 'Installable on your home screen. All data stays local — no account required.',
+      },
+    ],
+    footerHowBuilt: 'How it was built',
+  },
+  lv: {
+    heroTagline: 'Apgūsti vārdnīcu jebkurā valodā',
+    heroSubtitle: 'Vienkāršs veids, kā katru dienu trenēt vārdnīcu — bez reģistrācijas.',
+    tryItNow: 'Izmēģini tagad',
+    setUpYourOwn: 'Iestatīt pašam',
+    featuresSectionTitle: 'Viss, kas nepieciešams mācīšanās',
+    featuresSectionSubtitle: 'Fokusēts rīks, kas dara vienu lietu labi.',
+    features: [
+      {
+        title: 'Intervālu atkārtošana',
+        body: 'Vārdi, ar kuriem rodas grūtības, parādās biežāk. Zināmie vārdi paliek fonā.',
+      },
+      {
+        title: 'Vairāki testa veidi',
+        body: 'Raksti atbildi vai izvēlies no vairākiem variantiem. Abi veidi kopā dod daudzveidību.',
+      },
+      {
+        title: 'Progress un sērijas',
+        body: 'Seko dienas sērijām, katras vārda pārliecībai un kopējai mācīšanās līknei.',
+      },
+      {
+        title: 'Darbojas bez interneta',
+        body: 'Uzstādāms sākuma ekrānā. Visi dati glabājas lokāli — konts nav nepieciešams.',
+      },
+    ],
+    footerHowBuilt: 'Kā tas tika izveidots',
+  },
+}
+
+/**
+ * Detects the preferred language from the browser's navigator.language.
+ * Returns 'lv' if the primary language tag is Latvian, otherwise 'en'.
+ */
+function detectBrowserLang(): LandingLang {
+  const primary = navigator.language.split('-')[0].toLowerCase()
+  return primary === 'lv' ? 'lv' : 'en'
+}
+
+/**
+ * Hook that provides landing-page translations, the current language, and a toggle function.
+ *
+ * Priority: persisted StorageService value > browser auto-detection.
+ * Persists user choice under the key 'lexio-landing-lang'.
+ *
+ * Returns { t, lang, toggle } where:
+ *   t      – the full translations object for the current language
+ *   lang   – the current language code ('en' | 'lv')
+ *   toggle – swaps between EN and LV and persists the new choice
+ */
+export function useLandingI18n(): {
+  t: LandingTranslations
+  lang: LandingLang
+  toggle: () => void
+} {
+  const storage = useStorage()
+
+  // Initialise with browser detection; will be overridden by persisted value once loaded.
+  const [lang, setLang] = useState<LandingLang>(detectBrowserLang)
+
+  // On mount, check if a persisted preference exists and apply it.
+  useEffect(() => {
+    void storage.getItem(LANG_STORAGE_KEY).then((stored) => {
+      if (stored === 'lv' || stored === 'en') {
+        setLang(stored)
+      }
+    })
+  }, [storage])
+
+  const toggle = useCallback(() => {
+    setLang((prev) => {
+      const next: LandingLang = prev === 'en' ? 'lv' : 'en'
+      void storage.setItem(LANG_STORAGE_KEY, next)
+      return next
+    })
+  }, [storage])
+
+  return { t: translations[lang], lang, toggle }
+}


### PR DESCRIPTION
## Summary

- Adds a `useLandingI18n` hook with a full EN/LV translations record, browser language auto-detection, and persistence via StorageService (no direct `localStorage` calls)
- Adds a `LangToggle` pill component (fixed top-right, MUI `ButtonGroup`) that swaps all landing page text instantly without page reload
- Extracts all hardcoded English strings from `LandingPage` into the translations record
- Separates feature icons from translatable text into a dedicated `FEATURE_ICONS` array

## Changes

- `src/features/landing/useLandingI18n.ts` — new hook + translations record + `LandingTranslations` interface
- `src/features/landing/LandingPage.tsx` — add `LangToggle`, wire `t` props throughout all sections
- `src/features/landing/LandingPage.test.tsx` — 26 tests total (16 existing + 10 new for toggle/i18n)

## Testing

- All 1260 unit tests pass (baseline 1250, +10 new)
- All 14 E2E tests pass
- `npm run lint`, `npm run format:check`, `npx tsc --noEmit`, `npm run build` all clean

## Review

- Code review passed (reviewer comment on #124)
- StorageService convention followed throughout (no direct localStorage calls)
- TypeScript strict — no `any`, no `@ts-ignore`
- Accessibility: `aria-label` on toggle group, `aria-pressed` on each button

Closes #124